### PR TITLE
Implement Comment Pattern and Roadmap Breakdown

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -94,13 +94,13 @@
             - [x] 9.3.2.2 XML (Attributes) <!-- 2026-05-10, issue #9.3.2.2 -->
             - [x] 9.3.2.3 YAML <!-- 2026-05-10, issue #9.3.2.3 -->
             - [x] 9.3.2.4 TOML <!-- 2026-05-10, issue #9.3.2.4 -->
-    - [ ] 9.4 Comments support <!-- issue #9.4 -->
-        - [ ] 9.4.1 Define `Comment` pattern <!-- issue #9.4.1 -->
-        - [ ] 9.4.2 Implement instances across formats <!-- issue #9.4.2 -->
-            - [ ] 9.4.2.1 JSON (N/A) <!-- issue #9.4.2.1 -->
-            - [ ] 9.4.2.2 XML <!-- issue #9.4.2.2 -->
-            - [ ] 9.4.2.3 YAML <!-- issue #9.4.2.3 -->
-            - [ ] 9.4.2.4 TOML <!-- issue #9.4.2.4 -->
+    - [x] 9.4 Comments support <!-- 2026-05-11, issue #9.4 -->
+        - [x] 9.4.1 Define `Comment` pattern <!-- 2026-05-11, issue #9.4.1 -->
+        - [x] 9.4.2 Implement instances across formats <!-- 2026-05-11, issue #9.4.2 -->
+            - [x] 9.4.2.1 JSON (N/A) <!-- 2026-05-11, issue #9.4.2.1 -->
+            - [x] 9.4.2.2 XML <!-- 2026-05-11, issue #9.4.2.2 -->
+            - [x] 9.4.2.3 YAML <!-- 2026-05-11, issue #9.4.2.3 -->
+            - [x] 9.4.2.4 TOML <!-- 2026-05-11, issue #9.4.2.4 -->
     - [ ] 9.5 Schema validation <!-- issue #9.5 -->
         - [ ] 9.5.1 Define `SchemaLink` pattern <!-- issue #9.5.1 -->
         - [ ] 9.5.2 Implement instances across formats <!-- issue #9.5.2 -->
@@ -115,3 +115,7 @@
     - [x] 10.2 Setup `.readthedocs.yaml` <!-- 2026-05-03, issue #10.2 -->
     - [x] 10.3 Integrate transpiler output into Sphinx build <!-- 2026-05-03, issue #10.3 -->
 - [ ] Final review and polish of the comparative book <!-- issue #11 -->
+    - [ ] 11.1 Verify consistency of pattern descriptions and parameter names <!-- issue #11.1 -->
+    - [ ] 11.2 Review generated reST for formatting issues or table alignment problems <!-- issue #11.2 -->
+    - [ ] 11.3 Add a "Language/Format Coverage" summary to the documentation <!-- issue #11.3 -->
+    - [ ] 11.4 Final verification of the Read the Docs build process <!-- issue #11.4 -->

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -173,3 +173,47 @@ Parameters:
    * - TomlMetadata
      - N/A
      - TOML does not support per-element metadata, though it uses headers for grouping.
+
+
+
+Comment
+=======
+
+
+:description: Way to add non-executable explanatory text to the data.
+
+
+Parameters:
+
+* single_line: String
+
+* multi_line: String
+
+* notes: String
+
+
+
+.. list-table:: Comment Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - single_line
+     - multi_line
+     - notes
+   * - JsonComment
+     - N/A
+     - N/A
+     - JSON does not natively support comments.
+   * - XmlComment
+     - <!-- comment -->
+     - <!--\n  line 1\n  line 2\n-->
+     - XML uses the same syntax for single and multi-line comments.
+   * - YamlComment
+     - # comment
+     - # line 1\n# line 2
+     - YAML only supports single-line comments starting with #.
+   * - TomlComment
+     - # comment
+     - # line 1\n# line 2
+     - TOML only supports single-line comments starting with #.

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -121,3 +121,34 @@ instance TomlMetadata of Metadata {
     syntax = "N/A"
     notes = "TOML does not support per-element metadata, though it uses headers for grouping."
 }
+
+pattern Comment {
+    meta description: "Way to add non-executable explanatory text to the data."
+    parameter single_line: String
+    parameter multi_line: String
+    parameter notes: String
+}
+
+instance JsonComment of Comment {
+    single_line = "N/A"
+    multi_line = "N/A"
+    notes = "JSON does not natively support comments."
+}
+
+instance XmlComment of Comment {
+    single_line = "<!-- comment -->"
+    multi_line = "<!--\n  line 1\n  line 2\n-->"
+    notes = "XML uses the same syntax for single and multi-line comments."
+}
+
+instance YamlComment of Comment {
+    single_line = "# comment"
+    multi_line = "# line 1\n# line 2"
+    notes = "YAML only supports single-line comments starting with #."
+}
+
+instance TomlComment of Comment {
+    single_line = "# comment"
+    multi_line = "# line 1\n# line 2"
+    notes = "TOML only supports single-line comments starting with #."
+}


### PR DESCRIPTION
This PR implements Task 9.4 from the ROADMAP.md, adding support for the `Comment` pattern in data formats. It also breaks down the broad Task 11 ("Final review and polish") into more specific, actionable sub-tasks.

Changes:
1.  **`patterns/data_formats.patterns`**: Defined the `Comment` pattern and added instances for JSON (N/A), XML, YAML, and TOML.
2.  **`docs/data_formats.rst`**: Regenerated the documentation to include the new pattern.
3.  **`ROADMAP.md`**: Marked Task 9.4 as complete and added sub-tasks 11.1 through 11.4.

Verified by running the transpiler and existing tests (`pytest`).

Fixes #105

---
*PR created automatically by Jules for task [11210600777736231284](https://jules.google.com/task/11210600777736231284) started by @chatelao*