### PR TITLE
Implement reST rendering for nested instances and lists

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,9 +28,9 @@
         - [x] 6.3.3 Validate type consistency for assignments <!-- 2026-05-02, issue #6.3.3 -->
 - [ ] Implement Jinja2 generators for reStructuredText <!-- issue #7 -->
     - [x] 7.1 Setup Jinja2 environment and base reST templates <!-- 2026-05-02, issue #7.1 -->
-    - [ ] 7.2 Implement generator logic for Pattern instances (tables) <!-- issue #7.2 -->
+    - [x] 7.2 Implement generator logic for Pattern instances (tables) <!-- 2026-05-02, issue #7.2 -->
         - [x] 7.2.1 Implement reST table rendering for basic assignments <!-- 2026-05-02, issue #7.2.1 -->
-        - [ ] 7.2.2 Implement reST rendering for nested instances and lists <!-- issue #7.2.2 -->
+        - [x] 7.2.2 Implement reST rendering for nested instances and lists <!-- 2026-05-02, issue #7.2.2 -->
     - [ ] 7.3 Implement generator logic for Instructions (blocks) <!-- issue #7.3 -->
         - [ ] 7.3.1 Implement reST rendering for call, assign, and return instructions <!-- issue #7.3.1 -->
         - [ ] 7.3.2 Implement reST rendering for raw snippets and nested blocks <!-- issue #7.3.2 -->

--- a/src/generator.py
+++ b/src/generator.py
@@ -14,7 +14,8 @@ def format_value(value) -> str:
         elements = [format_value(e) for e in value.elements]
         return f"[{', '.join(elements)}]"
     if isinstance(value, AnonymousInstance):
-        return f"instance of {value.pattern_name}"
+        assignments = [f"{a.name}={format_value(a.value)}" for a in value.assignments]
+        return f"{value.pattern_name}({', '.join(assignments)})"
     if isinstance(value, Block):
         return "{ ... }"
     return str(value)

--- a/test/test_generator_nested.py
+++ b/test/test_generator_nested.py
@@ -1,0 +1,56 @@
+import pytest
+from src.models import Program, Pattern, Instance, Parameter, Type, Assignment, AnonymousInstance, ListLiteral, Identifier
+from src.generator import CodeGenerator
+
+def test_render_nested_list_and_instance():
+    pattern = Pattern(
+        name="DataMap",
+        parameters=[
+            Parameter(name="entries", type=Type(name="List", inner_type=Type(name="MapEntry")))
+        ]
+    )
+
+    map_entry_pattern = Pattern(
+        name="MapEntry",
+        parameters=[
+            Parameter(name="key", type=Type(name="String")),
+            Parameter(name="value", type=Type(name="Expression"))
+        ]
+    )
+
+    instances = [
+        Instance(
+            name="UserProfile",
+            pattern_name="DataMap",
+            assignments=[
+                Assignment(
+                    name="entries",
+                    value=ListLiteral(elements=[
+                        AnonymousInstance(
+                            pattern_name="MapEntry",
+                            assignments=[
+                                Assignment(name="key", value="id"),
+                                Assignment(name="value", value=1)
+                            ]
+                        ),
+                        AnonymousInstance(
+                            pattern_name="MapEntry",
+                            assignments=[
+                                Assignment(name="key", value="active"),
+                                Assignment(name="value", value=True)
+                            ]
+                        )
+                    ])
+                )
+            ]
+        )
+    ]
+
+    program = Program(patterns=[pattern, map_entry_pattern], instances=instances)
+    generator = CodeGenerator()
+    output = generator.render_program(program)
+
+    assert "UserProfile" in output
+    # Current output for AnonymousInstance is "instance of MapEntry"
+    # Current output for ListLiteral is "[instance of MapEntry, instance of MapEntry]"
+    assert "[MapEntry(key=id, value=1), MapEntry(key=active, value=True)]" in output


### PR DESCRIPTION
Improved the reStructuredText generator to support nested instances and lists. Previously, nested instances were rendered with a generic placeholder. Now they are rendered with their pattern name and all assigned parameters, following the DSL's intent for semantic representation. Added tests and updated the roadmap.

Fixes #37

---
*PR created automatically by Jules for task [2536281885705384417](https://jules.google.com/task/2536281885705384417) started by @chatelao*