### PR TITLE
Implement Schema validation patterns for data formats

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
     - [x] 12.2 Implement GitHub Actions workflow for PR merge and issue duplication (MVP) <!-- 2026-05-03, issue #12.2 -->
 
 ## Phase 2: Transpiler Development
-- [ ] Define DSL for Source Patterns <!-- issue #4 -->
+- [x] Define DSL for Source Patterns <!-- 2026-05-01, issue #4 -->
     - [x] 4.1 Define DSL requirements and syntax draft <!-- 2026-05-01, issue #4.1 -->
     - [x] 4.2 Validate DSL draft with example patterns <!-- 2026-05-01, issue #4.2 -->
     - [x] 4.3 Finalize DSL specification <!-- 2026-05-01, issue #4.3 -->
@@ -72,7 +72,7 @@
             - [x] 8.5.2.1 Rust instances <!-- 2026-05-08, issue #8.5.2.1 -->
             - [x] 8.5.2.2 Erlang instances <!-- 2026-05-08, issue #8.5.2.2 -->
             - [x] 8.5.2.3 Java instances <!-- 2026-05-08, issue #8.5.2.3 -->
-- [ ] Populate Data Format patterns <!-- issue #9 -->
+- [x] Populate Data Format patterns <!-- 2026-05-11, issue #9 -->
     - [x] 9.1 Basic data types (Strings, Numbers, Booleans) <!-- 2026-05-08, issue #9.1 -->
         - [x] 9.1.1 Define `BasicTypes` pattern <!-- 2026-05-08, issue #9.1.1 -->
         - [x] 9.1.2 Implement instances (JSON, XML, YAML, TOML) <!-- 2026-05-08, issue #9.1.2 -->
@@ -101,13 +101,13 @@
             - [x] 9.4.2.2 XML <!-- 2026-05-11, issue #9.4.2.2 -->
             - [x] 9.4.2.3 YAML <!-- 2026-05-11, issue #9.4.2.3 -->
             - [x] 9.4.2.4 TOML <!-- 2026-05-11, issue #9.4.2.4 -->
-    - [ ] 9.5 Schema validation <!-- issue #9.5 -->
-        - [ ] 9.5.1 Define `SchemaLink` pattern <!-- issue #9.5.1 -->
-        - [ ] 9.5.2 Implement instances across formats <!-- issue #9.5.2 -->
-            - [ ] 9.5.2.1 JSON Schema <!-- issue #9.5.2.1 -->
-            - [ ] 9.5.2.2 XML (XSD/DTD) <!-- issue #9.5.2.2 -->
-            - [ ] 9.5.2.3 YAML (JSON Schema/Custom) <!-- issue #9.5.2.3 -->
-            - [ ] 9.5.2.4 TOML <!-- issue #9.5.2.4 -->
+    - [x] 9.5 Schema validation <!-- 2026-05-11, issue #9.5 -->
+        - [x] 9.5.1 Define `SchemaLink` pattern <!-- 2026-05-11, issue #9.5.1 -->
+        - [x] 9.5.2 Implement instances across formats <!-- 2026-05-11, issue #9.5.2 -->
+            - [x] 9.5.2.1 JSON Schema <!-- 2026-05-11, issue #9.5.2.1 -->
+            - [x] 9.5.2.2 XML (XSD/DTD) <!-- 2026-05-11, issue #9.5.2.2 -->
+            - [x] 9.5.2.3 YAML (JSON Schema/Custom) <!-- 2026-05-11, issue #9.5.2.3 -->
+            - [x] 9.5.2.4 TOML <!-- 2026-05-11, issue #9.5.2.4 -->
 
 ## Phase 4: Publication
 - [x] Configure ReadTheDocs integration <!-- 2026-05-03, issue #10 -->

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -217,3 +217,40 @@ Parameters:
      - # comment
      - # line 1\n# line 2
      - TOML only supports single-line comments starting with #.
+
+
+
+SchemaLink
+==========
+
+
+:description: Linking a data file to a schema for validation (e.g., JSON Schema, XSD).
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: SchemaLink Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Instance
+     - syntax
+     - notes
+   * - JsonSchemaLink
+     - \"\$schema\": \"http://json-schema.org/draft-07/schema#\"
+     - JSON uses the \$schema keyword to point to a JSON Schema file.
+   * - XmlSchemaLink
+     - <root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n      xsi:schemaLocation=\"http://example.com schema.xsd\">
+     - XML uses the xsi:schemaLocation attribute to link to an XSD.
+   * - YamlSchemaLink
+     - # yaml-language-server: \$schema=<url_or_path>
+     - YAML often relies on editor-specific comments (like VS Code's language server) for schema linking.
+   * - TomlSchemaLink
+     - N/A
+     - TOML does not have a native or widely standardized way to link to a schema within the file.

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -152,3 +152,29 @@ instance TomlComment of Comment {
     multi_line = "# line 1\n# line 2"
     notes = "TOML only supports single-line comments starting with #."
 }
+
+pattern SchemaLink {
+    meta description: "Linking a data file to a schema for validation (e.g., JSON Schema, XSD)."
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance JsonSchemaLink of SchemaLink {
+    syntax = "\"\$schema\": \"http://json-schema.org/draft-07/schema#\""
+    notes = "JSON uses the \$schema keyword to point to a JSON Schema file."
+}
+
+instance XmlSchemaLink of SchemaLink {
+    syntax = "<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n      xsi:schemaLocation=\"http://example.com schema.xsd\">"
+    notes = "XML uses the xsi:schemaLocation attribute to link to an XSD."
+}
+
+instance YamlSchemaLink of SchemaLink {
+    syntax = "# yaml-language-server: \$schema=<url_or_path>"
+    notes = "YAML often relies on editor-specific comments (like VS Code's language server) for schema linking."
+}
+
+instance TomlSchemaLink of SchemaLink {
+    syntax = "N/A"
+    notes = "TOML does not have a native or widely standardized way to link to a schema within the file."
+}


### PR DESCRIPTION
This change implements the "Schema validation" step (issue #9.5) from the roadmap. It introduces the `SchemaLink` pattern to the data formats DSL, providing standard ways to link schemas across JSON, XML, YAML, and TOML. Additionally, it performs roadmap maintenance by marking parent tasks #4 and #9 as complete now that all their sub-tasks are finished. All tests passed, and the documentation generation was verified.

Fixes #107

---
*PR created automatically by Jules for task [3131247444632556547](https://jules.google.com/task/3131247444632556547) started by @chatelao*