### PR TITLE
Add CUDA and x86 Assembler to language list

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,6 +19,8 @@ This section compares languages based on common programming patterns.
 - Cmd
 - PowerShell
 - CSS
+- CUDA
+- x86 Assembler
 
 **Patterns to be compared:**
 - Variable declaration

--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -103,6 +103,18 @@ Parameters:
      - 42
      - --x: 42;
      - CSS custom properties (variables).
+   * - CudaVar
+     - x
+     - int
+     - 42
+     - __device__ int x = 42;
+     - Uses __device__ qualifier for GPU memory.
+   * - X86Var
+     - x
+     - DWORD
+     - 42
+     - x dd 42
+     - Defined in the .data section (Intel syntax).
 
 
 
@@ -224,6 +236,20 @@ Parameters:
      - { raw "N/A" }
      - N/A
      - CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors).
+   * - CudaFunction
+     - add
+     - [int a, int b]
+     - int
+     - { raw "return a + b;" }
+     - __device__ int add(int a, int b) { return a + b; }
+     - Functions can be qualified with __device__, __host__, or __global__.
+   * - X86Function
+     - add
+     - [eax, ebx]
+     - eax
+     - { raw "add eax, ebx\nret" }
+     - add_func:\nadd eax, ebx\nret
+     - Functions are labels; parameters usually passed via registers or stack.
 
 
 
@@ -330,6 +356,18 @@ Parameters:
      - { raw "color: blue;" }
      - @media (min-width: 0px) { .element { color: red; } }
      - Media queries provide conditional styling; no true else branch exists.
+   * - CudaIfElse
+     - x > 0
+     - { return 1 }
+     - { return 0 }
+     - if (x > 0) { return 1; } else { return 0; }
+     - Standard C-like if-else statement.
+   * - X86IfElse
+     - eax > 0
+     - { return 1 }
+     - { return 0 }
+     - cmp eax, 0\njle .else\nmov eax, 1\njmp .end\n.else:\nmov eax, 0\n.end:
+     - Implemented using comparison and jump instructions (Intel syntax).
 
 
 
@@ -421,6 +459,16 @@ Parameters:
      - { raw "N/A" }
      - N/A
      - CSS does not support loops natively.
+   * - CudaLoop
+     - x > 0
+     - { raw "x = x - 1;" }
+     - while (x > 0) { x = x - 1; }
+     - Standard C-like while loop.
+   * - X86Loop
+     - ecx > 0
+     - { raw "dec ecx" }
+     - .loop:\ncmp ecx, 0\njle .end\ndec ecx\njmp .loop\n.end:
+     - Implemented using labels and conditional jumps.
 
 
 
@@ -542,6 +590,20 @@ Parameters:
      - { raw "/* N/A */" }
      - N/A
      - CSS does not have native error handling mechanisms like try-catch.
+   * - CudaTryCatch
+     - { call do_something() }
+     - N/A
+     - N/A
+     - { raw "/* Error handling in CUDA kernels is typically manual */" }
+     - N/A
+     - CUDA does not support C++ exceptions in device code.
+   * - X86TryCatch
+     - { call do_something() }
+     - N/A
+     - N/A
+     - { raw "/* SEH or manual error checking */" }
+     - N/A
+     - No high-level try-catch; requires OS-specific mechanisms like SEH.
 
 
 
@@ -633,6 +695,16 @@ Parameters:
      - N/A
      - N/A
      - CSS does not have a mechanism to raise exceptions.
+   * - CudaRaise
+     - N/A
+     - N/A
+     - N/A
+     - No native exception mechanism in CUDA device code.
+   * - X86Raise
+     - Interrupt
+     - Error
+     - int 3
+     - Software interrupts (like int 3) can be used to signal errors or breakpoints.
 
 
 
@@ -673,6 +745,14 @@ Parameters:
      - { call do_work() }
      - new Thread(() -> { do_work(); }).start();
      - Spawns a new platform thread; virtual threads are available in newer versions.
