### PR TITLE
Implement Instruction and Block Rendering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,9 +31,9 @@
     - [x] 7.2 Implement generator logic for Pattern instances (tables) <!-- 2026-05-02, issue #7.2 -->
         - [x] 7.2.1 Implement reST table rendering for basic assignments <!-- 2026-05-02, issue #7.2.1 -->
         - [x] 7.2.2 Implement reST rendering for nested instances and lists <!-- 2026-05-02, issue #7.2.2 -->
-    - [ ] 7.3 Implement generator logic for Instructions (blocks) <!-- issue #7.3 -->
-        - [ ] 7.3.1 Implement reST rendering for call, assign, and return instructions <!-- issue #7.3.1 -->
-        - [ ] 7.3.2 Implement reST rendering for raw snippets and nested blocks <!-- issue #7.3.2 -->
+    - [x] 7.3 Implement generator logic for Instructions (blocks) <!-- 2026-05-02, issue #7.3 -->
+        - [x] 7.3.1 Implement reST rendering for call, assign, and return instructions <!-- 2026-05-02, issue #7.3.1 -->
+        - [x] 7.3.2 Implement reST rendering for raw snippets and nested blocks <!-- 2026-05-02, issue #7.3.2 -->
 
 ## Phase 3: Content Creation
 - [ ] Populate Programming Language patterns <!-- issue #8 -->

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from typing import List, Dict
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from .models import Pattern, Program, Instance, AnonymousInstance, Block, ListLiteral, Identifier
+from .models import (
+    Pattern, Program, Instance, AnonymousInstance, Block, ListLiteral, Identifier,
+    CallInstruction, AssignInstruction, ReturnInstruction, RawInstruction
+)
 
 def format_value(value) -> str:
     if isinstance(value, str):
@@ -17,7 +20,17 @@ def format_value(value) -> str:
         assignments = [f"{a.name}={format_value(a.value)}" for a in value.assignments]
         return f"{value.pattern_name}({', '.join(assignments)})"
     if isinstance(value, Block):
-        return "{ ... }"
+        instructions = [format_value(i) for i in value.instructions]
+        return f"{{ {'; '.join(instructions)} }}"
+    if isinstance(value, CallInstruction):
+        args = [format_value(a) for a in value.arguments]
+        return f"call {value.name}({', '.join(args)})"
+    if isinstance(value, AssignInstruction):
+        return f"assign {value.target} = {format_value(value.value)}"
+    if isinstance(value, ReturnInstruction):
+        return f"return {format_value(value.value)}"
+    if isinstance(value, RawInstruction):
+        return f'raw "{value.snippet}"'
     return str(value)
 
 class CodeGenerator:

--- a/test/test_generator_instructions.py
+++ b/test/test_generator_instructions.py
@@ -1,0 +1,79 @@
+import pytest
+from src.models import (
+    Program, Pattern, Instance, Parameter, Type, Assignment, Block,
+    CallInstruction, AssignInstruction, ReturnInstruction, RawInstruction, Identifier
+)
+from src.generator import CodeGenerator
+
+def test_render_instructions():
+    pattern = Pattern(
+        name="Function",
+        parameters=[
+            Parameter(name="body", type=Type(name="Block"))
+        ]
+    )
+
+    instances = [
+        Instance(
+            name="MyFunc",
+            pattern_name="Function",
+            assignments=[
+                Assignment(
+                    name="body",
+                    value=Block(instructions=[
+                        CallInstruction(name="print", arguments=["hello"]),
+                        AssignInstruction(target="x", value=10),
+                        ReturnInstruction(value=Identifier(name="x")),
+                        RawInstruction(snippet="exit(0);")
+                    ])
+                )
+            ]
+        )
+    ]
+
+    program = Program(patterns=[pattern], instances=instances)
+    generator = CodeGenerator()
+    output = generator.render_program(program)
+
+    expected_body = "{ call print(hello); assign x = 10; return x; raw \"exit(0);\" }"
+    assert expected_body in output
+
+def test_render_nested_blocks():
+    # Although the grammar currently doesn't explicitly support nested blocks
+    # as first-class values in instructions (only in Value),
+    # the ASG and generator can handle them if they appear in assignments.
+    pattern = Pattern(
+        name="ControlFlow",
+        parameters=[
+            Parameter(name="nested", type=Type(name="Block"))
+        ]
+    )
+
+    instances = [
+        Instance(
+            name="NestedTest",
+            pattern_name="ControlFlow",
+            assignments=[
+                Assignment(
+                    name="nested",
+                    value=Block(instructions=[
+                        AssignInstruction(
+                            target="inner",
+                            value=Block(instructions=[
+                                CallInstruction(name="log", arguments=["inner"])
+                            ])
+                        )
+                    ])
+                )
+            ]
+        )
+    ]
+
+    program = Program(patterns=[pattern], instances=instances)
+    generator = CodeGenerator()
+    output = generator.render_program(program)
+
+    # Note: Identifier 'inner' in assign target doesn't use format_value yet in AssignInstruction
+    # but the value does.
+    expected_content = "{ assign inner = { call log(inner) } }"
+    assert expected_content in output


### PR DESCRIPTION
Implemented the generator logic for instructions and blocks (ROADMAP tasks 7.3.1 and 7.3.2) and verified with new and existing tests.

Fixes #39

---
*PR created automatically by Jules for task [9007124114793526876](https://jules.google.com/task/9007124114793526876) started by @chatelao*