### PR TITLE
Implement FunctionDefinition instances for Scripting & Shell languages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@
         - [x] 8.3.1 Define `FunctionDefinition` pattern <!-- 2026-05-03, issue #8.3.1 -->
         - [ ] 8.3.2 Implement instances across language groups <!-- issue #8.3.2 -->
             - [x] 8.3.2.1 C-family languages (C, Java, Rust) <!-- 2026-05-03, issue #8.3.2.1 -->
-            - [ ] 8.3.2.2 Scripting & Shell instances <!-- issue #8.3.2.2 -->
+            - [x] 8.3.2.2 Scripting & Shell instances <!-- 2026-05-03, issue #8.3.2.2 -->
             - [ ] 8.3.2.3 Functional instances <!-- issue #8.3.2.3 -->
             - [ ] 8.3.2.4 Specialized instances (XQuery) <!-- issue #8.3.2.4 -->
     - [ ] 8.4 Error handling <!-- issue #8.4 -->

--- a/output.rst
+++ b/output.rst
@@ -155,6 +155,41 @@ Parameters:
      - { raw "a + b" }
      - fn add(a: i32, b: i32) -> i32 { a + b }
      - Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly.
+   * - PythonFunction
+     - add
+     - [a, b]
+     - Dynamic
+     - { raw "return a + b" }
+     - def add(a, b): return a + b
+     - Uses 'def' keyword; indentation defines the block.
+   * - BashFunction
+     - add
+     - [$1, $2]
+     - Exit Code / Stdout
+     - { raw "echo $(($1 + $2))" }
+     - add() { echo $(($1 + $2)); }
+     - Parameters are accessed via $1, $2, etc.; return values are typically exit codes or printed to stdout.
+   * - PowerShellFunction
+     - add
+     - [$a, $b]
+     - Dynamic
+     - { raw "return $a + $b" }
+     - function add($a, $b) { return $a + $b }
+     - Uses 'function' keyword; parameters are variables starting with $.
+   * - CmdFunction
+     - add
+     - [%1, %2]
+     - ErrorLevel
+     - { raw "set /a res=%1+%2\nexit /b %res%" }
+     - :add\nset /a res=%~1+%~2\nexit /b %res%
+     - Functions are labels; called with 'call :label'; arguments are %1, %2.
+   * - SqlFunction
+     - add
+     - [@a INT, @b INT]
+     - INT
+     - { raw "RETURN @a + @b" }
+     - CREATE FUNCTION add(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b END
+     - T-SQL syntax for Scalar-Valued Functions.
 
 
 Pattern: IfElse

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -336,3 +336,48 @@ instance RustFunction of FunctionDefinition {
     syntax = "fn add(a: i32, b: i32) -> i32 { a + b }"
     notes = "Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly."
 }
+
+instance PythonFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["a", "b"]
+    return_type = "Dynamic"
+    body = { raw "return a + b" }
+    syntax = "def add(a, b): return a + b"
+    notes = "Uses 'def' keyword; indentation defines the block."
+}
+
+instance BashFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["$1", "$2"]
+    return_type = "Exit Code / Stdout"
+    body = { raw "echo $(($1 + $2))" }
+    syntax = "add() { echo $(($1 + $2)); }"
+    notes = "Parameters are accessed via $1, $2, etc.; return values are typically exit codes or printed to stdout."
+}
+
+instance PowerShellFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["$a", "$b"]
+    return_type = "Dynamic"
+    body = { raw "return $a + $b" }
+    syntax = "function add($a, $b) { return $a + $b }"
+    notes = "Uses 'function' keyword; parameters are variables starting with $."
+}
+
+instance CmdFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["%1", "%2"]
+    return_type = "ErrorLevel"
+    body = { raw "set /a res=%1+%2\nexit /b %res%" }
+    syntax = ":add\nset /a res=%~1+%~2\nexit /b %res%"
+    notes = "Functions are labels; called with 'call :label'; arguments are %1, %2."
+}
+
+instance SqlFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["@a INT", "@b INT"]
+    return_type = "INT"
+    body = { raw "RETURN @a + @b" }
+    syntax = "CREATE FUNCTION add(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b END"
+    notes = "T-SQL syntax for Scalar-Valued Functions."
+}


### PR DESCRIPTION
This change implements roadmap task 8.3.2.2 by adding `FunctionDefinition` instances for Scripting and Shell languages (Python, Bash, PowerShell, Cmd, and SQL) to the `patterns/programming.patterns` file. It also updates the `ROADMAP.md` to reflect this progress and includes the regenerated `output.rst`.

Fixes #75

---
*PR created automatically by Jules for task [11302508289674789386](https://jules.google.com/task/11302508289674789386) started by @chatelao*