### PR TITLE
Update README.md with Read the Docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,27 @@
 
 Bible of Babylon is a comprehensive comparative guide designed for developers and data engineers. It provides structured comparisons of common patterns across various programming languages and data formats.
 
-## Key Concepts
+## 📖 Documentation
+
+The full documentation, including detailed comparison tables for programming patterns and data formats, is hosted on Read the Docs:
+
+- **Official Documentation**: [https://bible-of-babylon.readthedocs.io/](https://bible-of-babylon.readthedocs.io/)
+- **Read the Docs Project Page**: [https://readthedocs.org/projects/bible-of-babylon/](https://readthedocs.org/projects/bible-of-babylon/)
+
+## 🚀 Key Concepts
 
 - **Polyglot Developer Onboarding**: Accelerating the transition between programming languages by comparing syntax and patterns.
 - **Data Format Interoperability**: Understanding how data structures map across different formats like JSON, XML, YAML, and TOML.
 - **Automated Refinement**: Using a pattern-driven transpilation pipeline to ensure consistency and maintainability.
 
-## Documentation
+## 📁 Project Structure
 
-The full documentation, including detailed comparison tables for programming patterns and data formats, is hosted on Read the Docs:
+- `patterns/`: Domain-specific definitions of programming and data patterns using a custom DSL.
+- `src/`: The transpiler engine (ANTLR4 and Jinja2) that generates documentation from patterns.
+- `docs/`: Sphinx documentation source, including generated reStructuredText tables.
+- `specifications/`: Formal specifications for the DSL and automated workflows.
+- `test/`: Verification suite for grammar, transformation, and documentation consistency.
 
-- **Documentation**: [https://bible-of-babylon.readthedocs.io/](https://bible-of-babylon.readthedocs.io/)
-- **Project Page**: [https://readthedocs.org/projects/bible-of-babylon/](https://readthedocs.org/projects/bible-of-babylon/)
+## 📜 License
 
-## Project Structure
-
-- `patterns/`: Domain-specific definitions of programming and data patterns.
-- `src/`: The transpiler engine (ANTLR4 and Jinja2) that generates documentation.
-- `docs/`: Sphinx documentation source and generated reStructuredText.
-- `specifications/`: Formal specifications for the DSL and workflows.
+This project is licensed under the GNU Affero General Public License v3.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This PR updates the root README.md to provide clear and prominent links to the project's documentation on Read the Docs, as requested. It also improves the overall structure of the README to better reflect the project's current state, including its technology stack (ANTLR4, Jinja2, Sphinx) and its licensing (AGPL-3.0). All links have been verified to be correct and active.

Fixes #117

---
*PR created automatically by Jules for task [17678490183078977662](https://jules.google.com/task/17678490183078977662) started by @chatelao*