### PR TITLE
Decompose DSL Roadmap Task and Define Initial DSL Specification

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,9 @@
 
 ## Phase 2: Transpiler Development
 - [ ] Define DSL for Source Patterns <!-- issue #4 -->
+    - [x] 4.1 Define DSL requirements and syntax draft <!-- 2026-05-01, issue #4.1 -->
+    - [ ] 4.2 Validate DSL draft with example patterns <!-- issue #4.2 -->
+    - [ ] 4.3 Finalize DSL specification <!-- issue #4.3 -->
 - [ ] Implement ANTLR4 grammar for the DSL <!-- issue #5 -->
 - [ ] Design the Intermediate Representation (IR) / ASG <!-- issue #6 -->
 - [ ] Implement Jinja2 generators for reStructuredText <!-- issue #7 -->

--- a/docs/dsl_specification.md
+++ b/docs/dsl_specification.md
@@ -1,0 +1,55 @@
+# DSL Specification: Source Patterns
+
+This document defines the requirements and initial syntax draft for the Domain-Specific Language (DSL) used to define source patterns in the comparative book project.
+
+## 1. Requirements
+
+- **Semantic Intent**: The DSL must capture the *what* (the meaning of the pattern) rather than the *how* (the syntax of a specific language).
+- **Structure**: It should be easy to define patterns with parameters (e.g., variable name, type, value).
+- **Extensibility**: It must allow adding new pattern types and properties without breaking existing definitions.
+- **Parseability**: The syntax must be compatible with ANTLR4 for generating a parser.
+- **Readability**: It should be human-readable to facilitate contributions.
+
+## 2. Syntax Draft (v0.1)
+
+The DSL uses a block-based structure.
+
+### Pattern Definition
+A pattern definition describes the structure of a common programming or data concept.
+
+```
+pattern VariableDeclaration {
+    parameter name: Identifier
+    parameter type: Type
+    parameter initial_value: Expression
+}
+```
+
+### Pattern Instance
+An instance provides the specific values for a pattern to be compared across languages.
+
+```
+instance VarDec1 of VariableDeclaration {
+    name = "x"
+    type = "Integer"
+    initial_value = 42
+}
+```
+
+## 3. Metadata
+
+Patterns and instances can include metadata such as descriptions and notes.
+
+```
+pattern VariableDeclaration {
+    meta description: "The act of naming a value and optionally specifying its type."
+    parameter name: Identifier
+    ...
+}
+```
+
+## 4. Next Steps
+
+- [ ] Validate this syntax against more complex patterns (e.g., Concurrency).
+- [ ] Refine the list of built-in types (Identifier, Type, Expression, etc.).
+- [ ] Implement the ANTLR4 grammar based on this specification.


### PR DESCRIPTION
I have broken down the larger roadmap item "Define DSL for Source Patterns" (issue #4) into smaller, more manageable sub-tasks. Additionally, I've implemented the first of these sub-tasks by creating a DSL specification document that outlines the requirements and an initial syntax draft. This document will serve as a foundation for the subsequent ANTLR4 grammar implementation.

Changes:
- Modified `ROADMAP.md` to include sub-tasks 4.1, 4.2, and 4.3.
- Created the `docs/` directory.
- Created `docs/dsl_specification.md` with DSL requirements and a v0.1 syntax draft.
- Updated `ROADMAP.md` to reflect the completion of task 4.1.

Fixes #13

---
*PR created automatically by Jules for task [13624577400824878444](https://jules.google.com/task/13624577400824878444) started by @chatelao*