### PR TITLE
Implement BasicTypes for Data Formats and restructure documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 docs/_build/
-docs/patterns.rst
+docs/programming.rst
+docs/data_formats.rst

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,8 @@ build:
     python: "3.11"
   jobs:
     pre_build:
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -o docs/patterns.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -o docs/programming.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -o docs/data_formats.rst
 
 python:
   install:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@
     - [x] 7.4 Implement CLI entry point (`src/main.py`) <!-- 2026-05-02, issue #7.4 -->
 
 ## Phase 3: Content Creation
-- [ ] Populate Programming Language patterns <!-- issue #8 -->
+- [x] Populate Programming Language patterns <!-- 2026-05-08, issue #8 -->
     - [x] 8.1 Variable declaration <!-- 2026-05-03, issue #8.1 -->
         - [x] 8.1.1 C-family languages (C, Java, Rust) <!-- 2026-05-02, issue #8.1.1 -->
         - [x] 8.1.2 Functional languages (Erlang, Lisp) <!-- 2026-05-02, issue #8.1.2 -->
@@ -73,13 +73,13 @@
             - [x] 8.5.2.2 Erlang instances <!-- 2026-05-08, issue #8.5.2.2 -->
             - [x] 8.5.2.3 Java instances <!-- 2026-05-08, issue #8.5.2.3 -->
 - [ ] Populate Data Format patterns <!-- issue #9 -->
-    - [ ] 9.1 Basic data types (Strings, Numbers, Booleans) <!-- issue #9.1 -->
-        - [ ] 9.1.1 Define `BasicTypes` pattern <!-- issue #9.1.1 -->
-        - [ ] 9.1.2 Implement instances (JSON, XML, YAML, TOML) <!-- issue #9.1.2 -->
-            - [ ] 9.1.2.1 JSON <!-- issue #9.1.2.1 -->
-            - [ ] 9.1.2.2 XML <!-- issue #9.1.2.2 -->
-            - [ ] 9.1.2.3 YAML <!-- issue #9.1.2.3 -->
-            - [ ] 9.1.2.4 TOML <!-- issue #9.1.2.4 -->
+    - [x] 9.1 Basic data types (Strings, Numbers, Booleans) <!-- 2026-05-08, issue #9.1 -->
+        - [x] 9.1.1 Define `BasicTypes` pattern <!-- 2026-05-08, issue #9.1.1 -->
+        - [x] 9.1.2 Implement instances (JSON, XML, YAML, TOML) <!-- 2026-05-08, issue #9.1.2 -->
+            - [x] 9.1.2.1 JSON <!-- 2026-05-08, issue #9.1.2.1 -->
+            - [x] 9.1.2.2 XML <!-- 2026-05-08, issue #9.1.2.2 -->
+            - [x] 9.1.2.3 YAML <!-- 2026-05-08, issue #9.1.2.3 -->
+            - [x] 9.1.2.4 TOML <!-- 2026-05-08, issue #9.1.2.4 -->
     - [ ] 9.2 Nested structures (Objects/Maps, Arrays/Lists) <!-- issue #9.2 -->
         - [ ] 9.2.1 Define `Collection` and `Mapping` patterns <!-- issue #9.2.1 -->
         - [ ] 9.2.2 Implement instances across formats <!-- issue #9.2.2 -->

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -1,0 +1,50 @@
+
+
+BasicTypes
+==========
+
+
+:description: Representation of fundamental data types: Strings, Numbers, and Booleans.
+
+
+Parameters:
+
+* string_val: String
+
+* number_val: String
+
+* boolean_val: String
+
+* notes: String
+
+
+
+.. list-table:: BasicTypes Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - string_val
+     - number_val
+     - boolean_val
+     - notes
+   * - JsonBasic
+     - \"Hello\"
+     - 42 or 3.14
+     - true / false
+     - Standard JSON types; strings must be double-quoted.
+   * - XmlBasic
+     - <tag>Hello</tag>
+     - <tag>42</tag>
+     - <tag>true</tag>
+     - XML is text-based; types are typically inferred or defined by a schema (XSD).
+   * - YamlBasic
+     - Hello or 'Hello' or \"Hello\"
+     - 42 or 3.14
+     - true / false (or yes/no, on/off in YAML 1.1)
+     - YAML supports plain, single-quoted, and double-quoted strings.
+   * - TomlBasic
+     - \"Hello\"
+     - 42 or 3.14
+     - true / false
+     - TOML is strictly typed; strings must be double-quoted.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,8 @@ Welcome to the Xiao Seeed RP2040 Renode Pattern Documentation
 
    dsl_specification
    dsl_examples
