### PR TITLE
Implement Nested Data Structure Patterns

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,13 +80,13 @@
             - [x] 9.1.2.2 XML <!-- 2026-05-08, issue #9.1.2.2 -->
             - [x] 9.1.2.3 YAML <!-- 2026-05-08, issue #9.1.2.3 -->
             - [x] 9.1.2.4 TOML <!-- 2026-05-08, issue #9.1.2.4 -->
-    - [ ] 9.2 Nested structures (Objects/Maps, Arrays/Lists) <!-- issue #9.2 -->
-        - [ ] 9.2.1 Define `Collection` and `Mapping` patterns <!-- issue #9.2.1 -->
-        - [ ] 9.2.2 Implement instances across formats <!-- issue #9.2.2 -->
-            - [ ] 9.2.2.1 JSON <!-- issue #9.2.2.1 -->
-            - [ ] 9.2.2.2 XML <!-- issue #9.2.2.2 -->
-            - [ ] 9.2.2.3 YAML <!-- issue #9.2.2.3 -->
-            - [ ] 9.2.2.4 TOML <!-- issue #9.2.2.4 -->
+    - [x] 9.2 Nested structures (Objects/Maps, Arrays/Lists) <!-- 2026-05-04, issue #9.2 -->
+        - [x] 9.2.1 Define `Collection` and `Mapping` patterns <!-- 2026-05-04, issue #9.2.1 -->
+        - [x] 9.2.2 Implement instances across formats <!-- 2026-05-04, issue #9.2.2 -->
+            - [x] 9.2.2.1 JSON <!-- 2026-05-04, issue #9.2.2.1 -->
+            - [x] 9.2.2.2 XML <!-- 2026-05-04, issue #9.2.2.2 -->
+            - [x] 9.2.2.3 YAML <!-- 2026-05-04, issue #9.2.2.3 -->
+            - [x] 9.2.2.4 TOML <!-- 2026-05-04, issue #9.2.2.4 -->
     - [ ] 9.3 Metadata/Attributes <!-- issue #9.3 -->
         - [ ] 9.3.1 Define `Metadata` pattern <!-- issue #9.3.1 -->
         - [ ] 9.3.2 Implement instances across formats <!-- issue #9.3.2 -->

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -33,3 +33,65 @@ instance TomlBasic of BasicTypes {
     boolean_val = "true / false"
     notes = "TOML is strictly typed; strings must be double-quoted."
 }
+
+pattern Collection {
+    meta description: "Ordered sequence of elements (Arrays, Lists, or Sequences)."
+    parameter elements: String
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance JsonCollection of Collection {
+    elements = "Any JSON value"
+    syntax = "[1, \"two\", true]"
+    notes = "Elements are comma-separated and enclosed in square brackets."
+}
+
+instance XmlCollection of Collection {
+    elements = "Repeated child elements"
+    syntax = "<list>\n  <item>1</item>\n  <item>2</item>\n</list>"
+    notes = "Collections are typically represented by repeating elements under a parent."
+}
+
+instance YamlCollection of Collection {
+    elements = "Any YAML value"
+    syntax = "- 1\n- two\n- true"
+    notes = "Uses a dash followed by a space for each element."
+}
+
+instance TomlCollection of Collection {
+    elements = "Any TOML value"
+    syntax = "[1, 2, 3]"
+    notes = "Arrays can contain values of different types since TOML 1.0.0."
+}
+
+pattern Mapping {
+    meta description: "Unordered collection of key-value pairs (Objects, Maps, or Dictionaries)."
+    parameter entries: String
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance JsonMapping of Mapping {
+    entries = "Key-value pairs"
+    syntax = "{\"key\": \"value\", \"num\": 42}"
+    notes = "Keys must be double-quoted strings."
+}
+
+instance XmlMapping of Mapping {
+    entries = "Child elements or attributes"
+    syntax = "<object>\n  <key>value</key>\n  <num>42</num>\n</object>"
+    notes = "Mappings are represented as nested elements."
+}
+
+instance YamlMapping of Mapping {
+    entries = "Key-value pairs"
+    syntax = "key: value\nnum: 42"
+    notes = "Uses a colon followed by a space to separate key and value."
+}
+
+instance TomlMapping of Mapping {
+    entries = "Key-value pairs"
+    syntax = "key = \"value\"\nnum = 42"
+    notes = "Top-level or grouped using [headers]."
+}


### PR DESCRIPTION
I have implemented the next modest step from the `ROADMAP.md`: **9.2 Nested structures (Objects/Maps, Arrays/Lists)**.

### Changes:
- **`patterns/data_formats.patterns`**:
    - Defined the `Collection` pattern to represent ordered sequences of elements.
    - Defined the `Mapping` pattern to represent key-value pairs.
    - Added instances for both patterns across all supported formats: **JSON**, **XML**, **YAML**, and **TOML**.
- **`ROADMAP.md`**:
    - Marked task 9.2 and its subtasks (9.2.1, 9.2.2.1-4) as complete.

### Verification:
- Ran `PYTHONPATH=. python3 -m pytest` and all 36 tests passed.
- Verified reStructuredText generation by running `python3 -m src.main patterns/data_formats.patterns`, confirming that the new patterns and instances are correctly rendered into comparison tables.

Fixes #99

---
*PR created automatically by Jules for task [17545722588597146383](https://jules.google.com/task/17545722588597146383) started by @chatelao*