### PR TITLE
Implement C-family Control Flow Instances and Fix Import Consistency

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@
         - [x] 8.1.4 Specialized (XQuery, CSS) <!-- 2026-05-03, issue #8.1.4 -->
     - [ ] 8.2 Control flow (if/else, loops) <!-- issue #8.2 -->
         - [x] 8.2.1 Define `IfElse` and `Loop` patterns <!-- 2026-05-03, issue #8.2.1 -->
-        - [ ] 8.2.2 Implement C-family instances <!-- issue #8.2.2 -->
+        - [x] 8.2.2 Implement C-family instances (C, Java, Rust) <!-- 2026-05-03, issue #8.2.2 -->
         - [ ] 8.2.3 Implement Scripting & Shell instances <!-- issue #8.2.3 -->
         - [ ] 8.2.4 Implement Functional instances <!-- issue #8.2.4 -->
     - [ ] 8.3 Function/Procedure definition <!-- issue #8.3 -->

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -119,3 +119,48 @@ instance CssVar of VariableDeclaration {
     syntax = "--x: 42;"
     notes = "CSS custom properties (variables)."
 }
+
+instance CIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) { return 1; } else { return 0; }"
+    notes = "Standard C if-else statement."
+}
+
+instance CLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x = x - 1;" }
+    syntax = "while (x > 0) { x = x - 1; }"
+    notes = "Standard C while loop."
+}
+
+instance JavaIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) { return 1; } else { return 0; }"
+    notes = "Identical to C."
+}
+
+instance JavaLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x = x - 1;" }
+    syntax = "while (x > 0) { x = x - 1; }"
+    notes = "Identical to C."
+}
+
+instance RustIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if x > 0 { 1 } else { 0 }"
+    notes = "Rust if-else is an expression; parentheses around condition are not required."
+}
+
+instance RustLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x -= 1;" }
+    syntax = "while x > 0 { x -= 1; }"
+    notes = "Condition does not require parentheses."
+}

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), 'generat
 
 from SourcePatternsParser import SourcePatternsParser
 from SourcePatternsVisitor import SourcePatternsVisitor
-from models import (
+from .models import (
     Program, Pattern, Instance, AnonymousInstance, Metadata, Parameter,
     Type, Assignment, Block, Instruction, CallInstruction, AssignInstruction,
     ReturnInstruction, RawInstruction, Identifier, ListLiteral

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -9,8 +9,8 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 's
 
 from SourcePatternsLexer import SourcePatternsLexer
 from SourcePatternsParser import SourcePatternsParser
-from transformer import SourcePatternsTransformer
-from models import Program, Pattern, Instance, AnonymousInstance, Metadata, Type, Parameter, Assignment, Identifier, Block, CallInstruction, ListLiteral
+from src.transformer import SourcePatternsTransformer
+from src.models import Program, Pattern, Instance, AnonymousInstance, Metadata, Type, Parameter, Assignment, Identifier, Block, CallInstruction, ListLiteral
 
 def transform_snippet(snippet):
     input_stream = InputStream(snippet)


### PR DESCRIPTION
This PR implements the next step in the project roadmap by adding `IfElse` and `Loop` pattern instances for C-family languages (C, Java, Rust). 

Additionally, it addresses an architectural inconsistency where `src/transformer.py` was using absolute imports for other `src` modules while other components were using relative imports. This caused `isinstance` checks to fail in the `Validator` because multiple versions of the same class were being loaded into memory under different module paths.

Key changes:
- `patterns/programming.patterns`: Implementation of `CIfElse`, `CLoop`, `JavaIfElse`, `JavaLoop`, `RustIfElse`, and `RustLoop`.
- `ROADMAP.md`: Updated to reflect progress.
- `src/transformer.py`: Switched to relative imports for `models`.
- `test/test_transformer.py`: Updated imports to be compatible with the standard `python -m pytest` execution flow.
- `src/main.py`: Cleaned up an unused import.

Fixes #57

---
*PR created automatically by Jules for task [9738086132337953960](https://jules.google.com/task/9738086132337953960) started by @chatelao*