### PR TITLE
Implement Jinja2 Setup and Refine ASG Validation Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,9 +22,12 @@
         - [x] 6.2.1 Implement base Visitor for CST to ASG transformation <!-- 2026-05-02, issue #6.2.1 -->
         - [ ] 6.2.2 Implement transformation for Pattern definitions <!-- issue #6.2.2 -->
         - [ ] 6.2.3 Implement transformation for Instance definitions <!-- issue #6.2.3 -->
-    - [ ] 6.3 Implement ASG validation (e.g., parameter type checking) <!-- issue #6.3 -->
+    - [ ] 6.3 Implement ASG validation <!-- issue #6.3 -->
+        - [ ] 6.3.1 Validate pattern existence for instances <!-- issue #6.3.1 -->
+        - [ ] 6.3.2 Validate mandatory parameter assignment <!-- issue #6.3.2 -->
+        - [ ] 6.3.3 Validate type consistency for assignments <!-- issue #6.3.3 -->
 - [ ] Implement Jinja2 generators for reStructuredText <!-- issue #7 -->
-    - [ ] 7.1 Setup Jinja2 environment and base reST templates <!-- issue #7.1 -->
+    - [x] 7.1 Setup Jinja2 environment and base reST templates <!-- 2026-05-02, issue #7.1 -->
     - [ ] 7.2 Implement generator logic for Programming Language patterns <!-- issue #7.2 -->
     - [ ] 7.3 Implement generator logic for Data Format patterns <!-- issue #7.3 -->
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from .models import Pattern, Program
+
+class CodeGenerator:
+    def __init__(self, template_dir=None):
+        if template_dir is None:
+            template_dir = Path(__file__).parent / 'templates'
+
+        self.env = Environment(
+            loader=FileSystemLoader(str(template_dir)),
+            autoescape=select_autoescape()
+        )
+
+    def render_pattern(self, pattern: Pattern) -> str:
+        template = self.env.get_template('pattern.rst.j2')
+        return template.render(pattern=pattern)
+
+    def render_program(self, program: Program) -> str:
+        # For now, just render patterns
+        results = []
+        for pattern in program.patterns:
+            results.append(self.render_pattern(pattern))
+        return "\n\n".join(results)

--- a/src/templates/pattern.rst.j2
+++ b/src/templates/pattern.rst.j2
@@ -1,0 +1,11 @@
+{% if pattern %}
+Pattern: {{ pattern.name }}
+{% for meta in pattern.metadata %}
+:{{ meta.key }}: {{ meta.value }}
+{% endfor %}
+
+Parameters:
+{% for param in pattern.parameters %}
+* {{ param.name }}: {{ param.type.name }}{% if param.type.inner_type %}<{{ param.type.inner_type.name }}>{% endif %}
+{% endfor %}
+{% endif %}

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -1,0 +1,26 @@
+import pytest
+from src.models import Pattern, Metadata, Parameter, Type
+from src.generator import CodeGenerator
+
+def test_render_pattern():
+    pattern = Pattern(
+        name="VarDecl",
+        metadata=[Metadata(key="description", value="Variable")],
+        parameters=[
+            Parameter(name="name", type=Type(name="Identifier")),
+            Parameter(name="type", type=Type(name="List", inner_type=Type(name="String")))
+        ]
+    )
+
+    generator = CodeGenerator()
+    output = generator.render_pattern(pattern)
+
+    assert "Pattern: VarDecl" in output
+    assert ":description: Variable" in output
+    assert "* name: Identifier" in output
+    assert "* type: List<String>" in output
+
+def test_generator_initialization():
+    generator = CodeGenerator()
+    assert generator.env is not None
+    assert "pattern.rst.j2" in generator.env.list_templates()


### PR DESCRIPTION
This PR implements a modest step from the roadmap (Step 7.1) and refines a larger step (Step 6.3) into manageable subtasks.

### Changes:
- **ROADMAP.md**: 
    - Decomposed Step 6.3 "Implement ASG validation" into three subtasks: pattern existence, mandatory parameter assignment, and type consistency.
    - Marked Step 7.1 "Setup Jinja2 environment and base reST templates" as completed.
- **src/generator.py**: Introduced the `CodeGenerator` class. It initializes a Jinja2 environment pointing to `src/templates` and provides methods for rendering ASG objects (`Pattern`, `Program`).
- **src/templates/pattern.rst.j2**: A base reStructuredText template for rendering `Pattern` definitions, including metadata and parameters.
- **test/test_generator.py**: Unit tests verifying the `CodeGenerator` can correctly load templates and render a `Pattern` object.

All tests passed locally.

Fixes #27

---
*PR created automatically by Jules for task [18180505088466557352](https://jules.google.com/task/18180505088466557352) started by @chatelao*