### PR TITLE
Update README and project name to Bible of Babylon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
-# XIAO Seeed RP2040 Renode Project
+# Bible of Babylon
 
-This project provides a setup for the XIAO Seeed RP2040 to run UART, ADC, PWM, Interrupts, and Timer on the Renode emulation framework using PlatformIO.
+Bible of Babylon is a comprehensive comparative guide designed for developers and data engineers. It provides structured comparisons of common patterns across various programming languages and data formats.
+
+## Key Concepts
+
+- **Polyglot Developer Onboarding**: Accelerating the transition between programming languages by comparing syntax and patterns.
+- **Data Format Interoperability**: Understanding how data structures map across different formats like JSON, XML, YAML, and TOML.
+- **Automated Refinement**: Using a pattern-driven transpilation pipeline to ensure consistency and maintainability.
 
 ## Documentation
 
-The full documentation is available at [https://xiao-seeed-rp2040-renode.readthedocs.io/](https://xiao-seeed-rp2040-renode.readthedocs.io/).
+The full documentation, including detailed comparison tables for programming patterns and data formats, is hosted on Read the Docs:
+
+[https://xiao-seeed-rp2040-renode.readthedocs.io/](https://xiao-seeed-rp2040-renode.readthedocs.io/)
+
+## Project Structure
+
+- `patterns/`: Domain-specific definitions of programming and data patterns.
+- `src/`: The transpiler engine (ANTLR4 and Jinja2) that generates documentation.
+- `docs/`: Sphinx documentation source and generated reStructuredText.
+- `specifications/`: Formal specifications for the DSL and workflows.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # Configuration file for the Sphinx documentation builder.
 
-project = 'Xiao Seeed RP2040 Renode'
+project = 'Bible of Babylon'
 copyright = '2024, chatelao'
 author = 'chatelao'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-Welcome to the Xiao Seeed RP2040 Renode Pattern Documentation
-=============================================================
+Welcome to the Bible of Babylon Documentation
+=============================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR updates the project's identity to "Bible of Babylon" across all relevant documentation and configuration files. It also provides a more detailed README.md that includes the Read the Docs link as requested.

Changes:
- Modified `README.md` to reflect the correct project name, description, and documentation link.
- Updated `docs/conf.py` and `docs/index.rst` to ensure the generated documentation uses the correct project title.
- Verified that all existing tests pass and the Sphinx documentation builds successfully.

Fixes #113

---
*PR created automatically by Jules for task [16978005875948907834](https://jules.google.com/task/16978005875948907834) started by @chatelao*