### PR TITLE
Finalize DSL Spec and Refine Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,10 +10,20 @@
 - [ ] Define DSL for Source Patterns <!-- issue #4 -->
     - [x] 4.1 Define DSL requirements and syntax draft <!-- 2026-05-01, issue #4.1 -->
     - [x] 4.2 Validate DSL draft with example patterns <!-- 2026-05-01, issue #4.2 -->
-    - [ ] 4.3 Finalize DSL specification <!-- issue #4.3 -->
+    - [x] 4.3 Finalize DSL specification <!-- 2026-05-01, issue #4.3 -->
 - [ ] Implement ANTLR4 grammar for the DSL <!-- issue #5 -->
+    - [ ] 5.1 Define Lexer rules for identifiers, literals, and keywords <!-- issue #5.1 -->
+    - [ ] 5.2 Define Parser rules for pattern definitions, instances, and metadata <!-- issue #5.2 -->
+    - [ ] 5.3 Define Parser rules for blocks, instructions, and collections <!-- issue #5.3 -->
+    - [ ] 5.4 Implement grammar verification tests <!-- issue #5.4 -->
 - [ ] Design the Intermediate Representation (IR) / ASG <!-- issue #6 -->
+    - [ ] 6.1 Define the ASG object model in Python <!-- issue #6.1 -->
+    - [ ] 6.2 Implement CST to ASG transformation logic <!-- issue #6.2 -->
+    - [ ] 6.3 Implement ASG validation (e.g., parameter type checking) <!-- issue #6.3 -->
 - [ ] Implement Jinja2 generators for reStructuredText <!-- issue #7 -->
+    - [ ] 7.1 Setup Jinja2 environment and base reST templates <!-- issue #7.1 -->
+    - [ ] 7.2 Implement generator logic for Programming Language patterns <!-- issue #7.2 -->
+    - [ ] 7.3 Implement generator logic for Data Format patterns <!-- issue #7.3 -->
 
 ## Phase 3: Content Creation
 - [ ] Populate Programming Language patterns (Variables, Control Flow, etc.) <!-- issue #8 -->

--- a/docs/dsl_specification.md
+++ b/docs/dsl_specification.md
@@ -1,6 +1,6 @@
 # DSL Specification: Source Patterns
 
-This document defines the requirements and initial syntax draft for the Domain-Specific Language (DSL) used to define source patterns in the comparative book project.
+This document defines the requirements and syntax for the Domain-Specific Language (DSL) used to define source patterns in the comparative book project.
 
 ## 1. Requirements
 
@@ -10,7 +10,7 @@ This document defines the requirements and initial syntax draft for the Domain-S
 - **Parseability**: The syntax must be compatible with ANTLR4 for generating a parser.
 - **Readability**: It should be human-readable to facilitate contributions.
 
-## 2. Syntax (v0.2)
+## 2. Syntax (v1.0)
 
 The DSL uses a block-based structure.
 
@@ -19,6 +19,7 @@ A pattern definition describes the structure of a common programming or data con
 
 ```
 pattern VariableDeclaration {
+    meta description: "Declares a variable."
     parameter name: Identifier
     parameter type: Type
     parameter initial_value: Expression
@@ -39,12 +40,12 @@ instance VarDec1 of VariableDeclaration {
 ### Types
 - **Identifier**: A standard name (e.g., variable or function name).
 - **Type**: A logical type name (e.g., "Integer", "String").
-- **Expression**: A value or simple operation (often represented as a string literal for simplicity in v0.2).
-- **Block**: A collection of logical steps (see below).
-- **List<T>**: A collection of items of type T.
+- **Expression**: A value or simple operation (represented as a string literal or number).
+- **Block**: A sequence of instructions enclosed in `{}`.
+- **List<T>**: A collection of items of type T, represented by `[]`.
 
 ### Blocks and Instructions
-Blocks are used for control flow or procedural patterns. They contain instructions rather than raw code.
+Blocks are used for control flow or procedural patterns. They contain a sequence of instructions.
 
 ```
 instance CheckBalance of IfElse {
@@ -54,8 +55,14 @@ instance CheckBalance of IfElse {
 }
 ```
 
+#### Supported Instructions:
+- `call <name>(<args>)`: Invokes a function or procedure.
+- `assign <target> = <expression>`: Assigns a value to a variable.
+- `return <expression>`: Returns a value.
+- `raw "<snippet>"`: Fallback for language-specific code that doesn't fit the DSL model.
+
 ### Anonymous Instances and Collections
-Used for nesting complex structures.
+Used for nesting complex structures without requiring a top-level name for every sub-component.
 
 ```
 instance UserProfile of DataMap {
@@ -68,7 +75,7 @@ instance UserProfile of DataMap {
 
 ## 3. Metadata
 
-Patterns and instances can include metadata such as descriptions and notes.
+Patterns and instances can include metadata such as descriptions and notes using the `meta` keyword.
 
 ```
 pattern VariableDeclaration {
@@ -87,6 +94,14 @@ pattern VariableDeclaration {
 | **A: Opaque Strings** | Represent blocks as single string literals. | Extremely simple to parse. | No semantic validation; generator must do all the heavy lifting. | Discarded |
 | **B: Structural Blocks** | Define a set of logical instructions (call, assign, return) inside `{}`. | Captures semantic intent; allows structured transformation. | Increases grammar complexity. | **Selected** |
 | **C: External References** | Link to external snippets in files. | Keeps DSL clean. | Fragmented source; harder to maintain. | Discarded |
+
+### Instruction Set for Structural Blocks
+
+| Option | Description | Pros | Cons | Status |
+|---|---|---|---|---|
+| **A: Minimal Set** | Only `call`, `assign`, `return`. | Simple to implement; covers 90% of cases. | Might lack expressiveness for complex patterns. | Discarded |
+| **B: Extended Set** | `call`, `assign`, `return` + `raw`. | High flexibility; `raw` provides an escape hatch. | `raw` might be overused, defeating the purpose of the DSL. | **Selected** |
+| **C: Full AST** | Replicate a full programming language AST. | Can represent anything. | Extremely complex to design and implement. | Discarded |
 
 ---
 *Evaluated on 2026-05-01*


### PR DESCRIPTION
This change completes ROADMAP task 4.3 by finalizing the DSL specification to version 1.0. It also follows the GEMINI.md rule of decomposing large tasks by breaking down Phase 2 tasks (ANTLR4 grammar, IR/ASG design, and Jinja2 generators) into modest, feasible subtasks.

Key changes:
- `docs/dsl_specification.md`: Formalized syntax for structural blocks, a specific instruction set, and anonymous instances. Added a decision evaluation appendix.
- `ROADMAP.md`: Marked 4.3 as complete and added detailed subtasks (5.x, 6.x, 7.x) to guide future development.

Fixes #17

---
*PR created automatically by Jules for task [18189750854068622512](https://jules.google.com/task/18189750854068622512) started by @chatelao*