-   patterns
+   programming
+   data_formats
 
 Indices and tables
 ==================

--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -1,0 +1,767 @@
+
+
+VariableDeclaration
+===================
+
+
+:description: The act of naming a value and optionally specifying its type.
+
+
+Parameters:
+
+* name: String
+
+* type: String
+
+* initial_value: Number
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: VariableDeclaration Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - name
+     - type
+     - initial_value
+     - syntax
+     - notes
+   * - CVar
+     - x
+     - int
+     - 42
+     - int x = 42;
+     - Static typing, terminated by semicolon.
+   * - JavaVar
+     - x
+     - int
+     - 42
+     - int x = 42;
+     - Strongly typed, similar to C.
+   * - RustVar
+     - x
+     - i32
+     - 42
+     - let x: i32 = 42;
+     - Immutable by default; supports type inference.
+   * - PythonVar
+     - x
+     - None
+     - 42
+     - x = 42
+     - Dynamically typed, no explicit type declaration needed.
+   * - ErlangVar
+     - X
+     - Dynamic
+     - 42
+     - X = 42.
+     - Single assignment; must start with an uppercase letter.
+   * - LispVar
+     - x
+     - Dynamic
+     - 42
+     - (defparameter x 42)
+     - Dynamic typing; defined using defparameter or defvar.
+   * - BashVar
+     - x
+     - Untyped
+     - 42
+     - x=42
+     - No spaces around the assignment operator.
+   * - CmdVar
+     - x
+     - Untyped
+     - 42
+     - set x=42
+     - Used in Windows Command Prompt.
+   * - PowerShellVar
+     - x
+     - Dynamic
+     - 42
+     - $x = 42
+     - Variables start with a dollar sign.
+   * - SqlVar
+     - x
+     - INT
+     - 42
+     - DECLARE @x INT = 42;
+     - T-SQL syntax for variable declaration.
+   * - XQueryVar
+     - x
+     - xs:integer
+     - 42
+     - let $x := 42
+     - XQuery uses 'let' for variable binding.
+   * - CssVar
+     - x
+     - Number
+     - 42
+     - --x: 42;
+     - CSS custom properties (variables).
+
+
+
+FunctionDefinition
+==================
+
+
+:description: Declaration of a reusable block of code with parameters and a return value.
+
+
+Parameters:
+
+* name: String
+
+* parameters: List<String>
+
+* return_type: String
+
+* body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: FunctionDefinition Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - name
+     - parameters
+     - return_type
+     - body
+     - syntax
+     - notes
+   * - CFunction
+     - add
+     - [int a, int b]
+     - int
+     - { raw "return a + b;" }
+     - int add(int a, int b) { return a + b; }
+     - Standard C function with static types and curly braces.
+   * - JavaFunction
+     - add
+     - [int a, int b]
+     - int
+     - { raw "return a + b;" }
+     - public int add(int a, int b) { return a + b; }
+     - Similar to C, but typically within a class with an access modifier.
+   * - RustFunction
+     - add
+     - [a: i32, b: i32]
+     - i32
+     - { raw "a + b" }
+     - fn add(a: i32, b: i32) -> i32 { a + b }
+     - Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly.
+   * - PythonFunction
+     - add
+     - [a, b]
+     - Dynamic
+     - { raw "return a + b" }
+     - def add(a, b): return a + b
+     - Uses 'def' keyword; indentation defines the block.
+   * - BashFunction
+     - add
+     - [$1, $2]
+     - Exit Code / Stdout
+     - { raw "echo $(($1 + $2))" }
+     - add() { echo $(($1 + $2)); }
+     - Parameters are accessed via $1, $2, etc.; return values are typically exit codes or printed to stdout.
+   * - PowerShellFunction
+     - add
+     - [$a, $b]
+     - Dynamic
+     - { raw "return $a + $b" }
+     - function add($a, $b) { return $a + $b }
+     - Uses 'function' keyword; parameters are variables starting with $.
+   * - CmdFunction
+     - add
+     - [%1, %2]
+     - ErrorLevel
+     - { raw "set /a res=%1+%2\nexit /b %res%" }
+     - :add\nset /a res=%~1+%~2\nexit /b %res%
+     - Functions are labels; called with 'call :label'; arguments are %1, %2.
+   * - SqlFunction
+     - add
+     - [@a INT, @b INT]
+     - INT
+     - { raw "RETURN @a + @b" }
+     - CREATE FUNCTION add(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b END
+     - T-SQL syntax for Scalar-Valued Functions.
+   * - ErlangFunction
+     - add
+     - [A, B]
+     - Dynamic
+     - { raw "A + B" }
+     - add(A, B) -> A + B.
+     - Erlang functions use pattern matching on arguments; the last expression's value is returned.
+   * - LispFunction
+     - add
+     - [a, b]
+     - Dynamic
+     - { raw "(+ a b)" }
+     - (defun add (a b) (+ a b))
+     - Functions are defined with 'defun'; Lisp follows prefix notation.
+   * - XQueryFunction
+     - local:add
+     - [$a as xs:integer, $b as xs:integer]
+     - xs:integer
+     - { raw "$a + $b" }
+     - declare function local:add($a as xs:integer, $b as xs:integer) as xs:integer { $a + $b };
+     - Functions must be declared in a namespace (e.g., 'local').
+   * - CssFunction
+     - N/A
+     - [N/A]
+     - N/A
+     - { raw "N/A" }
+     - N/A
+     - CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors).
+
+
+
+IfElse
+======
+
+
+:description: Conditional execution of code blocks.
+
+
+Parameters:
+
+* condition: String
+
+* then_branch: Block
+
+* else_branch: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: IfElse Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - condition
+     - then_branch
+     - else_branch
+     - syntax
+     - notes
+   * - CIfElse
+     - x > 0
+     - { return 1 }
+     - { return 0 }
+     - if (x > 0) { return 1; } else { return 0; }
+     - Standard C if-else statement.
+   * - JavaIfElse
+     - x > 0
+     - { return 1 }
+     - { return 0 }
+     - if (x > 0) { return 1; } else { return 0; }
+     - Identical to C.
+   * - RustIfElse
+     - x > 0
+     - { return 1 }
+     - { return 0 }
+     - if x > 0 { 1 } else { 0 }
+     - Rust if-else is an expression; parentheses around condition are not required.
+   * - PythonIfElse
+     - x > 0
+     - { return 1 }
+     - { return 0 }
+     - 1 if x > 0 else 0
+     - Uses ternary expression; multi-line if-else uses colons and indentation.
+   * - BashIfElse
+     - x -gt 0
+     - { return 1 }
+     - { return 0 }
+     - if [ $x -gt 0 ]; then exit 1; else exit 0; fi
+     - Uses if-then-else-fi structure; brackets are for test command.
+   * - PowerShellIfElse
+     - $x -gt 0
+     - { return 1 }
+     - { return 0 }
+     - if ($x -gt 0) { return 1 } else { return 0 }
+     - Uses PowerShell comparison operators (e.g., -gt).
+   * - CmdIfElse
+     - x GTR 0
+     - { return 1 }
+     - { return 0 }
+     - if %x% GTR 0 (exit /b 1) else (exit /b 0)
+     - Uses GTR for 'greater than'; blocks are enclosed in parentheses.
+   * - SqlIfElse
+     - @x > 0
+     - { return 1 }
+     - { return 0 }
+     - IF @x > 0 BEGIN RETURN 1 END ELSE BEGIN RETURN 0 END
+     - Uses IF-ELSE with BEGIN-END blocks.
+   * - ErlangIfElse
+     - X > 0
+     - { return 1 }
+     - { return 0 }
+     - if X > 0 -> 1; true -> 0 end
+     - Erlang 'if' uses guards; 'true' acts as an 'else' branch.
+   * - LispIfElse
+     - (> x 0)
+     - { return 1 }
+     - { return 0 }
+     - (if (> x 0) 1 0)
+     - The 'if' expression evaluates the condition and returns the corresponding branch result.
+   * - XQueryIfElse
+     - $x > 0
+     - { return 1 }
+     - { return 0 }
+     - if ($x > 0) then 1 else 0
+     - Functional if-then-else expression; both branches are required.
+   * - CssIfElse
+     - min-width: 0px
+     - { raw "color: red;" }
+     - { raw "color: blue;" }
+     - @media (min-width: 0px) { .element { color: red; } }
+     - Media queries provide conditional styling; no true else branch exists.
+
+
+
+Loop
+====
+
+
+:description: Repeated execution of a code block based on a condition.
+
+
+Parameters:
+
+* condition: String
+
+* body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Loop Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - condition
+     - body
+     - syntax
+     - notes
+   * - CLoop
+     - x > 0
+     - { raw "x = x - 1;" }
+     - while (x > 0) { x = x - 1; }
+     - Standard C while loop.
+   * - JavaLoop
+     - x > 0
+     - { raw "x = x - 1;" }
+     - while (x > 0) { x = x - 1; }
+     - Identical to C.
+   * - RustLoop
+     - x > 0
+     - { raw "x -= 1;" }
+     - while x > 0 { x -= 1; }
+     - Condition does not require parentheses.
+   * - PythonLoop
+     - x > 0
+     - { raw "x = x - 1" }
+     - while x > 0: x = x - 1
+     - Uses colon and indentation for the body; parentheses around condition are not required.
+   * - BashLoop
+     - x -gt 0
+     - { raw "x=$((x-1))" }
+     - while [ $x -gt 0 ]; do x=$((x-1)); done
+     - Uses while-do-done structure.
+   * - PowerShellLoop
+     - $x -gt 0
+     - { raw "$x = $x - 1" }
+     - while ($x -gt 0) { $x = $x - 1 }
+     - Standard while loop with C-like block syntax.
+   * - CmdLoop
+     - x GTR 0
+     - { raw "set /a x=x-1" }
+     - :loop\nif %x% GTR 0 (set /a x=x-1 & goto loop)
+     - Loops are typically implemented using labels and goto.
+   * - SqlLoop
+     - @x > 0
+     - { raw "SET @x = @x - 1" }
+     - WHILE @x > 0 BEGIN SET @x = @x - 1 END
+     - Standard WHILE loop in T-SQL.
+   * - ErlangLoop
+     - X > 0
+     - { raw "loop(X - 1)" }
+     - loop(0) -> ok; loop(X) when X > 0 -> loop(X - 1).
+     - Erlang uses recursion for looping; there are no built-in while/for loops.
+   * - LispLoop
+     - (> x 0)
+     - { raw "(setq x (1- x))" }
+     - (loop while (> x 0) do (setq x (1- x)))
+     - Common Lisp 'loop' macro provides a versatile way to iterate.
+   * - XQueryLoop
+     - $i in 1 to $x
+     - { raw "$i" }
+     - for $i in 1 to $x return $i
+     - XQuery uses 'for' expressions for iteration over sequences.
+   * - CssLoop
+     - N/A
+     - { raw "N/A" }
+     - N/A
+     - CSS does not support loops natively.
+
+
+
+TryCatch
+========
+
+
+:description: Handling exceptions or errors within a block of code.
+
+
+Parameters:
+
+* try_body: Block
+
+* exception_type: String
+
+* error_variable: String
+
+* catch_body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: TryCatch Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - try_body
+     - exception_type
+     - error_variable
+     - catch_body
+     - syntax
+     - notes
+   * - CTryCatch
+     - { call do_something() }
+     - N/A
+     - N/A
+     - { raw "/* Error handling in C is typically done via return codes */" }
+     - N/A
+     - C does not have native try-catch blocks; error handling is usually manual.
+   * - JavaTryCatch
+     - { call do_something() }
+     - Exception
+     - e
+     - { call handle(e) }
+     - try { do_something(); } catch (Exception e) { handle(e); }
+     - Standard Java exception handling.
+   * - RustTryCatch
+     - { call do_something() }
+     - Result
+     - e
+     - { call handle(e) }
+     - match do_something() { Ok(v) => v, Err(e) => handle(e) }
+     - Rust uses Result type and pattern matching instead of traditional try-catch.
+   * - PythonTryCatch
+     - { call do_something() }
+     - Exception
+     - e
+     - { call handle(e) }
+     - try:\n    do_something()\nexcept Exception as e:\n    handle(e)
+     - Standard Python exception handling using try-except.
+   * - BashTryCatch
+     - { call do_something() }
+     - Exit Code
+     - EXIT_STATUS
+     - { call handle_error() }
+     - do_something || handle_error
+     - Shells often use command chaining (||) for basic error handling based on exit codes; $? stores the exit status.
+   * - PowerShellTryCatch
+     - { call do_something() }
+     - ErrorRecord
+     - PSItem
+     - { call handle_error(PSItem) }
+     - try { do_something } catch { handle_error($_) }
+     - PowerShell supports try-catch-finally blocks; $_ (or $PSItem) refers to the current error.
+   * - CmdTryCatch
+     - { call do_something() }
+     - ErrorLevel
+     - %errorlevel%
+     - { call handle_error() }
+     - do_something || call :handle_error
+     - Cmd uses || to execute a command if the previous one failed (non-zero errorlevel).
+   * - SqlTryCatch
+     - { call do_something() }
+     - Error
+     - @@ERROR
+     - { call handle_error() }
+     - BEGIN TRY\n    EXEC do_something;\nEND TRY\nBEGIN CATCH\n    EXEC handle_error;\nEND CATCH
+     - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
+   * - ErlangTryCatch
+     - { call do_something() }
+     - error
+     - Reason
+     - { call handle(Reason) }
+     - try do_something() catch error:Reason -> handle(Reason) end
+     - Erlang uses try...catch blocks; the type can be throw, error, or exit (defaulting to throw if omitted).
+   * - LispTryCatch
+     - { call do_something() }
+     - error
+     - c
+     - { call handle(c) }
+     - (handler-case (do_something) (error (c) (handle c)))
+     - Common Lisp uses handler-case for high-level error handling.
+   * - XQueryTryCatch
+     - { call do_something() }
+     - *
+     - err
+     - { raw "handle($err)" }
+     - try { do_something() } catch * { handle($err) }
+     - XQuery 3.0+ supports try-catch; $err is a variable containing error information.
+   * - CssTryCatch
+     - { raw "/* N/A */" }
+     - N/A
+     - N/A
+     - { raw "/* N/A */" }
+     - N/A
+     - CSS does not have native error handling mechanisms like try-catch.
+
+
+
+Raise
+=====
+
+
+:description: Explicitly triggering an exception or error.
+
+
+Parameters:
+
+* exception_type: String
+
+* message: String
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Raise Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - exception_type
+     - message
+     - syntax
+     - notes
+   * - CRaise
+     - Signal/Exit
+     - Error
+     - exit(1);
+     - C uses exit() or signals for severe errors.
+   * - JavaRaise
+     - RuntimeException
+     - Error
+     - throw new RuntimeException(\"Error\");
+     - Uses 'throw' to raise an exception.
+   * - RustRaise
+     - Panic
+     - Error
+     - panic!(\"Error\");
+     - Uses 'panic!' for unrecoverable errors.
+   * - PythonRaise
+     - Exception
+     - Error
+     - raise Exception(\"Error\")
+     - Uses 'raise' to trigger an exception.
+   * - BashRaise
+     - Exit
+     - Error
+     - exit 1
+     - Terminates the script or subshell with a non-zero exit code.
+   * - PowerShellRaise
+     - Exception
+     - Error
+     - throw \"Error\"
+     - Uses 'throw' to create a terminating error.
+   * - CmdRaise
+     - ErrorLevel
+     - Error
+     - exit /b 1
+     - Sets the errorlevel and exits the current script or function.
+   * - SqlRaise
+     - Error
+     - Error
+     - THROW 50000, 'Error', 1;
+     - The THROW statement raises an exception and transfers execution to a CATCH block.
+   * - ErlangRaise
+     - error
+     - Error
+     - error(\"Error\")
+     - The error/1 BIF is used to stop execution and provide a stack trace.
+   * - LispRaise
+     - error
+     - Error
+     - (error \"Error\")
+     - Signals a continuous error that must be handled or it enters the debugger.
+   * - XQueryRaise
+     - error
+     - Error
+     - fn:error(fn:QName('http://example.com/errors', 'MY_ERROR'), 'Error')
+     - The fn:error() function signals a dynamic error.
+   * - CssRaise
+     - N/A
+     - N/A
+     - N/A
+     - CSS does not have a mechanism to raise exceptions.
+
+
+
+Thread
+======
+
+
+:description: Creating and running a new thread of execution.
+
+
+Parameters:
+
+* body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Thread Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - body
+     - syntax
+     - notes
+   * - ErlangThread
+     - { call do_work() }
+     - Pid = spawn(fun() -> do_work() end).
+     - Creates a new process (lightweight thread) and returns its PID.
+   * - RustThread
+     - { call do_work() }
+     - thread::spawn(|| { do_work(); });
+     - Spawns a native OS thread. Closures are used for the thread body.
+   * - JavaThread
+     - { call do_work() }
+     - new Thread(() -> { do_work(); }).start();
+     - Spawns a new platform thread; virtual threads are available in newer versions.
+
+
+
+SendMessage
+===========
+
+
+:description: Sending a message to another process or thread.
+
+
+Parameters:
+
+* recipient: String
+
+* message: String
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: SendMessage Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - recipient
+     - message
+     - syntax
+     - notes
+   * - ErlangSendMessage
+     - Pid
+     - hello
+     - Pid ! hello.
+     - Asynchronous message passing using the ! operator.
+   * - RustSendMessage
+     - tx
+     - 42
+     - tx.send(42).unwrap();
+     - Using a channel sender. Result must be handled.
+   * - JavaSendMessage
+     - queue
+     - 42
+     - queue.put(42);
+     - Commonly implemented using BlockingQueue; put() may block if the queue is full.
+
+
+
+ReceiveMessage
+==============
+
+
+:description: Receiving a message from another process or thread.
+
+
+Parameters:
+
+* match_pattern: String
+
+* body: Block
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ReceiveMessage Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - match_pattern
+     - body
+     - syntax
+     - notes
+   * - ErlangReceiveMessage
+     - hello
+     - { call handle_hello() }
+     - receive hello -> handle_hello() end.
+     - Selective receive; blocks until a matching message is in the mailbox.
+   * - RustReceiveMessage
+     - msg
+     - { call handle(msg) }
+     - let msg = rx.recv().unwrap(); handle(msg);
+     - Using a channel receiver; blocks until a message is available.
+   * - JavaReceiveMessage
+     - msg
+     - { call handle(msg) }
+     - int msg = queue.take(); handle(msg);
+     - Using BlockingQueue.take(); blocks until an element becomes available.

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -1,0 +1,35 @@
+pattern BasicTypes {
+    meta description: "Representation of fundamental data types: Strings, Numbers, and Booleans."
+    parameter string_val: String
+    parameter number_val: String
+    parameter boolean_val: String
+    parameter notes: String
+}
+
+instance JsonBasic of BasicTypes {
+    string_val = "\"Hello\""
+    number_val = "42 or 3.14"
+    boolean_val = "true / false"
+    notes = "Standard JSON types; strings must be double-quoted."
+}
+
+instance XmlBasic of BasicTypes {
+    string_val = "<tag>Hello</tag>"
+    number_val = "<tag>42</tag>"
+    boolean_val = "<tag>true</tag>"
+    notes = "XML is text-based; types are typically inferred or defined by a schema (XSD)."
+}
+
+instance YamlBasic of BasicTypes {
+    string_val = "Hello or 'Hello' or \"Hello\""
+    number_val = "42 or 3.14"
+    boolean_val = "true / false (or yes/no, on/off in YAML 1.1)"
+    notes = "YAML supports plain, single-quoted, and double-quoted strings."
+}
+
+instance TomlBasic of BasicTypes {
+    string_val = "\"Hello\""
+    number_val = "42 or 3.14"
+    boolean_val = "true / false"
+    notes = "TOML is strictly typed; strings must be double-quoted."
+}


### PR DESCRIPTION
This PR implements the "Basic data types" pattern for Data Formats as specified in the roadmap (Task 9.1). It also restructures the documentation build process to separate Programming Language patterns from Data Format patterns, allowing for better scalability as content grows.

Key changes:
- Marked Task 8 (Programming Language patterns) and Task 9.1 (Basic data types) as completed in `ROADMAP.md`.
- Added `patterns/data_formats.patterns` containing the `BasicTypes` pattern definition and instances for JSON, XML, YAML, and TOML.
- Updated `docs/index.rst` to link to the new `programming` and `data_formats` documentation pages.
- Configured `.readthedocs.yaml` to run the transpiler for both DSL files during the pre-build phase.
- Updated `.gitignore` to ensure generated documentation artifacts are not tracked.

Fixes #95

---
*PR created automatically by Jules for task [14090329119533957753](https://jules.google.com/task/14090329119533957753) started by @chatelao*