### PR TITLE
Update copyright year to 2026

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # Configuration file for the Sphinx documentation builder.
 
 project = 'Bible of Babylon'
-copyright = '2024, chatelao'
+copyright = '2026, chatelao'
 author = 'chatelao'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
Updated the copyright year in `docs/conf.py` from 2024 to 2026 as requested. Verified the change by reading the file and running all project tests, which passed successfully.

Fixes #126

---
*PR created automatically by Jules for task [16969781834608060181](https://jules.google.com/task/16969781834608060181) started by @chatelao*