### PR TITLE
Implement Metadata pattern for data formats

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,13 +87,13 @@
             - [x] 9.2.2.2 XML <!-- 2026-05-04, issue #9.2.2.2 -->
             - [x] 9.2.2.3 YAML <!-- 2026-05-04, issue #9.2.2.3 -->
             - [x] 9.2.2.4 TOML <!-- 2026-05-04, issue #9.2.2.4 -->
-    - [ ] 9.3 Metadata/Attributes <!-- issue #9.3 -->
-        - [ ] 9.3.1 Define `Metadata` pattern <!-- issue #9.3.1 -->
-        - [ ] 9.3.2 Implement instances across formats <!-- issue #9.3.2 -->
-            - [ ] 9.3.2.1 JSON (N/A) <!-- issue #9.3.2.1 -->
-            - [ ] 9.3.2.2 XML (Attributes) <!-- issue #9.3.2.2 -->
-            - [ ] 9.3.2.3 YAML <!-- issue #9.3.2.3 -->
-            - [ ] 9.3.2.4 TOML <!-- issue #9.3.2.4 -->
+    - [x] 9.3 Metadata/Attributes <!-- 2026-05-10, issue #9.3 -->
+        - [x] 9.3.1 Define `Metadata` pattern <!-- 2026-05-10, issue #9.3.1 -->
+        - [x] 9.3.2 Implement instances across formats <!-- 2026-05-10, issue #9.3.2 -->
+            - [x] 9.3.2.1 JSON (N/A) <!-- 2026-05-10, issue #9.3.2.1 -->
+            - [x] 9.3.2.2 XML (Attributes) <!-- 2026-05-10, issue #9.3.2.2 -->
+            - [x] 9.3.2.3 YAML <!-- 2026-05-10, issue #9.3.2.3 -->
+            - [x] 9.3.2.4 TOML <!-- 2026-05-10, issue #9.3.2.4 -->
     - [ ] 9.4 Comments support <!-- issue #9.4 -->
         - [ ] 9.4.1 Define `Comment` pattern <!-- issue #9.4.1 -->
         - [ ] 9.4.2 Implement instances across formats <!-- issue #9.4.2 -->

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -48,3 +48,128 @@ Parameters:
      - 42 or 3.14
      - true / false
      - TOML is strictly typed; strings must be double-quoted.
+
+
+
+Collection
+==========
+
+
+:description: Ordered sequence of elements (Arrays, Lists, or Sequences).
+
+
+Parameters:
+
+* elements: String
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Collection Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - elements
+     - syntax
+     - notes
+   * - JsonCollection
+     - Any JSON value
+     - [1, \"two\", true]
+     - Elements are comma-separated and enclosed in square brackets.
+   * - XmlCollection
+     - Repeated child elements
+     - <list>\n  <item>1</item>\n  <item>2</item>\n</list>
+     - Collections are typically represented by repeating elements under a parent.
+   * - YamlCollection
+     - Any YAML value
+     - - 1\n- two\n- true
+     - Uses a dash followed by a space for each element.
+   * - TomlCollection
+     - Any TOML value
+     - [1, 2, 3]
+     - Arrays can contain values of different types since TOML 1.0.0.
+
+
+
+Mapping
+=======
+
+
+:description: Unordered collection of key-value pairs (Objects, Maps, or Dictionaries).
+
+
+Parameters:
+
+* entries: String
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Mapping Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - entries
+     - syntax
+     - notes
+   * - JsonMapping
+     - Key-value pairs
+     - {\"key\": \"value\", \"num\": 42}
+     - Keys must be double-quoted strings.
+   * - XmlMapping
+     - Child elements or attributes
+     - <object>\n  <key>value</key>\n  <num>42</num>\n</object>
+     - Mappings are represented as nested elements.
+   * - YamlMapping
+     - Key-value pairs
+     - key: value\nnum: 42
+     - Uses a colon followed by a space to separate key and value.
+   * - TomlMapping
+     - Key-value pairs
+     - key = \"value\"\nnum = 42
+     - Top-level or grouped using [headers].
+
+
+
+Metadata
+========
+
+
+:description: Way to attach metadata or attributes to data elements.
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: Metadata Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - syntax
+     - notes
+   * - JsonMetadata
+     - N/A
+     - JSON does not support metadata or attributes on elements; often simulated using underscore-prefixed keys (e.g., \"_metadata\": { ... }).
+   * - XmlMetadata
+     - <element attr=\"value\">Content</element>
+     - XML has native support for attributes on elements.
+   * - YamlMetadata
+     - !!str \"value\" or !custom { key: val }
+     - YAML supports tags to specify types or attach metadata to nodes.
+   * - TomlMetadata
+     - N/A
+     - TOML does not support per-element metadata, though it uses headers for grouping.

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -95,3 +95,29 @@ instance TomlMapping of Mapping {
     syntax = "key = \"value\"\nnum = 42"
     notes = "Top-level or grouped using [headers]."
 }
+
+pattern Metadata {
+    meta description: "Way to attach metadata or attributes to data elements."
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance JsonMetadata of Metadata {
+    syntax = "N/A"
+    notes = "JSON does not support metadata or attributes on elements; often simulated using underscore-prefixed keys (e.g., \"_metadata\": { ... })."
+}
+
+instance XmlMetadata of Metadata {
+    syntax = "<element attr=\"value\">Content</element>"
+    notes = "XML has native support for attributes on elements."
+}
+
+instance YamlMetadata of Metadata {
+    syntax = "!!str \"value\" or !custom { key: val }"
+    notes = "YAML supports tags to specify types or attach metadata to nodes."
+}
+
+instance TomlMetadata of Metadata {
+    syntax = "N/A"
+    notes = "TOML does not support per-element metadata, though it uses headers for grouping."
+}


### PR DESCRIPTION
This change implements Phase 3, Task 9.3 of the roadmap. It introduces a new `Metadata` pattern to compare how different data formats (JSON, XML, YAML, TOML) handle attributes or metadata. XML demonstrates native attribute support, YAML uses tags, and JSON/TOML are documented as not having native support for per-element metadata. The documentation was also updated to include the generated tables for the newly added patterns.

Fixes #102

---
*PR created automatically by Jules for task [490181153216151520](https://jules.google.com/task/490181153216151520) started by @chatelao*