### PR TITLE
Fix automated merge and iteration workflow (BC 3)

### DIFF
--- a/.github/workflows/auto_repeat.yml
+++ b/.github/workflows/auto_repeat.yml
@@ -25,58 +25,98 @@ jobs:
         run: |
           set -e
 
-          # Get the PR associated with the workflow run
+          # 1. Get the PR associated with the workflow run
+          echo "Fetching PR information..."
           PR_INFO=$(gh api "/repos/$REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.[0] | {number: .number, state: .state}')
           PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
-          PR_STATE=$(echo "$PR_INFO" | jq -r '.state // empty')
+
+          # Fallback: search by head SHA if direct link is missing
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
+            echo "Direct PR link not found, falling back to head SHA lookup..."
+            HEAD_SHA=$(gh api "/repos/$REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}" --jq '.head_sha')
+            PR_INFO=$(gh api "/repos/$REPOSITORY/commits/$HEAD_SHA/pulls" --jq '.[0] | {number: .number, state: .state}')
+            PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
+          fi
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
             echo "No PR associated with this workflow run."
             exit 0
           fi
 
+          # Refresh state to ensure accuracy
+          PR_STATE=$(gh pr view $PR_NUMBER --repo $REPOSITORY --json state --jq -r '.state')
           echo "Processing PR #$PR_NUMBER (State: $PR_STATE)"
 
-          if [ "$PR_STATE" != "open" ]; then
-            echo "PR #$PR_NUMBER is not open (State: $PR_STATE). Skipping merge."
+          if [ "$PR_STATE" != "OPEN" ]; then
+            echo "PR #$PR_NUMBER is not open. Skipping merge."
             exit 0
           fi
 
-          # Check for Auto-Repeat label on the PR
-          IS_AUTO_REPEAT=$(gh pr view $PR_NUMBER --repo $REPOSITORY --json labels --jq 'any(.labels[]?; .name == "Auto-Repeat")')
-
-          if [ "$IS_AUTO_REPEAT" != "true" ]; then
-            echo "No Auto-Repeat label found on PR #$PR_NUMBER. Skipping."
-            exit 0
-          fi
-
-          # Merge the PR
-          echo "Merging PR #$PR_NUMBER"
-          gh pr merge $PR_NUMBER --repo $REPOSITORY --merge
-
-          # Find associated issue
+          # 2. Detect associated issue
+          echo "Detecting associated issue..."
           ISSUE_NUMBER=$(gh pr view $PR_NUMBER --repo $REPOSITORY --json closingIssuesReferences --jq '.closingIssuesReferences[0]?.number // empty')
-
           if [ -z "$ISSUE_NUMBER" ]; then
-            # Fallback: search for #ISSUE in body
-            ISSUE_NUMBER=$(gh pr view $PR_NUMBER --repo $REPOSITORY --json body --jq '.body // ""' | grep -oP '(?<=#)[0-9]+' | head -n 1 || true)
+            echo "No closing reference found, searching PR body and title..."
+            ISSUE_NUMBER=$(gh pr view $PR_NUMBER --repo $REPOSITORY --json body,title --jq '.body + " " + .title' | grep -oE '#[0-9]+' | head -n 1 | tr -d '#' || true)
           fi
 
-          if [ -z "$ISSUE_NUMBER" ]; then
-            echo "No associated issue found for PR #$PR_NUMBER."
+          # 3. Check for iteration labels (Auto-Repeat or Auto-Repeat-X)
+          # We check both the PR and the associated Issue
+          PR_LABELS=$(gh pr view $PR_NUMBER --repo $REPOSITORY --json labels --jq -r '.labels[].name' 2>/dev/null || true)
+          ISSUE_LABELS=""
+          if [ -n "$ISSUE_NUMBER" ]; then
+            ISSUE_LABELS=$(gh issue view $ISSUE_NUMBER --repo $REPOSITORY --json labels --jq -r '.labels[].name' 2>/dev/null || true)
+          fi
+
+          ALL_LABELS=$(printf "%s\n%s" "$PR_LABELS" "$ISSUE_LABELS" | grep . | sort -u || true)
+          ITERATION_LABEL=$(echo "$ALL_LABELS" | grep -E "^Auto-Repeat(-[0-9]+)?$" | head -n 1 || true)
+
+          if [ -z "$ITERATION_LABEL" ]; then
+            echo "No Auto-Repeat or Auto-Repeat-X label found on PR #$PR_NUMBER or Issue #$ISSUE_NUMBER. Skipping."
             exit 0
           fi
 
-          echo "Duplicating issue #$ISSUE_NUMBER"
+          echo "Iteration label found: $ITERATION_LABEL"
 
+          # 4. Merge the PR
+          echo "Merging PR #$PR_NUMBER..."
+          # Use --auto to handle mergeability waiting, but fallback to immediate merge
+          gh pr merge $PR_NUMBER --repo $REPOSITORY --merge --auto || gh pr merge $PR_NUMBER --repo $REPOSITORY --merge
+
+          # 5. Handle Iteration (Issue Duplication)
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No associated issue found for PR #$PR_NUMBER. Iteration cannot continue."
+            exit 0
+          fi
+
+          echo "Duplicating issue #$ISSUE_NUMBER for the next iteration..."
           ISSUE_DATA=$(gh issue view $ISSUE_NUMBER --repo $REPOSITORY --json title,body,labels)
           TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
           BODY_FILE=$(mktemp)
           echo "$ISSUE_DATA" | jq -r '.body' > "$BODY_FILE"
 
-          # Prepare new labels for the duplicated issue
-          # We take all labels from the original issue, and ensure Auto-Repeat is present
-          NEW_LABELS=$(echo "$ISSUE_DATA" | jq -r '[.labels[].name, "Auto-Repeat"] | unique | join(",")')
+          # Calculate the next iteration label (decrement counter if Auto-Repeat-X)
+          NEXT_LABEL="$ITERATION_LABEL"
+          if [[ "$ITERATION_LABEL" =~ ^Auto-Repeat-([0-9]+)$ ]]; then
+            COUNT="${BASH_REMATCH[1]}"
+            NEXT_COUNT=$((COUNT - 1))
+            if [ $NEXT_COUNT -le 0 ]; then
+              echo "Counter reached 0. Stopping iteration."
+              NEXT_LABEL=""
+            else
+              NEXT_LABEL="Auto-Repeat-$NEXT_COUNT"
+              echo "Decrementing counter: $ITERATION_LABEL -> $NEXT_LABEL"
+            fi
+          fi
+
+          # Prepare labels for the new issue
+          if [ -n "$NEXT_LABEL" ]; then
+            NEW_LABELS=$(echo "$ISSUE_DATA" | jq -r --arg next "$NEXT_LABEL" --arg old "$ITERATION_LABEL" \
+              '[.labels[].name | select(. != $old)] + [$next] | unique | join(",")')
+          else
+            NEW_LABELS=$(echo "$ISSUE_DATA" | jq -r --arg old "$ITERATION_LABEL" \
+              '[.labels[].name | select(. != $old)] | unique | join(",")')
+          fi
 
           echo "Creating new issue with labels: $NEW_LABELS"
           gh issue create --repo $REPOSITORY --title "$TITLE" --body-file "$BODY_FILE" --label "$NEW_LABELS"

--- a/AUTO_MERGE.md
+++ b/AUTO_MERGE.md
@@ -1,0 +1,35 @@
+# Automated Merge and Iteration Workflow (BC 3)
+
+This project uses an automated workflow to speed up development by automatically merging successful Pull Requests and re-opening the associated tasks for the next iteration.
+
+## How it works
+
+The workflow is triggered whenever the **CI** workflow completes successfully for a Pull Request targeting the `main` branch.
+
+### 1. Label Detection
+The workflow looks for specific "Iteration Labels" on either the **Pull Request** or its **linked Issue**.
+
+*   **`Auto-Repeat`**: Merges the PR and duplicates the associated issue for another iteration. This continues indefinitely.
+*   **`Auto-Repeat-X`** (e.g., `Auto-Repeat-5`): Merges the PR and duplicates the issue, but decrements the counter in the label (e.g., to `Auto-Repeat-4`). The process stops when the counter reaches 0.
+
+### 2. PR Merging
+If an iteration label is found, the workflow attempts to merge the Pull Request using the `--merge` strategy.
+
+### 3. Issue Duplication
+After a successful merge, the workflow identifies the associated issue. It then creates a **new issue** with the same title and description, and applies the next iteration label (either `Auto-Repeat` or the decremented `Auto-Repeat-X`).
+
+## Troubleshooting: Why didn't my PR merge?
+
+If your PR was not merged automatically even though CI passed, check the following:
+
+1.  **Label Missing**: Ensure the `Auto-Repeat` or `Auto-Repeat-X` label is present on either the PR or the linked Issue.
+2.  **Issue Link**: The workflow must be able to find the associated issue. It looks for:
+    *   Official GitHub "Linked Issues" (e.g., using "Closes #123" in the description).
+    *   Any `#123` reference in the PR title or body.
+3.  **Branch Protection**: If the `main` branch has protection rules (e.g., "Require status checks to pass before merging" or "Require a pull request before merging"), the `GITHUB_TOKEN` used by the workflow must have permission to bypass these, or the requirements must be met.
+4.  **Conflicts**: If the PR has merge conflicts, it cannot be merged automatically.
+5.  **Draft Status**: The PR must not be in "Draft" status.
+
+## Configuration
+
+The workflow logic is defined in [`.github/workflows/auto_repeat.yml`](.github/workflows/auto_repeat.yml).


### PR DESCRIPTION
This PR fixes the automated merge and iteration workflow (Business Case 3) which was failing to process PRs like PR-65.

Key improvements:
1. **Case-Insensitive State Check**: The workflow now correctly identifies `OPEN` PRs (GitHub CLI returns uppercase).
2. **Dual-Source Label Detection**: Iteration labels (`Auto-Repeat`, `Auto-Repeat-X`) are now searched for on both the Pull Request and any associated Issue, increasing flexibility.
3. **Robust Discovery**: 
    - Fallback to searching PRs by head SHA if the direct API link is missing.
    - Fallback to regex-based issue detection in PR body and title if official linking is absent.
4. **Auto-Repeat-X Implementation**: Successfully implemented the planned decrementing counter logic, allowing for a fixed number of automated iterations.
5. **Reliable Merging**: Switched to `gh pr merge --auto` to better handle repository-level merge requirements and waiting periods.
6. **Documentation**: Created `AUTO_MERGE.md` to guide users on using the automated workflow and troubleshooting common failures.

Fixes #65

---
*PR created automatically by Jules for task [12152490812896216560](https://jules.google.com/task/12152490812896216560) started by @chatelao*