### PR TITLE
Validate DSL draft and update specification to v0.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,7 +9,7 @@
 ## Phase 2: Transpiler Development
 - [ ] Define DSL for Source Patterns <!-- issue #4 -->
     - [x] 4.1 Define DSL requirements and syntax draft <!-- 2026-05-01, issue #4.1 -->
-    - [ ] 4.2 Validate DSL draft with example patterns <!-- issue #4.2 -->
+    - [x] 4.2 Validate DSL draft with example patterns <!-- 2026-05-01, issue #4.2 -->
     - [ ] 4.3 Finalize DSL specification <!-- issue #4.3 -->
 - [ ] Implement ANTLR4 grammar for the DSL <!-- issue #5 -->
 - [ ] Design the Intermediate Representation (IR) / ASG <!-- issue #6 -->

--- a/docs/dsl_examples.md
+++ b/docs/dsl_examples.md
@@ -1,0 +1,67 @@
+# DSL Examples
+
+These examples validate the DSL draft from `docs/dsl_specification.md` and identify areas for refinement.
+
+## 1. Control Flow (If/Else)
+
+Capturing blocks of code is essential for control flow.
+
+```
+pattern IfElse {
+    parameter condition: Expression
+    parameter then_branch: Block
+    parameter else_branch: Block
+}
+
+instance CheckBalance of IfElse {
+    condition = "balance > 100"
+    then_branch = {
+        call charge_fee(0)
+    }
+    else_branch = {
+        call charge_fee(10)
+    }
+}
+```
+
+*Gap Identified*: The `Block` type and `{}` syntax for blocks need to be formally defined.
+
+## 2. Concurrency (Message Passing)
+
+Basic message passing can be represented with simple parameters.
+
+```
+pattern MessageSend {
+    parameter target: Identifier
+    parameter payload: Expression
+}
+
+instance NotifyUser of MessageSend {
+    target = "user_service"
+    payload = "registration_complete"
+}
+```
+
+## 3. Nested Data Structures (Object/Map)
+
+Data formats often require nesting and collections.
+
+```
+pattern DataMap {
+    parameter entries: List<MapEntry>
+}
+
+pattern MapEntry {
+    parameter key: String
+    parameter value: Expression
+}
+
+instance UserProfile of DataMap {
+    entries = [
+        instance of MapEntry { key = "id", value = 1 },
+        instance of MapEntry { key = "active", value = true }
+    ]
+}
+```
+
+*Gap Identified*: Support for `List` types, literal lists `[]`, and anonymous instances (`instance of ...`) as parameter values are missing from v0.1.

--- a/docs/dsl_specification.md
+++ b/docs/dsl_specification.md
@@ -10,7 +10,7 @@ This document defines the requirements and initial syntax draft for the Domain-S
 - **Parseability**: The syntax must be compatible with ANTLR4 for generating a parser.
 - **Readability**: It should be human-readable to facilitate contributions.
 
-## 2. Syntax Draft (v0.1)
+## 2. Syntax (v0.2)
 
 The DSL uses a block-based structure.
 
@@ -36,6 +36,36 @@ instance VarDec1 of VariableDeclaration {
 }
 ```
 
+### Types
+- **Identifier**: A standard name (e.g., variable or function name).
+- **Type**: A logical type name (e.g., "Integer", "String").
+- **Expression**: A value or simple operation (often represented as a string literal for simplicity in v0.2).
+- **Block**: A collection of logical steps (see below).
+- **List<T>**: A collection of items of type T.
+
+### Blocks and Instructions
+Blocks are used for control flow or procedural patterns. They contain instructions rather than raw code.
+
+```
+instance CheckBalance of IfElse {
+    then_branch = {
+        call charge_fee(0)
+    }
+}
+```
+
+### Anonymous Instances and Collections
+Used for nesting complex structures.
+
+```
+instance UserProfile of DataMap {
+    entries = [
+        instance of MapEntry { key = "id", value = 1 },
+        instance of MapEntry { key = "active", value = true }
+    ]
+}
+```
+
 ## 3. Metadata
 
 Patterns and instances can include metadata such as descriptions and notes.
@@ -48,8 +78,15 @@ pattern VariableDeclaration {
 }
 ```
 
-## 4. Next Steps
+## Appendix: Decision Evaluation
 
-- [ ] Validate this syntax against more complex patterns (e.g., Concurrency).
-- [ ] Refine the list of built-in types (Identifier, Type, Expression, etc.).
-- [ ] Implement the ANTLR4 grammar based on this specification.
+### Code Block Representation Options
+
+| Option | Description | Pros | Cons | Status |
+|---|---|---|---|---|
+| **A: Opaque Strings** | Represent blocks as single string literals. | Extremely simple to parse. | No semantic validation; generator must do all the heavy lifting. | Discarded |
+| **B: Structural Blocks** | Define a set of logical instructions (call, assign, return) inside `{}`. | Captures semantic intent; allows structured transformation. | Increases grammar complexity. | **Selected** |
+| **C: External References** | Link to external snippets in files. | Keeps DSL clean. | Fragmented source; harder to maintain. | Discarded |
+
+---
+*Evaluated on 2026-05-01*


### PR DESCRIPTION
This change implements step 4.2 of the project roadmap. I validated the initial DSL syntax draft by creating several complex pattern examples in `docs/dsl_examples.md`. This process revealed gaps in the version 0.1 syntax (e.g., lack of structured blocks and collections), which I addressed by refining the specification to version 0.2 in `docs/dsl_specification.md`. I also included the mandatory Decision Evaluation appendix for the code block representation choice. Finally, I updated `ROADMAP.md` to reflect the completion of this task.

Fixes #15

---
*PR created automatically by Jules for task [2849415850761387238](https://jules.google.com/task/2849415850761387238) started by @chatelao*