### PR TITLE
Implement FunctionDefinition instances and refine ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,21 +57,35 @@
         - [ ] 8.3.2 Implement instances across language groups <!-- issue #8.3.2 -->
             - [x] 8.3.2.1 C-family languages (C, Java, Rust) <!-- 2026-05-03, issue #8.3.2.1 -->
             - [x] 8.3.2.2 Scripting & Shell instances <!-- 2026-05-03, issue #8.3.2.2 -->
-            - [ ] 8.3.2.3 Functional instances <!-- issue #8.3.2.3 -->
-            - [ ] 8.3.2.4 Specialized instances (XQuery) <!-- issue #8.3.2.4 -->
+            - [x] 8.3.2.3 Functional instances <!-- 2026-05-04, issue #8.3.2.3 -->
+            - [x] 8.3.2.4 Specialized instances (XQuery) <!-- 2026-05-04, issue #8.3.2.4 -->
     - [ ] 8.4 Error handling <!-- issue #8.4 -->
         - [ ] 8.4.1 Define `TryCatch` and `Raise` patterns <!-- issue #8.4.1 -->
         - [ ] 8.4.2 Implement instances across language groups <!-- issue #8.4.2 -->
+            - [ ] 8.4.2.1 C-family languages (C, Java, Rust) <!-- issue #8.4.2.1 -->
+            - [ ] 8.4.2.2 Scripting & Shell instances <!-- issue #8.4.2.2 -->
+            - [ ] 8.4.2.3 Functional instances <!-- issue #8.4.2.3 -->
     - [ ] 8.5 Concurrency models <!-- issue #8.5 -->
         - [ ] 8.5.1 Define `Thread` and `MessagePassing` patterns <!-- issue #8.5.1 -->
         - [ ] 8.5.2 Implement instances (Rust, Erlang, Java) <!-- issue #8.5.2 -->
+            - [ ] 8.5.2.1 Rust instances <!-- issue #8.5.2.1 -->
+            - [ ] 8.5.2.2 Erlang instances <!-- issue #8.5.2.2 -->
+            - [ ] 8.5.2.3 Java instances <!-- issue #8.5.2.3 -->
 - [ ] Populate Data Format patterns <!-- issue #9 -->
     - [ ] 9.1 Basic data types (Strings, Numbers, Booleans) <!-- issue #9.1 -->
         - [ ] 9.1.1 Define `BasicTypes` pattern <!-- issue #9.1.1 -->
         - [ ] 9.1.2 Implement instances (JSON, XML, YAML, TOML) <!-- issue #9.1.2 -->
+            - [ ] 9.1.2.1 JSON <!-- issue #9.1.2.1 -->
+            - [ ] 9.1.2.2 XML <!-- issue #9.1.2.2 -->
+            - [ ] 9.1.2.3 YAML <!-- issue #9.1.2.3 -->
+            - [ ] 9.1.2.4 TOML <!-- issue #9.1.2.4 -->
     - [ ] 9.2 Nested structures (Objects/Maps, Arrays/Lists) <!-- issue #9.2 -->
         - [ ] 9.2.1 Define `Collection` and `Mapping` patterns <!-- issue #9.2.1 -->
         - [ ] 9.2.2 Implement instances across formats <!-- issue #9.2.2 -->
+            - [ ] 9.2.2.1 JSON <!-- issue #9.2.2.1 -->
+            - [ ] 9.2.2.2 XML <!-- issue #9.2.2.2 -->
+            - [ ] 9.2.2.3 YAML <!-- issue #9.2.2.3 -->
+            - [ ] 9.2.2.4 TOML <!-- issue #9.2.2.4 -->
     - [ ] 9.3 Metadata/Attributes <!-- issue #9.3 -->
     - [ ] 9.4 Comments support <!-- issue #9.4 -->
     - [ ] 9.5 Schema validation <!-- issue #9.5 -->

--- a/output.rst
+++ b/output.rst
@@ -190,6 +190,34 @@ Parameters:
      - { raw "RETURN @a + @b" }
      - CREATE FUNCTION add(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b END
      - T-SQL syntax for Scalar-Valued Functions.
+   * - ErlangFunction
+     - add
+     - [A, B]
+     - Dynamic
+     - { raw "A + B" }
+     - add(A, B) -> A + B.
+     - Erlang functions use pattern matching on arguments; the last expression's value is returned.
+   * - LispFunction
+     - add
+     - [a, b]
+     - Dynamic
+     - { raw "(+ a b)" }
+     - (defun add (a b) (+ a b))
+     - Functions are defined with 'defun'; Lisp follows prefix notation.
+   * - XQueryFunction
+     - local:add
+     - [$a as xs:integer, $b as xs:integer]
+     - xs:integer
+     - { raw "$a + $b" }
+     - declare function local:add($a as xs:integer, $b as xs:integer) as xs:integer { $a + $b };
+     - Functions must be declared in a namespace (e.g., 'local').
+   * - CssFunction
+     - N/A
+     - [N/A]
+     - N/A
+     - { raw "N/A" }
+     - N/A
+     - CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors).
 
 
 Pattern: IfElse

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -381,3 +381,39 @@ instance SqlFunction of FunctionDefinition {
     syntax = "CREATE FUNCTION add(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b END"
     notes = "T-SQL syntax for Scalar-Valued Functions."
 }
+
+instance ErlangFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["A", "B"]
+    return_type = "Dynamic"
+    body = { raw "A + B" }
+    syntax = "add(A, B) -> A + B."
+    notes = "Erlang functions use pattern matching on arguments; the last expression's value is returned."
+}
+
+instance LispFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["a", "b"]
+    return_type = "Dynamic"
+    body = { raw "(+ a b)" }
+    syntax = "(defun add (a b) (+ a b))"
+    notes = "Functions are defined with 'defun'; Lisp follows prefix notation."
+}
+
+instance XQueryFunction of FunctionDefinition {
+    name = "local:add"
+    parameters = ["$a as xs:integer", "$b as xs:integer"]
+    return_type = "xs:integer"
+    body = { raw "$a + $b" }
+    syntax = "declare function local:add($a as xs:integer, $b as xs:integer) as xs:integer { $a + $b };"
+    notes = "Functions must be declared in a namespace (e.g., 'local')."
+}
+
+instance CssFunction of FunctionDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    return_type = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors)."
+}


### PR DESCRIPTION
This PR implements the next set of programming language instances for the `FunctionDefinition` pattern and refines the future roadmap.

### Key Changes:
1. **Content Creation**:
   - Added `ErlangFunction` and `LispFunction` (Functional group).
   - Added `XQueryFunction` and `CssFunction` (Specialized group).
   - These additions complete the `FunctionDefinition` implementation across all currently defined language groups.

2. **Roadmap Refinement**:
   - Marked tasks 8.3.2.3 and 8.3.2.4 as completed.
   - Broke down large tasks into smaller, more manageable sub-tasks:
     - **Error Handling (8.4.2)**: Split into C-family, Scripting & Shell, and Functional groups.
     - **Concurrency Models (8.5.2)**: Split into Rust, Erlang, and Java specific tasks.
     - **Data Formats (9.1.2, 9.2.2)**: Split into JSON, XML, YAML, and TOML specific tasks for both basic types and nested structures.

### Verification:
- Ran `python3 -m src.main patterns/programming.patterns -o output.rst` and confirmed the new instances are correctly rendered in the reST table.
- Ran `python3 -m pytest` and all 36 tests passed.

Fixes #77

---
*PR created automatically by Jules for task [13058460211668452626](https://jules.google.com/task/13058460211668452626) started by @chatelao*