### PR TITLE
Initialize Design, Roadmap, and Project Structure

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,90 @@
+# Design
+
+## Book Structure
+
+The comparative book is divided into two main parts: Programming Languages and Data Formats.
+
+### Part I: Programming Languages
+This section compares languages based on common programming patterns.
+
+**Languages:**
+- SQL
+- C
+- XQuery
+- Java
+- Rust
+- Erlang
+- Lisp
+- Bash
+- Cmd
+- PowerShell
+- CSS
+
+**Patterns to be compared:**
+- Variable declaration
+- Control flow (if/else, loops)
+- Function/Procedure definition
+- Error handling
+- Concurrency models
+
+### Part II: Data Formats
+This section compares data structures and serialization formats.
+
+**Formats:**
+- Fixlength
+- CSV
+- XML
+- JSON
+- YAML
+- TOML
+
+**Patterns to be compared:**
+- Basic data types (Strings, Numbers, Booleans)
+- Nested structures (Objects/Maps, Arrays/Lists)
+- Metadata/Attributes
+- Comments support
+- Schema validation
+
+## Presentation Design: Comparison Tables
+
+Each pattern will be presented using a standardized table format to ensure consistency across the book.
+
+### Table Layout Example
+
+| Language/Format | Pattern Implementation | Notes |
+|-----------------|------------------------|-------|
+| Java            | `int x = 5;`           | Strongly typed |
+| Python          | `x = 5`                | Dynamically typed |
+| Rust            | `let x = 5;`           | Immutable by default |
+
+## Technical Architecture: Transpiler Pipeline
+
+The book is generated using a custom transpilation pipeline to ensure consistency and maintainability.
+
+### 1. Source Patterns
+Patterns are defined in a domain-specific format (DSL) that describes the semantic intent of a pattern.
+
+### 2. ANTLR4 Parser
+An ANTLR4 grammar parses the source patterns into a concrete syntax tree (CST).
+
+### 3. Abstract Semantic Graph (ASG) / Intermediate Representation (IR)
+The CST is transformed into an ASG. This representation is language-agnostic and captures the core logic and parameters of the pattern.
+
+### 4. Jinja2 Generators
+Target-specific Jinja2 templates consume the IR to produce reStructuredText (reST) snippets for each language or format.
+
+### 5. Final Assembly
+The generated reST snippets are aggregated into the final documentation structure for ReadTheDocs.
+
+## Appendix: Decision Evaluation
+
+### Presentation Layout Options
+
+| Option | Description | Pros | Cons | Status |
+|---|---|---|---|---|
+| **A: Markdown Tables** | Standard GitHub-flavored Markdown tables. | Simple; native support in most editors; readable in raw form. | Limited styling; hard to manage very wide tables (many languages). | **Selected** |
+| **B: Sphinx Grid Tables** | reStructuredText grid tables. | More flexible than Markdown; better support for multi-line cells. | Harder to write/read in raw text; requires reST knowledge for contributors. | Discarded |
+| **C: Interactive Tabs** | Using `sphinx-tabs` to switch between languages. | Saves vertical space; clean look; good for long code snippets. | Requires JavaScript; hard to compare two languages at a glance. | Discarded |
+
+---
+*Evaluated on 2024-05-24*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,20 @@
+# Roadmap
+
+## Phase 1: Foundation
+- [x] Create project structure and initial documentation (`CONCEPT.md`, `GEMINI.md`, `DESIGN.md`) <!-- 2024-05-24, issue #1 -->
+- [ ] Setup `src/install.sh` for development environment <!-- issue #2 -->
+- [ ] Setup `test/install.sh` and CI/CD workflow <!-- issue #3 -->
+
+## Phase 2: Transpiler Development
+- [ ] Define DSL for Source Patterns <!-- issue #4 -->
+- [ ] Implement ANTLR4 grammar for the DSL <!-- issue #5 -->
+- [ ] Design the Intermediate Representation (IR) / ASG <!-- issue #6 -->
+- [ ] Implement Jinja2 generators for reStructuredText <!-- issue #7 -->
+
+## Phase 3: Content Creation
+- [ ] Populate Programming Language patterns (Variables, Control Flow, etc.) <!-- issue #8 -->
+- [ ] Populate Data Format patterns (JSON, XML, YAML, etc.) <!-- issue #9 -->
+
+## Phase 4: Publication
+- [ ] Configure ReadTheDocs integration <!-- issue #10 -->
+- [ ] Final review and polish of the comparative book <!-- issue #11 -->

--- a/TECHNICAL_DEBTS.md
+++ b/TECHNICAL_DEBTS.md
@@ -1,0 +1,11 @@
+# Technical Debts
+
+## Documentation
+- [ ] reStructuredText conversion: Some external docs in `/specifications/` and `/docs/` might still be in their original formats.
+
+## Architecture
+- [ ] Jinja2 Template duplication: Risk of duplication between different language templates if shared patterns are not properly identified.
+- [ ] DSL Complexity: The initial DSL might be too simple to capture complex language features (e.g., Rust's ownership or Erlang's actor model).
+
+## Implementation
+- [ ] Missing initial templates: Basic templates for all target languages/formats need to be created.


### PR DESCRIPTION
This PR initializes the project directory structure and core documentation files (DESIGN.md, ROADMAP.md, TECHNICAL_DEBTS.md) as specified in GEMINI.md and CONCEPT.md. It defines the book's structure, comparison patterns, and the transpiler-based architecture for generating the comparative book.

Fixes #5

---
*PR created automatically by Jules for task [4176293478106750553](https://jules.google.com/task/4176293478106750553) started by @chatelao*