### PR TITLE
Fix Auto-Repeat workflow failures

### DIFF
--- a/.github/workflows/auto_repeat.yml
+++ b/.github/workflows/auto_repeat.yml
@@ -32,8 +32,10 @@ jobs:
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
             echo "PR number not found in event context, attempting API lookup..."
-            PR_NUMBER=$(gh api "/repos/$REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.[0].number // empty')
+            PR_NUMBER=$(gh api "/repos/$REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.pull_requests[0].number // empty')
           fi
+
+          echo "PR_NUMBER: $PR_NUMBER"
 
           # Fallback: search by head SHA if direct link is missing
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
@@ -63,8 +65,10 @@ jobs:
           ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json closingIssuesReferences --template '{{range .closingIssuesReferences}}{{.number}}{{"\n"}}{{end}}' | head -n 1)
           if [ -z "$ISSUE_NUMBER" ]; then
             echo "No closing reference found, searching PR body and title..."
-            ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json body,title --template '{{.body}} {{.title}}' | grep -oE '#[0-9]+' | head -n 1 | tr -d '#' || true)
+            ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json body,title --template '{{.body}} {{.title}}' | grep -oE '#[0-9]+' | tr -d '#' | grep -v "^$PR_NUMBER$" | head -n 1 || true)
           fi
+
+          echo "ISSUE_NUMBER: $ISSUE_NUMBER"
 
           # 3. Check for iteration labels (Auto-Repeat or Auto-Repeat-X)
           # We check both the PR and the associated Issue
@@ -117,6 +121,13 @@ jobs:
 
           # Prepare labels for the new issue
           if [ -n "$NEXT_LABEL" ]; then
+            # Ensure NEXT_LABEL exists
+            if ! gh label list --repo "$REPOSITORY" --json name --jq '.[].name' | grep -q "^$NEXT_LABEL$"; then
+              echo "Label $NEXT_LABEL does not exist. Creating it..."
+              COLOR=$(gh label view "$ITERATION_LABEL" --repo "$REPOSITORY" --json color --jq '.color' 2>/dev/null || echo "EDEDED")
+              gh label create "$NEXT_LABEL" --repo "$REPOSITORY" --color "$COLOR"
+            fi
+
             NEW_LABELS=$(echo "$ISSUE_DATA" | jq -r --arg next "$NEXT_LABEL" --arg old "$ITERATION_LABEL" \
               '[.labels[].name | select(. != $old)] + [$next] | unique | join(",")')
           else


### PR DESCRIPTION
This PR fixes several failure points in the `Auto Repeat` workflow:
1. **Broken PR Lookup**: The workflow was using an incorrect JQ filter (`.[0].number`) to extract the PR number from the GitHub Actions API response. It now correctly uses `.pull_requests[0].number`.
2. **Incorrect Issue Identification**: When searching for associated issues in the PR body/title, the script could accidentally pick up the PR number itself. I've added a filter to exclude the current `PR_NUMBER`.
3. **Missing Label Failures**: The workflow would fail if the next decremented label (e.g., `Auto-Repeat-4`) didn't already exist in the repository. It now checks for the label's existence and creates it (inheriting the color of the current label) if necessary.
4. **Visibility**: Added debug `echo` statements to log the resolved `PR_NUMBER` and `ISSUE_NUMBER` for easier troubleshooting in the future.

Fixes #81

---
*PR created automatically by Jules for task [4134894827455927128](https://jules.google.com/task/4134894827455927128) started by @chatelao*