### PR TITLE
Improve ReadTheDocs TOC hierarchy

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,8 +6,8 @@ build:
     python: "3.11"
   jobs:
     pre_build:
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -o docs/programming.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -o docs/data_formats.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -o docs/programming.rst --title "Programming Language Patterns"
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -o docs/data_formats.rst --title "Data Format Patterns"
 
 python:
   install:

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -1,7 +1,10 @@
+Data Format Patterns
+====================
+
 
 
 BasicTypes
-==========
+----------
 
 
 :description: Representation of fundamental data types: Strings, Numbers, and Booleans.
@@ -52,7 +55,7 @@ Parameters:
 
 
 Collection
-==========
+----------
 
 
 :description: Ordered sequence of elements (Arrays, Lists, or Sequences).
@@ -96,7 +99,7 @@ Parameters:
 
 
 Mapping
-=======
+-------
 
 
 :description: Unordered collection of key-value pairs (Objects, Maps, or Dictionaries).
@@ -140,7 +143,7 @@ Parameters:
 
 
 Metadata
-========
+--------
 
 
 :description: Way to attach metadata or attributes to data elements.
@@ -177,7 +180,7 @@ Parameters:
 
 
 Comment
-=======
+-------
 
 
 :description: Way to add non-executable explanatory text to the data.
@@ -221,7 +224,7 @@ Parameters:
 
 
 SchemaLink
-==========
+----------
 
 
 :description: Linking a data file to a schema for validation (e.g., JSON Schema, XSD).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,15 @@ Welcome to the Bible of Babylon Documentation
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: DSL Reference:
 
    dsl_specification
    dsl_examples
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Pattern Comparison:
+
    programming
    data_formats
 

--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -1,7 +1,10 @@
+Programming Language Patterns
+=============================
+
 
 
 VariableDeclaration
-===================
+-------------------
 
 
 :description: The act of naming a value and optionally specifying its type.
@@ -119,7 +122,7 @@ Parameters:
 
 
 FunctionDefinition
-==================
+------------------
 
 
 :description: Declaration of a reusable block of code with parameters and a return value.
@@ -254,7 +257,7 @@ Parameters:
 
 
 IfElse
-======
+------
 
 
 :description: Conditional execution of code blocks.
@@ -372,7 +375,7 @@ Parameters:
 
 
 Loop
-====
+----
 
 
 :description: Repeated execution of a code block based on a condition.
@@ -473,7 +476,7 @@ Parameters:
 
 
 TryCatch
-========
+--------
 
 
 :description: Handling exceptions or errors within a block of code.
@@ -608,7 +611,7 @@ Parameters:
 
 
 Raise
-=====
+-----
 
 
 :description: Explicitly triggering an exception or error.
@@ -709,7 +712,7 @@ Parameters:
 
 
 Thread
-======
+------
 
 
 :description: Creating and running a new thread of execution.
@@ -757,7 +760,7 @@ Parameters:
 
 
 SendMessage
-===========
+-----------
 
 
 :description: Sending a message to another process or thread.
@@ -813,7 +816,7 @@ Parameters:
 
 
 ReceiveMessage
-==============
+--------------
 
 
 :description: Receiving a message from another process or thread.

--- a/src/generator.py
+++ b/src/generator.py
@@ -52,8 +52,11 @@ class CodeGenerator:
         template = self.env.get_template('instance_table.rst.j2')
         return template.render(pattern=pattern, instances=instances)
 
-    def render_program(self, program: Program) -> str:
+    def render_program(self, program: Program, title: str = None) -> str:
         results = []
+
+        if title:
+            results.append(f"{title}\n{'=' * len(title)}")
 
         # Map pattern name to pattern object
         patterns_map = {p.name: p for p in program.patterns}

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ def main():
     parser = argparse.ArgumentParser(description="Transform Source Patterns DSL to reStructuredText.")
     parser.add_argument("input", help="Path to the input .patterns file")
     parser.add_argument("-o", "--output", help="Path to the output .rst file (defaults to stdout)")
+    parser.add_argument("-t", "--title", help="Top-level title for the generated documentation")
 
     args = parser.parse_args()
 
@@ -48,7 +49,7 @@ def main():
 
     # 4. Generation
     generator = CodeGenerator()
-    output_rst = generator.render_program(program_asg)
+    output_rst = generator.render_program(program_asg, title=args.title)
 
     # 5. Output
     if args.output:

--- a/src/templates/pattern.rst.j2
+++ b/src/templates/pattern.rst.j2
@@ -1,7 +1,7 @@
 {% if pattern %}
 
 {{ pattern.name }}
-{{ "=" * pattern.name|length }}
+{{ "-" * pattern.name|length }}
 
 {% for meta in pattern.metadata %}
 :{{ meta.key }}: {{ meta.value }}

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -15,9 +15,25 @@ def test_render_pattern_only():
     output = generator.render_program(program)
 
     assert "VarDec" in output
-    assert "======" in output
+    assert "------" in output
     assert "* name: Identifier" in output
     assert "* type: Type" in output
+
+def test_render_program_with_title():
+    pattern = Pattern(
+        name="VarDec",
+        parameters=[
+            Parameter(name="name", type=Type(name="Identifier"))
+        ]
+    )
+    program = Program(patterns=[pattern], instances=[])
+    generator = CodeGenerator()
+    output = generator.render_program(program, title="My Title")
+
+    assert "My Title" in output
+    assert "========" in output
+    assert "VarDec" in output
+    assert "------" in output
 
 def test_render_instance_table():
     pattern = Pattern(


### PR DESCRIPTION
This change improves the documentation hierarchy on ReadTheDocs by nesting patterns under their respective page titles and organizing the main index into logical sections.

Key changes:
- Patterns now use level-2 headers ('-') in the generated RST files.
- The transpiler CLI now supports a `--title` argument to generate a level-1 header ('=') for the entire document.
- `.readthedocs.yaml` has been updated to use these titles during the build process.
- `docs/index.rst` now features two distinct sections: "DSL Reference" and "Pattern Comparison", each with its own `toctree`.
- Unit tests have been updated to reflect the new header levels and a new test case for title generation has been added.

Fixes #122

---
*PR created automatically by Jules for task [7702297895396743210](https://jules.google.com/task/7702297895396743210) started by @chatelao*