### PR TITLE
Implement Error Handling patterns and C-family instances

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,28 +41,28 @@
 
 ## Phase 3: Content Creation
 - [ ] Populate Programming Language patterns <!-- issue #8 -->
-    - [ ] 8.1 Variable declaration <!-- issue #8.1 -->
+    - [x] 8.1 Variable declaration <!-- 2026-05-03, issue #8.1 -->
         - [x] 8.1.1 C-family languages (C, Java, Rust) <!-- 2026-05-02, issue #8.1.1 -->
         - [x] 8.1.2 Functional languages (Erlang, Lisp) <!-- 2026-05-02, issue #8.1.2 -->
         - [x] 8.1.3 Shells and Scripting (Bash, Cmd, PowerShell, SQL, Python) <!-- 2026-05-03, issue #8.1.3 -->
         - [x] 8.1.4 Specialized (XQuery, CSS) <!-- 2026-05-03, issue #8.1.4 -->
-    - [ ] 8.2 Control flow (if/else, loops) <!-- issue #8.2 -->
+    - [x] 8.2 Control flow (if/else, loops) <!-- 2026-05-03, issue #8.2 -->
         - [x] 8.2.1 Define `IfElse` and `Loop` patterns <!-- 2026-05-03, issue #8.2.1 -->
         - [x] 8.2.2 Implement C-family instances (C, Java, Rust) <!-- 2026-05-03, issue #8.2.2 -->
         - [x] 8.2.3 Implement Scripting & Shell instances <!-- 2026-05-03, issue #8.2.3 -->
         - [x] 8.2.4 Implement Functional instances <!-- 2026-05-03, issue #8.2.4 -->
         - [x] 8.2.5 Implement Specialized instances (XQuery, CSS) <!-- 2026-05-03, issue #8.2.5 -->
-    - [ ] 8.3 Function/Procedure definition <!-- issue #8.3 -->
+    - [x] 8.3 Function/Procedure definition <!-- 2026-05-04, issue #8.3 -->
         - [x] 8.3.1 Define `FunctionDefinition` pattern <!-- 2026-05-03, issue #8.3.1 -->
-        - [ ] 8.3.2 Implement instances across language groups <!-- issue #8.3.2 -->
+        - [x] 8.3.2 Implement instances across language groups <!-- 2026-05-04, issue #8.3.2 -->
             - [x] 8.3.2.1 C-family languages (C, Java, Rust) <!-- 2026-05-03, issue #8.3.2.1 -->
             - [x] 8.3.2.2 Scripting & Shell instances <!-- 2026-05-03, issue #8.3.2.2 -->
             - [x] 8.3.2.3 Functional instances <!-- 2026-05-04, issue #8.3.2.3 -->
             - [x] 8.3.2.4 Specialized instances (XQuery) <!-- 2026-05-04, issue #8.3.2.4 -->
     - [ ] 8.4 Error handling <!-- issue #8.4 -->
-        - [ ] 8.4.1 Define `TryCatch` and `Raise` patterns <!-- issue #8.4.1 -->
+        - [x] 8.4.1 Define `TryCatch` and `Raise` patterns <!-- 2026-05-05, issue #8.4.1 -->
         - [ ] 8.4.2 Implement instances across language groups <!-- issue #8.4.2 -->
-            - [ ] 8.4.2.1 C-family languages (C, Java, Rust) <!-- issue #8.4.2.1 -->
+            - [x] 8.4.2.1 C-family languages (C, Java, Rust) <!-- 2026-05-05, issue #8.4.2.1 -->
             - [ ] 8.4.2.2 Scripting & Shell instances <!-- issue #8.4.2.2 -->
             - [ ] 8.4.2.3 Functional instances <!-- issue #8.4.2.3 -->
     - [ ] 8.5 Concurrency models <!-- issue #8.5 -->

--- a/output.rst
+++ b/output.rst
@@ -409,3 +409,101 @@ Parameters:
      - { raw "N/A" }
      - N/A
      - CSS does not support loops natively.
