### PR TITLE
Add Read the Docs badge and links to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bible of Babylon
 
+[![Documentation Status](https://readthedocs.org/projects/bible-of-babylon/badge/?version=latest)](https://bible-of-babylon.readthedocs.io/en/latest/?badge=latest)
+
 Bible of Babylon is a comprehensive comparative guide designed for developers and data engineers. It provides structured comparisons of common patterns across various programming languages and data formats.
 
 ## Key Concepts
@@ -12,7 +14,8 @@ Bible of Babylon is a comprehensive comparative guide designed for developers an
 
 The full documentation, including detailed comparison tables for programming patterns and data formats, is hosted on Read the Docs:
 
-[https://xiao-seeed-rp2040-renode.readthedocs.io/](https://xiao-seeed-rp2040-renode.readthedocs.io/)
+- **Documentation**: [https://bible-of-babylon.readthedocs.io/](https://bible-of-babylon.readthedocs.io/)
+- **Project Page**: [https://readthedocs.org/projects/bible-of-babylon/](https://readthedocs.org/projects/bible-of-babylon/)
 
 ## Project Structure
 


### PR DESCRIPTION
This PR enhances the `README.md` by adding a Read the Docs documentation status badge and providing direct links to the documentation and the Read the Docs project page. This ensures that users can easily find and access the latest documentation for the project.

Key changes:
- Added a Read the Docs badge to the top of `README.md`.
- Added a "Documentation" section with links to the Read the Docs hosted site and project dashboard.
- Verified project identity consistency across `README.md`, `docs/conf.py`, and `docs/index.rst`.

Fixes #115

---
*PR created automatically by Jules for task [353350518681400113](https://jules.google.com/task/353350518681400113) started by @chatelao*