### PR TITLE
Implement roadmap steps 8.2.5 and 8.3.1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,9 +51,9 @@
         - [x] 8.2.2 Implement C-family instances (C, Java, Rust) <!-- 2026-05-03, issue #8.2.2 -->
         - [x] 8.2.3 Implement Scripting & Shell instances <!-- 2026-05-03, issue #8.2.3 -->
         - [x] 8.2.4 Implement Functional instances <!-- 2026-05-03, issue #8.2.4 -->
-        - [ ] 8.2.5 Implement Specialized instances (XQuery, CSS) <!-- issue #8.2.5 -->
+        - [x] 8.2.5 Implement Specialized instances (XQuery, CSS) <!-- 2026-05-03, issue #8.2.5 -->
     - [ ] 8.3 Function/Procedure definition <!-- issue #8.3 -->
-        - [ ] 8.3.1 Define `FunctionDefinition` pattern <!-- issue #8.3.1 -->
+        - [x] 8.3.1 Define `FunctionDefinition` pattern <!-- 2026-05-03, issue #8.3.1 -->
         - [ ] 8.3.2 Implement instances across language groups <!-- issue #8.3.2 -->
     - [ ] 8.4 Error handling <!-- issue #8.4 -->
         - [ ] 8.4.1 Define `TryCatch` and `Raise` patterns <!-- issue #8.4.1 -->

--- a/output.rst
+++ b/output.rst
@@ -102,6 +102,28 @@ Parameters:
      - CSS custom properties (variables).
 
 
+Pattern: FunctionDefinition
+
+:description: Declaration of a reusable block of code with parameters and a return value.
+
+
+Parameters:
+
+* name: String
+
+* parameters: List<String>
+
+* return_type: String
+
+* body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+
 Pattern: IfElse
 
 :description: Conditional execution of code blocks.
@@ -191,6 +213,18 @@ Parameters:
      - { return 0 }
      - (if (> x 0) 1 0)
      - The 'if' expression evaluates the condition and returns the corresponding branch result.
+   * - XQueryIfElse
+     - $x > 0
+     - { return 1 }
+     - { return 0 }
+     - if ($x > 0) then 1 else 0
+     - Functional if-then-else expression; both branches are required.
+   * - CssIfElse
+     - min-width: 0px
+     - { raw "color: red;" }
+     - { raw "color: blue;" }
+     - @media (min-width: 0px) { .element { color: red; } }
+     - Media queries provide conditional styling; no true else branch exists.
 
 
 Pattern: Loop
@@ -269,3 +303,13 @@ Parameters:
      - { raw "(setq x (1- x))" }
      - (loop while (> x 0) do (setq x (1- x)))
      - Common Lisp 'loop' macro provides a versatile way to iterate.
+   * - XQueryLoop
+     - $i in 1 to $x
+     - { raw "$i" }
+     - for $i in 1 to $x return $i
+     - XQuery uses 'for' expressions for iteration over sequences.
+   * - CssLoop
+     - N/A
+     - { raw "N/A" }
+     - N/A
+     - CSS does not support loops natively.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -7,6 +7,16 @@ pattern VariableDeclaration {
     parameter notes: String
 }
 
+pattern FunctionDefinition {
+    meta description: "Declaration of a reusable block of code with parameters and a return value."
+    parameter name: String
+    parameter parameters: List<String>
+    parameter return_type: String
+    parameter body: Block
+    parameter syntax: String
+    parameter notes: String
+}
+
 pattern IfElse {
     meta description: "Conditional execution of code blocks."
     parameter condition: String
@@ -268,4 +278,34 @@ instance LispLoop of Loop {
     body = { raw "(setq x (1- x))" }
     syntax = "(loop while (> x 0) do (setq x (1- x)))"
     notes = "Common Lisp 'loop' macro provides a versatile way to iterate."
+}
+
+instance XQueryIfElse of IfElse {
+    condition = "$x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if ($x > 0) then 1 else 0"
+    notes = "Functional if-then-else expression; both branches are required."
+}
+
+instance XQueryLoop of Loop {
+    condition = "$i in 1 to $x"
+    body = { raw "$i" }
+    syntax = "for $i in 1 to $x return $i"
+    notes = "XQuery uses 'for' expressions for iteration over sequences."
+}
+
+instance CssIfElse of IfElse {
+    condition = "min-width: 0px"
+    then_branch = { raw "color: red;" }
+    else_branch = { raw "color: blue;" }
+    syntax = "@media (min-width: 0px) { .element { color: red; } }"
+    notes = "Media queries provide conditional styling; no true else branch exists."
+}
+
+instance CssLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "CSS does not support loops natively."
 }


### PR DESCRIPTION
This PR implements two modest steps from the ROADMAP.md:
1. **Step 8.2.5**: Added specialized instances for XQuery and CSS for the `IfElse` and `Loop` patterns. XQuery uses functional expressions, while CSS uses media queries as a conditional equivalent and notes that loops are not natively supported.
2. **Step 8.3.1**: Defined the `FunctionDefinition` pattern to allow cross-language comparison of how functions are declared.

The changes were verified by running the transpiler and ensuring the output.rst correctly renders the new content. All existing tests passed.

Fixes #67

---
*PR created automatically by Jules for task [8885788520594237904](https://jules.google.com/task/8885788520594237904) started by @chatelao*