### PR TITLE
Implement C-family FunctionDefinition instances

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,10 @@
     - [ ] 8.3 Function/Procedure definition <!-- issue #8.3 -->
         - [x] 8.3.1 Define `FunctionDefinition` pattern <!-- 2026-05-03, issue #8.3.1 -->
         - [ ] 8.3.2 Implement instances across language groups <!-- issue #8.3.2 -->
+            - [x] 8.3.2.1 C-family languages (C, Java, Rust) <!-- 2026-05-03, issue #8.3.2.1 -->
+            - [ ] 8.3.2.2 Scripting & Shell instances <!-- issue #8.3.2.2 -->
+            - [ ] 8.3.2.3 Functional instances <!-- issue #8.3.2.3 -->
+            - [ ] 8.3.2.4 Specialized instances (XQuery) <!-- issue #8.3.2.4 -->
     - [ ] 8.4 Error handling <!-- issue #8.4 -->
         - [ ] 8.4.1 Define `TryCatch` and `Raise` patterns <!-- issue #8.4.1 -->
         - [ ] 8.4.2 Implement instances across language groups <!-- issue #8.4.2 -->

--- a/output.rst
+++ b/output.rst
@@ -123,6 +123,39 @@ Parameters:
 
 
 
+.. list-table:: FunctionDefinition Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - name
+     - parameters
+     - return_type
+     - body
+     - syntax
+     - notes
+   * - CFunction
+     - add
+     - [int a, int b]
+     - int
+     - { raw "return a + b;" }
+     - int add(int a, int b) { return a + b; }
+     - Standard C function with static types and curly braces.
+   * - JavaFunction
+     - add
+     - [int a, int b]
+     - int
+     - { raw "return a + b;" }
+     - public int add(int a, int b) { return a + b; }
+     - Similar to C, but typically within a class with an access modifier.
+   * - RustFunction
+     - add
+     - [a: i32, b: i32]
+     - i32
+     - { raw "a + b" }
+     - fn add(a: i32, b: i32) -> i32 { a + b }
+     - Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly.
+
 
 Pattern: IfElse
 

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -309,3 +309,30 @@ instance CssLoop of Loop {
     syntax = "N/A"
     notes = "CSS does not support loops natively."
 }
+
+instance CFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["int a", "int b"]
+    return_type = "int"
+    body = { raw "return a + b;" }
+    syntax = "int add(int a, int b) { return a + b; }"
+    notes = "Standard C function with static types and curly braces."
+}
+
+instance JavaFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["int a", "int b"]
+    return_type = "int"
+    body = { raw "return a + b;" }
+    syntax = "public int add(int a, int b) { return a + b; }"
+    notes = "Similar to C, but typically within a class with an access modifier."
+}
+
+instance RustFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["a: i32", "b: i32"]
+    return_type = "i32"
+    body = { raw "a + b" }
+    syntax = "fn add(a: i32, b: i32) -> i32 { a + b }"
+    notes = "Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly."
+}


### PR DESCRIPTION
I have implemented the C-family (C, Java, Rust) instances for the `FunctionDefinition` pattern in `patterns/programming.patterns`. Additionally, I broke down the broad roadmap item 8.3.2 into more manageable sub-steps (C-family, Scripting & Shell, Functional, and Specialized) to better track progress. I verified the changes by running the transpiler and confirming the reStructuredText output contains the new comparison table. All 36 project tests passed.

Fixes #71

---
*PR created automatically by Jules for task [2033616661348826657](https://jules.google.com/task/2033616661348826657) started by @chatelao*