+
+
+Pattern: TryCatch
+
+:description: Handling exceptions or errors within a block of code.
+
+
+Parameters:
+
+* try_body: Block
+
+* exception_type: String
+
+* error_variable: String
+
+* catch_body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: TryCatch Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - try_body
+     - exception_type
+     - error_variable
+     - catch_body
+     - syntax
+     - notes
+   * - CTryCatch
+     - { call do_something() }
+     - N/A
+     - N/A
+     - { raw "/* Error handling in C is typically done via return codes */" }
+     - N/A
+     - C does not have native try-catch blocks; error handling is usually manual.
+   * - JavaTryCatch
+     - { call do_something() }
+     - Exception
+     - e
+     - { call handle(e) }
+     - try { do_something(); } catch (Exception e) { handle(e); }
+     - Standard Java exception handling.
+   * - RustTryCatch
+     - { call do_something() }
+     - Result
+     - e
+     - { call handle(e) }
+     - match do_something() { Ok(v) => v, Err(e) => handle(e) }
+     - Rust uses Result type and pattern matching instead of traditional try-catch.
+
+
+Pattern: Raise
+
+:description: Explicitly triggering an exception or error.
+
+
+Parameters:
+
+* exception_type: String
+
+* message: String
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Raise Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - exception_type
+     - message
+     - syntax
+     - notes
+   * - CRaise
+     - Signal/Exit
+     - Error
+     - exit(1);
+     - C uses exit() or signals for severe errors.
+   * - JavaRaise
+     - RuntimeException
+     - Error
+     - throw new RuntimeException(\"Error\");
+     - Uses 'throw' to raise an exception.
+   * - RustRaise
+     - Panic
+     - Error
+     - panic!(\"Error\");
+     - Uses 'panic!' for unrecoverable errors.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -417,3 +417,69 @@ instance CssFunction of FunctionDefinition {
     syntax = "N/A"
     notes = "CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors)."
 }
+
+pattern TryCatch {
+    meta description: "Handling exceptions or errors within a block of code."
+    parameter try_body: Block
+    parameter exception_type: String
+    parameter error_variable: String
+    parameter catch_body: Block
+    parameter syntax: String
+    parameter notes: String
+}
+
+pattern Raise {
+    meta description: "Explicitly triggering an exception or error."
+    parameter exception_type: String
+    parameter message: String
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance CTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "/* Error handling in C is typically done via return codes */" }
+    syntax = "N/A"
+    notes = "C does not have native try-catch blocks; error handling is usually manual."
+}
+
+instance JavaTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "Exception"
+    error_variable = "e"
+    catch_body = { call handle(e) }
+    syntax = "try { do_something(); } catch (Exception e) { handle(e); }"
+    notes = "Standard Java exception handling."
+}
+
+instance RustTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "Result"
+    error_variable = "e"
+    catch_body = { call handle(e) }
+    syntax = "match do_something() { Ok(v) => v, Err(e) => handle(e) }"
+    notes = "Rust uses Result type and pattern matching instead of traditional try-catch."
+}
+
+instance CRaise of Raise {
+    exception_type = "Signal/Exit"
+    message = "Error"
+    syntax = "exit(1);"
+    notes = "C uses exit() or signals for severe errors."
+}
+
+instance JavaRaise of Raise {
+    exception_type = "RuntimeException"
+    message = "Error"
+    syntax = "throw new RuntimeException(\"Error\");"
+    notes = "Uses 'throw' to raise an exception."
+}
+
+instance RustRaise of Raise {
+    exception_type = "Panic"
+    message = "Error"
+    syntax = "panic!(\"Error\");"
+    notes = "Uses 'panic!' for unrecoverable errors."
+}


### PR DESCRIPTION
I have implemented the next planned step in the roadmap by adding Error Handling patterns (`TryCatch` and `Raise`) to the DSL. 

Additionally, I've provided concrete implementations for the C-family language group (C, Java, Rust) and updated the `ROADMAP.md` to reflect both these new changes and previously completed but unmarked tasks in Phase 3. 

The transpiler output has been updated to include comparison tables for these new patterns.

Fixes #82

---
*PR created automatically by Jules for task [17050380681729090587](https://jules.google.com/task/17050380681729090587) started by @chatelao*