### PR TITLE
Implement Scripting & Shell instances for Error Handling patterns

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,7 +63,7 @@
         - [x] 8.4.1 Define `TryCatch` and `Raise` patterns <!-- 2026-05-05, issue #8.4.1 -->
         - [ ] 8.4.2 Implement instances across language groups <!-- issue #8.4.2 -->
             - [x] 8.4.2.1 C-family languages (C, Java, Rust) <!-- 2026-05-05, issue #8.4.2.1 -->
-            - [ ] 8.4.2.2 Scripting & Shell instances <!-- issue #8.4.2.2 -->
+            - [x] 8.4.2.2 Scripting & Shell instances <!-- 2026-05-06, issue #8.4.2.2 -->
             - [ ] 8.4.2.3 Functional instances <!-- issue #8.4.2.3 -->
     - [ ] 8.5 Concurrency models <!-- issue #8.5 -->
         - [ ] 8.5.1 Define `Thread` and `MessagePassing` patterns <!-- issue #8.5.1 -->

--- a/output.rst
+++ b/output.rst
@@ -1,5 +1,8 @@
 
-Pattern: VariableDeclaration
+
+VariableDeclaration
+===================
+
 
 :description: The act of naming a value and optionally specifying its type.
 
@@ -102,7 +105,10 @@ Parameters:
      - CSS custom properties (variables).
 
 
-Pattern: FunctionDefinition
+
+FunctionDefinition
+==================
+
 
 :description: Declaration of a reusable block of code with parameters and a return value.
 
@@ -220,7 +226,10 @@ Parameters:
      - CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors).
 
 
-Pattern: IfElse
+
+IfElse
+======
+
 
 :description: Conditional execution of code blocks.
 
@@ -323,7 +332,10 @@ Parameters:
      - Media queries provide conditional styling; no true else branch exists.
 
 
-Pattern: Loop
+
+Loop
+====
+
 
 :description: Repeated execution of a code block based on a condition.
 
@@ -411,7 +423,10 @@ Parameters:
      - CSS does not support loops natively.
 
 
-Pattern: TryCatch
+
+TryCatch
+========
+
 
 :description: Handling exceptions or errors within a block of code.
 
@@ -464,9 +479,47 @@ Parameters:
      - { call handle(e) }
      - match do_something() { Ok(v) => v, Err(e) => handle(e) }
      - Rust uses Result type and pattern matching instead of traditional try-catch.
+   * - PythonTryCatch
+     - { call do_something() }
+     - Exception
+     - e
+     - { call handle(e) }
+     - try:\n    do_something()\nexcept Exception as e:\n    handle(e)
+     - Standard Python exception handling using try-except.
+   * - BashTryCatch
+     - { call do_something() }
+     - Exit Code
+     - EXIT_STATUS
+     - { call handle_error() }
+     - do_something || handle_error
+     - Shells often use command chaining (||) for basic error handling based on exit codes; $? stores the exit status.
+   * - PowerShellTryCatch
+     - { call do_something() }
+     - ErrorRecord
+     - PSItem
+     - { call handle_error(PSItem) }
+     - try { do_something } catch { handle_error($_) }
+     - PowerShell supports try-catch-finally blocks; $_ (or $PSItem) refers to the current error.
+   * - CmdTryCatch
+     - { call do_something() }
+     - ErrorLevel
+     - %errorlevel%
+     - { call handle_error() }
+     - do_something || call :handle_error
+     - Cmd uses || to execute a command if the previous one failed (non-zero errorlevel).
+   * - SqlTryCatch
+     - { call do_something() }
+     - Error
+     - @@ERROR
+     - { call handle_error() }
+     - BEGIN TRY\n    EXEC do_something;\nEND TRY\nBEGIN CATCH\n    EXEC handle_error;\nEND CATCH
+     - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
 
 
-Pattern: Raise
+
+Raise
+=====
+
 
 :description: Explicitly triggering an exception or error.
 
