### PR TITLE
Implement Roadmap Step 8.1.1: C-family Variable Declarations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@
 ## Phase 3: Content Creation
 - [ ] Populate Programming Language patterns <!-- issue #8 -->
     - [ ] 8.1 Variable declaration <!-- issue #8.1 -->
-        - [ ] 8.1.1 C-family languages (C, Java, Rust) <!-- issue #8.1.1 -->
+        - [x] 8.1.1 C-family languages (C, Java, Rust) <!-- 2026-05-02, issue #8.1.1 -->
         - [ ] 8.1.2 Functional languages (Erlang, Lisp) <!-- issue #8.1.2 -->
         - [ ] 8.1.3 Shells and Scripting (Bash, Cmd, PowerShell, SQL) <!-- issue #8.1.3 -->
         - [ ] 8.1.4 Specialized (XQuery, CSS) <!-- issue #8.1.4 -->

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -3,16 +3,38 @@ pattern VariableDeclaration {
     parameter name: String
     parameter type: String
     parameter initial_value: Number
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance CVar of VariableDeclaration {
+    name = "x"
+    type = "int"
+    initial_value = 42
+    syntax = "int x = 42;"
+    notes = "Static typing, terminated by semicolon."
 }
 
 instance JavaVar of VariableDeclaration {
     name = "x"
     type = "int"
     initial_value = 42
+    syntax = "int x = 42;"
+    notes = "Strongly typed, similar to C."
+}
+
+instance RustVar of VariableDeclaration {
+    name = "x"
+    type = "i32"
+    initial_value = 42
+    syntax = "let x: i32 = 42;"
+    notes = "Immutable by default; supports type inference."
 }
 
 instance PythonVar of VariableDeclaration {
     name = "x"
     type = "None"
     initial_value = 42
+    syntax = "x = 42"
+    notes = "Dynamically typed, no explicit type declaration needed."
 }


### PR DESCRIPTION
I have implemented the next modest step in the roadmap (Task 8.1.1: C-family languages variable declaration). 

Key changes:
1.  **Pattern Refinement**: Updated the `VariableDeclaration` pattern in `patterns/programming.patterns` to include `syntax` and `notes` parameters. This allows for a more detailed and structured comparison in the generated documentation, as suggested in `DESIGN.md`.
2.  **Content Creation**: Added instances for **C** (`CVar`), **Java** (`JavaVar`), and **Rust** (`RustVar`) to the `VariableDeclaration` pattern, providing language-specific syntax and comparative notes.
3.  **Roadmap Update**: Marked task 8.1.1 as completed in `ROADMAP.md`.
4.  **Verification**: 
    - Verified the output by running the transpiler, which correctly generates the comparison table with the new fields and languages.
    - Ran the full unit test suite (36 tests), all of which passed.
    - Performed a code review and recorded relevant memories.

Fixes #43

---
*PR created automatically by Jules for task [7786266092302509807](https://jules.google.com/task/7786266092302509807) started by @chatelao*