### PR TITLE
Implement CLI Entry Point and Refine Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,22 +11,22 @@
     - [x] 4.1 Define DSL requirements and syntax draft <!-- 2026-05-01, issue #4.1 -->
     - [x] 4.2 Validate DSL draft with example patterns <!-- 2026-05-01, issue #4.2 -->
     - [x] 4.3 Finalize DSL specification <!-- 2026-05-01, issue #4.3 -->
-- [ ] Implement ANTLR4 grammar for the DSL <!-- issue #5 -->
+- [x] Implement ANTLR4 grammar for the DSL <!-- 2026-05-02, issue #5 -->
     - [x] 5.1 Define Lexer rules for identifiers, literals, and keywords <!-- 2026-05-01, issue #5.1 -->
     - [x] 5.2 Define Parser rules for pattern definitions, instances, and metadata <!-- 2026-05-01, issue #5.2 -->
     - [x] 5.3 Define Parser rules for blocks, instructions, and collections <!-- 2026-05-01, issue #5.3 -->
     - [x] 5.4 Implement grammar verification tests <!-- 2026-05-01, issue #5.4 -->
-- [ ] Design the Intermediate Representation (IR) / ASG <!-- issue #6 -->
+- [x] Design the Intermediate Representation (IR) / ASG <!-- 2026-05-02, issue #6 -->
     - [x] 6.1 Define the ASG object model in Python <!-- 2026-05-01, issue #6.1 -->
-    - [ ] 6.2 Implement CST to ASG transformation logic <!-- issue #6.2 -->
+    - [x] 6.2 Implement CST to ASG transformation logic <!-- 2026-05-02, issue #6.2 -->
         - [x] 6.2.1 Implement base Visitor for CST to ASG transformation <!-- 2026-05-02, issue #6.2.1 -->
         - [x] 6.2.2 Implement transformation for Pattern definitions <!-- 2026-05-02, issue #6.2.2 -->
         - [x] 6.2.3 Implement transformation for Instance definitions <!-- 2026-05-02, issue #6.2.3 -->
-    - [ ] 6.3 Implement ASG validation <!-- issue #6.3 -->
+    - [x] 6.3 Implement ASG validation <!-- 2026-05-02, issue #6.3 -->
         - [x] 6.3.1 Validate pattern existence for instances <!-- 2026-05-02, issue #6.3.1 -->
         - [x] 6.3.2 Validate mandatory parameter assignment <!-- 2026-05-02, issue #6.3.2 -->
         - [x] 6.3.3 Validate type consistency for assignments <!-- 2026-05-02, issue #6.3.3 -->
-- [ ] Implement Jinja2 generators for reStructuredText <!-- issue #7 -->
+- [x] Implement Jinja2 generators for reStructuredText <!-- 2026-05-02, issue #7 -->
     - [x] 7.1 Setup Jinja2 environment and base reST templates <!-- 2026-05-02, issue #7.1 -->
     - [x] 7.2 Implement generator logic for Pattern instances (tables) <!-- 2026-05-02, issue #7.2 -->
         - [x] 7.2.1 Implement reST table rendering for basic assignments <!-- 2026-05-02, issue #7.2.1 -->
@@ -34,10 +34,15 @@
     - [x] 7.3 Implement generator logic for Instructions (blocks) <!-- 2026-05-02, issue #7.3 -->
         - [x] 7.3.1 Implement reST rendering for call, assign, and return instructions <!-- 2026-05-02, issue #7.3.1 -->
         - [x] 7.3.2 Implement reST rendering for raw snippets and nested blocks <!-- 2026-05-02, issue #7.3.2 -->
+    - [x] 7.4 Implement CLI entry point (`src/main.py`) <!-- 2026-05-02, issue #7.4 -->
 
 ## Phase 3: Content Creation
 - [ ] Populate Programming Language patterns <!-- issue #8 -->
     - [ ] 8.1 Variable declaration <!-- issue #8.1 -->
+        - [ ] 8.1.1 C-family languages (C, Java, Rust) <!-- issue #8.1.1 -->
+        - [ ] 8.1.2 Functional languages (Erlang, Lisp) <!-- issue #8.1.2 -->
+        - [ ] 8.1.3 Shells and Scripting (Bash, Cmd, PowerShell, SQL) <!-- issue #8.1.3 -->
+        - [ ] 8.1.4 Specialized (XQuery, CSS) <!-- issue #8.1.4 -->
     - [ ] 8.2 Control flow (if/else, loops) <!-- issue #8.2 -->
     - [ ] 8.3 Function/Procedure definition <!-- issue #8.3 -->
     - [ ] 8.4 Error handling <!-- issue #8.4 -->

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -1,0 +1,18 @@
+pattern VariableDeclaration {
+    meta description: "The act of naming a value and optionally specifying its type."
+    parameter name: String
+    parameter type: String
+    parameter initial_value: Number
+}
+
+instance JavaVar of VariableDeclaration {
+    name = "x"
+    type = "int"
+    initial_value = 42
+}
+
+instance PythonVar of VariableDeclaration {
+    name = "x"
+    type = "None"
+    initial_value = 42
+}

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,62 @@
+import argparse
+import sys
+import os
+from pathlib import Path
+from antlr4 import CommonTokenStream, InputStream
+
+# Add src/generated to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), 'generated')))
+
+from SourcePatternsLexer import SourcePatternsLexer
+from SourcePatternsParser import SourcePatternsParser
+from .transformer import SourcePatternsTransformer
+from .validator import Validator, ValidationError
+from .generator import CodeGenerator
+
+def main():
+    parser = argparse.ArgumentParser(description="Transform Source Patterns DSL to reStructuredText.")
+    parser.add_argument("input", help="Path to the input .patterns file")
+    parser.add_argument("-o", "--output", help="Path to the output .rst file (defaults to stdout)")
+
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: Input file '{args.input}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    content = input_path.read_text()
+
+    # 1. Parsing
+    input_stream = InputStream(content)
+    lexer = SourcePatternsLexer(input_stream)
+    token_stream = CommonTokenStream(lexer)
+    sp_parser = SourcePatternsParser(token_stream)
+    tree = sp_parser.program()
+
+    # 2. Transformation
+    transformer = SourcePatternsTransformer()
+    program_asg = transformer.visit(tree)
+
+    # 3. Validation
+    validator = Validator()
+    try:
+        validator.validate(program_asg)
+    except ValidationError as e:
+        print(f"Validation Error:\n{e}", file=sys.stderr)
+        sys.exit(1)
+
+    # 4. Generation
+    generator = CodeGenerator()
+    output_rst = generator.render_program(program_asg)
+
+    # 5. Output
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output_rst)
+    else:
+        print(output_rst)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change implements the next logical step in the roadmap: a CLI entry point for the transpiler. It also updates the `ROADMAP.md` to accurately reflect the project's progress and refines the upcoming "Content Creation" phase by breaking down large tasks into smaller, manageable subtasks. Additionally, an initial pattern file is provided to demonstrate and verify the full pipeline from DSL to reStructuredText.

Fixes #41

---
*PR created automatically by Jules for task [9467825765014647258](https://jules.google.com/task/9467825765014647258) started by @chatelao*