### PR TITLE
Integrate google-labs-code/jules-invoke for auto-repeat logic

### DIFF
--- a/.github/workflows/auto_repeat.yml
+++ b/.github/workflows/auto_repeat.yml
@@ -19,27 +19,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Process Auto-Repeat
+      - name: Extract PR and Issue Information
+        id: info
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -ex
-
-          # 1. Get the PR associated with the workflow run
-          echo "Fetching PR information..."
           PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
-
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "PR number not found in event context, attempting API lookup..."
             PR_NUMBER=$(gh api "/repos/$REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}/pull_requests" --jq '.pull_requests[0].number // empty')
           fi
-
-          echo "PR_NUMBER: $PR_NUMBER"
-
-          # Fallback: search by head SHA if direct link is missing
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "Direct PR link not found, falling back to head SHA lookup..."
             HEAD_SHA=$(gh api "/repos/$REPOSITORY/actions/runs/${{ github.event.workflow_run.id }}" --jq '.head_sha // empty')
             if [ -n "$HEAD_SHA" ]; then
               PR_NUMBER=$(gh api "/repos/$REPOSITORY/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty')
@@ -47,99 +38,34 @@ jobs:
           fi
 
           if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "No PR associated with this workflow run."
+            echo "PR not found."
             exit 0
           fi
 
-          # Refresh state to ensure accuracy
-          PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json state --template '{{.state}}')
-          echo "Processing PR #$PR_NUMBER (State: $PR_STATE)"
-
-          if [ "$PR_STATE" != "OPEN" ]; then
-            echo "PR #$PR_NUMBER is not open. Skipping merge."
-            exit 0
-          fi
-
-          # 2. Detect associated issue
-          echo "Detecting associated issue..."
           ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json closingIssuesReferences --template '{{range .closingIssuesReferences}}{{.number}}{{"\n"}}{{end}}' | head -n 1)
           if [ -z "$ISSUE_NUMBER" ]; then
-            echo "No closing reference found, searching PR body and title..."
             ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json body,title --template '{{.body}} {{.title}}' | grep -oE '#[0-9]+' | tr -d '#' | grep -v "^$PR_NUMBER$" | head -n 1 || true)
           fi
 
-          echo "ISSUE_NUMBER: $ISSUE_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
 
-          # 3. Check for iteration labels (Auto-Repeat or Auto-Repeat-X)
-          # We check both the PR and the associated Issue
-          PR_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels --template '{{range .labels}}{{.name}}{{"\n"}}{{end}}' 2>/dev/null || true)
-          ISSUE_LABELS=""
-          if [ -n "$ISSUE_NUMBER" ]; then
-            ISSUE_LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --json labels --template '{{range .labels}}{{.name}}{{"\n"}}{{end}}' 2>/dev/null || true)
-          fi
+      - name: Invoke Jules for Auto-Repeat
+        if: steps.info.outputs.pr_number != ''
+        uses: google-labs-code/jules-invoke@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            The CI workflow has completed successfully for PR #${{ steps.info.outputs.pr_number }}.
 
-          ALL_LABELS=$(printf "%s\n%s" "$PR_LABELS" "$ISSUE_LABELS" | grep . | sort -u || true)
-          ITERATION_LABEL=$(echo "$ALL_LABELS" | grep -E "^Auto-Repeat(-[0-9]+)?$" | head -n 1 || true)
+            Task: Handle the 'Auto-Repeat' logic for PR #${{ steps.info.outputs.pr_number }} and its associated Issue #${{ steps.info.outputs.issue_number }}.
 