+   * - CudaThread
+     - { call kernel() }
+     - kernel<<<grid, block>>>();
+     - Launches a grid of threads on the GPU.
+   * - X86Thread
+     - { call do_work() }
+     - push offset do_work\ncall CreateThread
+     - Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread).
 
 
 
@@ -719,6 +799,16 @@ Parameters:
      - 42
      - queue.put(42);
      - Commonly implemented using BlockingQueue; put() may block if the queue is full.
+   * - CudaSendMessage
+     - sm_id
+     - data
+     - N/A
+     - CUDA threads typically communicate via shared memory or atomics, not explicit message passing.
+   * - X86SendMessage
+     - thread_id
+     - msg
+     - push msg\npush thread_id\ncall PostThreadMessage
+     - Message passing is done via OS APIs.
 
 
 
@@ -765,3 +855,13 @@ Parameters:
      - { call handle(msg) }
      - int msg = queue.take(); handle(msg);
      - Using BlockingQueue.take(); blocks until an element becomes available.
+   * - CudaReceiveMessage
+     - data
+     - { raw "/* access shared memory */" }
+     - N/A
+     - Communication is memory-based.
+   * - X86ReceiveMessage
+     - msg
+     - { call handle(msg) }
+     - call GetMessage
+     - Message retrieval via OS APIs.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -130,6 +130,22 @@ instance CssVar of VariableDeclaration {
     notes = "CSS custom properties (variables)."
 }
 