@@ -507,3 +560,28 @@ Parameters:
      - Error
      - panic!(\"Error\");
      - Uses 'panic!' for unrecoverable errors.
+   * - PythonRaise
+     - Exception
+     - Error
+     - raise Exception(\"Error\")
+     - Uses 'raise' to trigger an exception.
+   * - BashRaise
+     - Exit
+     - Error
+     - exit 1
+     - Terminates the script or subshell with a non-zero exit code.
+   * - PowerShellRaise
+     - Exception
+     - Error
+     - throw \"Error\"
+     - Uses 'throw' to create a terminating error.
+   * - CmdRaise
+     - ErrorLevel
+     - Error
+     - exit /b 1
+     - Sets the errorlevel and exits the current script or function.
+   * - SqlRaise
+     - Error
+     - Error
+     - THROW 50000, 'Error', 1;
+     - The THROW statement raises an exception and transfers execution to a CATCH block.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -483,3 +483,83 @@ instance RustRaise of Raise {
     syntax = "panic!(\"Error\");"
     notes = "Uses 'panic!' for unrecoverable errors."
 }
+
+instance PythonTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "Exception"
+    error_variable = "e"
+    catch_body = { call handle(e) }
+    syntax = "try:\n    do_something()\nexcept Exception as e:\n    handle(e)"
+    notes = "Standard Python exception handling using try-except."
+}
+
+instance PythonRaise of Raise {
+    exception_type = "Exception"
+    message = "Error"
+    syntax = "raise Exception(\"Error\")"
+    notes = "Uses 'raise' to trigger an exception."
+}
+
+instance BashTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "Exit Code"
+    error_variable = "EXIT_STATUS"
+    catch_body = { call handle_error() }
+    syntax = "do_something || handle_error"
+    notes = "Shells often use command chaining (||) for basic error handling based on exit codes; $? stores the exit status."
+}
+
+instance BashRaise of Raise {
+    exception_type = "Exit"
+    message = "Error"
+    syntax = "exit 1"
+    notes = "Terminates the script or subshell with a non-zero exit code."
+}
+
+instance PowerShellTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "ErrorRecord"
+    error_variable = "PSItem"
+    catch_body = { call handle_error(PSItem) }
+    syntax = "try { do_something } catch { handle_error($_) }"
+    notes = "PowerShell supports try-catch-finally blocks; $_ (or $PSItem) refers to the current error."
+}
+
+instance PowerShellRaise of Raise {
+    exception_type = "Exception"
+    message = "Error"
+    syntax = "throw \"Error\""
+    notes = "Uses 'throw' to create a terminating error."
+}
+
+instance CmdTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "ErrorLevel"
+    error_variable = "%errorlevel%"
+    catch_body = { call handle_error() }
+    syntax = "do_something || call :handle_error"
+    notes = "Cmd uses || to execute a command if the previous one failed (non-zero errorlevel)."
+}
+
+instance CmdRaise of Raise {
+    exception_type = "ErrorLevel"
+    message = "Error"
+    syntax = "exit /b 1"
+    notes = "Sets the errorlevel and exits the current script or function."
+}
+
+instance SqlTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "Error"
+    error_variable = "@@ERROR"
+    catch_body = { call handle_error() }
+    syntax = "BEGIN TRY\n    EXEC do_something;\nEND TRY\nBEGIN CATCH\n    EXEC handle_error;\nEND CATCH"
+    notes = "T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks."
+}
+
+instance SqlRaise of Raise {
+    exception_type = "Error"
+    message = "Error"
+    syntax = "THROW 50000, 'Error', 1;"
+    notes = "The THROW statement raises an exception and transfers execution to a CATCH block."
+}

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -71,7 +71,7 @@ class SourcePatternsTransformer(SourcePatternsVisitor):
     def visitMetaDefinition(self, ctx: SourcePatternsParser.MetaDefinitionContext):
         key = ctx.IDENTIFIER(0).getText()
         if ctx.STRING():
-            value = ctx.STRING().getText().strip('"')
+            value = ctx.STRING().getText()[1:-1]
         else:
             value = ctx.IDENTIFIER(1).getText()
         return Metadata(key=key, value=value)
@@ -96,7 +96,7 @@ class SourcePatternsTransformer(SourcePatternsVisitor):
 
     def visitValue(self, ctx: SourcePatternsParser.ValueContext):
         if ctx.STRING():
-            return ctx.STRING().getText().strip('"')
+            return ctx.STRING().getText()[1:-1]
         if ctx.NUMBER():
             val = ctx.NUMBER().getText()
             return float(val) if '.' in val else int(val)
@@ -136,5 +136,5 @@ class SourcePatternsTransformer(SourcePatternsVisitor):
         return ReturnInstruction(value=value)
 
     def visitRawInstruction(self, ctx: SourcePatternsParser.RawInstructionContext):
-        snippet = ctx.STRING().getText().strip('"')
+        snippet = ctx.STRING().getText()[1:-1]
         return RawInstruction(snippet=snippet)


### PR DESCRIPTION
This PR implements the Scripting & Shell language instances (Python, Bash, PowerShell, Cmd, SQL) for the TryCatch and Raise patterns in programming.patterns. It also fixes a bug in the transformer where string literals were incorrectly unquoted using .strip('"'), and updates the ROADMAP.md to reflect the completion of task 8.4.2.2.

Fixes #86

---
*PR created automatically by Jules for task [11519345599851039271](https://jules.google.com/task/11519345599851039271) started by @chatelao*