### PR TITLE
Fix Read the Docs build errors and configure Sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .pytest_cache/
 *.py[cod]
 *$py.class
+docs/_build/
+docs/patterns.rst

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_build:
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -o docs/patterns.rst
+
+python:
+  install:
+    - requirements: requirements.txt
+
+sphinx:
+  configuration: docs/conf.py

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,8 +91,8 @@
     - [ ] 9.5 Schema validation <!-- issue #9.5 -->
 
 ## Phase 4: Publication
-- [ ] Configure ReadTheDocs integration <!-- issue #10 -->
-    - [ ] 10.1 Create `docs/conf.py` and `index.rst` <!-- issue #10.1 -->
-    - [ ] 10.2 Setup `.readthedocs.yaml` <!-- issue #10.2 -->
-    - [ ] 10.3 Integrate transpiler output into Sphinx build <!-- issue #10.3 -->
+- [x] Configure ReadTheDocs integration <!-- 2026-05-03, issue #10 -->
+    - [x] 10.1 Create `docs/conf.py` and `index.rst` <!-- 2026-05-03, issue #10.1 -->
+    - [x] 10.2 Setup `.readthedocs.yaml` <!-- 2026-05-03, issue #10.2 -->
+    - [x] 10.3 Integrate transpiler output into Sphinx build <!-- 2026-05-03, issue #10.3 -->
 - [ ] Final review and polish of the comparative book <!-- issue #11 -->

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,25 @@
+# Configuration file for the Sphinx documentation builder.
+
+project = 'Xiao Seeed RP2040 Renode'
+copyright = '2024, chatelao'
+author = 'chatelao'
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    'myst_parser',
+    'sphinx_rtd_theme',
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,17 @@
+Welcome to the Xiao Seeed RP2040 Renode Pattern Documentation
+=============================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   dsl_specification
+   dsl_examples
+   patterns
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ antlr4-tools
 antlr4-python3-runtime==4.13.2
 pytest
 sphinx
+myst-parser
+sphinx-rtd-theme

--- a/src/templates/pattern.rst.j2
+++ b/src/templates/pattern.rst.j2
@@ -1,5 +1,8 @@
 {% if pattern %}
-Pattern: {{ pattern.name }}
+
+{{ pattern.name }}
+{{ "=" * pattern.name|length }}
+
 {% for meta in pattern.metadata %}
 :{{ meta.key }}: {{ meta.value }}
 {% endfor %}

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -14,7 +14,8 @@ def test_render_pattern_only():
     generator = CodeGenerator()
     output = generator.render_program(program)
 
-    assert "Pattern: VarDec" in output
+    assert "VarDec" in output
+    assert "======" in output
     assert "* name: Identifier" in output
     assert "* type: Type" in output
 


### PR DESCRIPTION
Fixed the Read the Docs build errors by adding the missing configuration files and integrating the transpiler into the build process.

Key changes:
- Added `.readthedocs.yaml` to define the build environment and a `pre_build` job that generates `docs/patterns.rst` using the project's transpiler.
- Set up Sphinx in the `docs/` directory with `conf.py` and `index.rst`.
- Enabled Markdown support via `myst-parser` and set the theme to `sphinx-rtd-theme`.
- Updated `.gitignore` to ensure that generated documentation files and build directories are not committed to the repository.
- Refined the Jinja2 template for patterns to use standard reStructuredText section headers, improving the document structure and resolving Sphinx warnings about missing titles in the table of contents.
- Updated unit tests to match the improved template output.

Fixes #85

---
*PR created automatically by Jules for task [1966992954074765352](https://jules.google.com/task/1966992954074765352) started by @chatelao*