-          if [ -z "$ITERATION_LABEL" ]; then
-            echo "No Auto-Repeat or Auto-Repeat-X label found on PR #$PR_NUMBER or Issue #$ISSUE_NUMBER. Skipping."
-            exit 0
-          fi
-
-          echo "Iteration label found: $ITERATION_LABEL"
-
-          # 4. Merge the PR
-          echo "Merging PR #$PR_NUMBER..."
-          # Use --auto to handle mergeability waiting, but fallback to immediate merge
-          gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --merge --auto || gh pr merge "$PR_NUMBER" --repo "$REPOSITORY" --merge
-
-          # 5. Handle Iteration (Issue Duplication)
-          if [ -z "$ISSUE_NUMBER" ]; then
-            echo "Error: No associated issue found for PR #$PR_NUMBER. Iteration cannot continue."
-            exit 1
-          fi
-
-          echo "Duplicating issue #$ISSUE_NUMBER for the next iteration..."
-          ISSUE_DATA=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --json title,body,labels)
-          TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
-          BODY_FILE=$(mktemp)
-          echo "$ISSUE_DATA" | jq -r '.body' > "$BODY_FILE"
-
-          # Calculate the next iteration label (decrement counter if Auto-Repeat-X)
-          NEXT_LABEL="$ITERATION_LABEL"
-          if [[ "$ITERATION_LABEL" =~ ^Auto-Repeat-([0-9]+)$ ]]; then
-            COUNT="${BASH_REMATCH[1]}"
-            NEXT_COUNT=$((COUNT - 1))
-            if [ $NEXT_COUNT -le 0 ]; then
-              echo "Counter reached 0. Stopping iteration."
-              NEXT_LABEL=""
-            else
-              NEXT_LABEL="Auto-Repeat-$NEXT_COUNT"
-              echo "Decrementing counter: $ITERATION_LABEL -> $NEXT_LABEL"
-            fi
-          fi
-
-          # Prepare labels for the new issue
-          if [ -n "$NEXT_LABEL" ]; then
-            # Ensure NEXT_LABEL exists
-            if ! gh label list --repo "$REPOSITORY" --json name --jq '.[].name' | grep -q "^$NEXT_LABEL$"; then
-              echo "Label $NEXT_LABEL does not exist. Creating it..."
-              COLOR=$(gh label view "$ITERATION_LABEL" --repo "$REPOSITORY" --json color --jq '.color' 2>/dev/null || echo "EDEDED")
-              gh label create "$NEXT_LABEL" --repo "$REPOSITORY" --color "$COLOR"
-            fi
-
-            NEW_LABELS=$(echo "$ISSUE_DATA" | jq -r --arg next "$NEXT_LABEL" --arg old "$ITERATION_LABEL" \
-              '[.labels[].name | select(. != $old)] + [$next] | unique | join(",")')
-          else
-            NEW_LABELS=$(echo "$ISSUE_DATA" | jq -r --arg old "$ITERATION_LABEL" \
-              '[.labels[].name | select(. != $old)] | unique | join(",")')
-          fi
-
-          echo "Creating new issue..."
-          if [ -n "$NEW_LABELS" ]; then
-            echo "Applying labels: $NEW_LABELS"
-            gh issue create --repo "$REPOSITORY" --title "$TITLE" --body-file "$BODY_FILE" --label "$NEW_LABELS"
-          else
-            echo "No labels to apply."
-            gh issue create --repo "$REPOSITORY" --title "$TITLE" --body-file "$BODY_FILE"
-          fi
+            Instructions:
+            1. Check for 'Auto-Repeat' or 'Auto-Repeat-X' labels on either the PR or the Issue.
+            2. If an iteration label is found:
+               a. Merge PR #${{ steps.info.outputs.pr_number }}.
+               b. Duplicate Issue #${{ steps.info.outputs.issue_number }}.
+               c. If the label was 'Auto-Repeat-X' (e.g., 'Auto-Repeat-5'), decrement the counter in the new issue's label (e.g., to 'Auto-Repeat-4'). If it reaches 0, stop repeating.
+               d. Ensure any new labels (like decremented counters) are created in the repository if they don't exist, using the same color as the original label.
+            3. Maintain all other labels from the original issue on the new one.


### PR DESCRIPTION
Replaced the complex bash script in `.github/workflows/auto_repeat.yml` with the `google-labs-code/jules-invoke@v1` action. The workflow now extracts the PR and Issue context using `gh` CLI and passes it to Jules with explicit instructions to handle merging and iteration (issue duplication) based on 'Auto-Repeat' and 'Auto-Repeat-X' labels, while maintaining all existing labels. This change aims to improve the reliability of the auto-repeat trigger.

Fixes #90

---
*PR created automatically by Jules for task [1495748125683550375](https://jules.google.com/task/1495748125683550375) started by @chatelao*