+instance CudaVar of VariableDeclaration {
+    name = "x"
+    type = "int"
+    initial_value = 42
+    syntax = "__device__ int x = 42;"
+    notes = "Uses __device__ qualifier for GPU memory."
+}
+
+instance X86Var of VariableDeclaration {
+    name = "x"
+    type = "DWORD"
+    initial_value = 42
+    syntax = "x dd 42"
+    notes = "Defined in the .data section (Intel syntax)."
+}
+
 instance CIfElse of IfElse {
     condition = "x > 0"
     then_branch = { return 1 }
@@ -303,11 +319,41 @@ instance CssIfElse of IfElse {
     notes = "Media queries provide conditional styling; no true else branch exists."
 }
 
+instance CudaIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) { return 1; } else { return 0; }"
+    notes = "Standard C-like if-else statement."
+}
+
+instance X86IfElse of IfElse {
+    condition = "eax > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "cmp eax, 0\njle .else\nmov eax, 1\njmp .end\n.else:\nmov eax, 0\n.end:"
+    notes = "Implemented using comparison and jump instructions (Intel syntax)."
+}
+
 instance CssLoop of Loop {
     condition = "N/A"
     body = { raw "N/A" }
     syntax = "N/A"
     notes = "CSS does not support loops natively."
+}
+
+instance CudaLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x = x - 1;" }
+    syntax = "while (x > 0) { x = x - 1; }"
+    notes = "Standard C-like while loop."
+}
+
+instance X86Loop of Loop {
+    condition = "ecx > 0"
+    body = { raw "dec ecx" }
+    syntax = ".loop:\ncmp ecx, 0\njle .end\ndec ecx\njmp .loop\n.end:"
+    notes = "Implemented using labels and conditional jumps."
 }
 
 instance CFunction of FunctionDefinition {
@@ -416,6 +462,24 @@ instance CssFunction of FunctionDefinition {
     body = { raw "N/A" }
     syntax = "N/A"
     notes = "CSS does not support user-defined functions in the traditional sense (excluding Houdini or preprocessors)."
+}
+
+instance CudaFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["int a", "int b"]
+    return_type = "int"
+    body = { raw "return a + b;" }
+    syntax = "__device__ int add(int a, int b) { return a + b; }"
+    notes = "Functions can be qualified with __device__, __host__, or __global__."
+}
+
+instance X86Function of FunctionDefinition {
+    name = "add"
+    parameters = ["eax", "ebx"]
+    return_type = "eax"
+    body = { raw "add eax, ebx\nret" }
+    syntax = "add_func:\nadd eax, ebx\nret"
+    notes = "Functions are labels; parameters usually passed via registers or stack."
 }
 
 pattern TryCatch {
@@ -621,11 +685,43 @@ instance CssTryCatch of TryCatch {
     notes = "CSS does not have native error handling mechanisms like try-catch."
 }
 
+instance CudaTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "/* Error handling in CUDA kernels is typically manual */" }
+    syntax = "N/A"
+    notes = "CUDA does not support C++ exceptions in device code."
+}
+
+instance X86TryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "/* SEH or manual error checking */" }
+    syntax = "N/A"
+    notes = "No high-level try-catch; requires OS-specific mechanisms like SEH."
+}
+
 instance CssRaise of Raise {
     exception_type = "N/A"
     message = "N/A"
     syntax = "N/A"
     notes = "CSS does not have a mechanism to raise exceptions."
+}
+
+instance CudaRaise of Raise {
+    exception_type = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "No native exception mechanism in CUDA device code."
+}
+
+instance X86Raise of Raise {
+    exception_type = "Interrupt"
+    message = "Error"
+    syntax = "int 3"
+    notes = "Software interrupts (like int 3) can be used to signal errors or breakpoints."
 }
 
 pattern Thread {
@@ -697,6 +793,18 @@ instance JavaThread of Thread {
     notes = "Spawns a new platform thread; virtual threads are available in newer versions."
 }
 
+instance CudaThread of Thread {
+    body = { call kernel() }
+    syntax = "kernel<<<grid, block>>>();"
+    notes = "Launches a grid of threads on the GPU."
+}
+
+instance X86Thread of Thread {
+    body = { call do_work() }
+    syntax = "push offset do_work\ncall CreateThread"
+    notes = "Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread)."
+}
+
 instance JavaSendMessage of SendMessage {
     recipient = "queue"
     message = "42"
@@ -704,9 +812,37 @@ instance JavaSendMessage of SendMessage {
     notes = "Commonly implemented using BlockingQueue; put() may block if the queue is full."
 }
 
+instance CudaSendMessage of SendMessage {
+    recipient = "sm_id"
+    message = "data"
+    syntax = "N/A"
+    notes = "CUDA threads typically communicate via shared memory or atomics, not explicit message passing."
+}
+
+instance X86SendMessage of SendMessage {
+    recipient = "thread_id"
+    message = "msg"
+    syntax = "push msg\npush thread_id\ncall PostThreadMessage"
+    notes = "Message passing is done via OS APIs."
+}
+
 instance JavaReceiveMessage of ReceiveMessage {
     match_pattern = "msg"
     body = { call handle(msg) }
     syntax = "int msg = queue.take(); handle(msg);"
     notes = "Using BlockingQueue.take(); blocks until an element becomes available."
+}
+
+instance CudaReceiveMessage of ReceiveMessage {
+    match_pattern = "data"
+    body = { raw "/* access shared memory */" }
+    syntax = "N/A"
+    notes = "Communication is memory-based."
+}
+
+instance X86ReceiveMessage of ReceiveMessage {
+    match_pattern = "msg"
+    body = { call handle(msg) }
+    syntax = "call GetMessage"
+    notes = "Message retrieval via OS APIs."
 }


### PR DESCRIPTION
I have added CUDA and x86 Assembler to the language comparison project. 

Key changes:
- **`patterns/programming.patterns`**: Added comprehensive pattern instances for both languages, covering variables, functions, control flow, error handling, and concurrency models.
- **`DESIGN.md`**: Updated the language list to include CUDA and x86 Assembler.
- **`docs/programming.rst`**: Regenerated the documentation to include the new comparison data.

I verified the changes by running the full test suite (36 tests passed) and by inspecting the generated reStructuredText for table consistency and correct rendering.

Fixes #118

---
*PR created automatically by Jules for task [12663991076868795327](https://jules.google.com/task/12663991076868795327) started by @chatelao*