### PR TITLE
Fix multi-line example linebreaks in comparison tables

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -1,10 +1,16 @@
 from pathlib import Path
-from typing import List, Dict
+from typing import List, Dict, Any
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from .models import (
     Pattern, Program, Instance, AnonymousInstance, Block, ListLiteral, Identifier,
     CallInstruction, AssignInstruction, ReturnInstruction, RawInstruction
 )
+
+def format_table_cell(value: Any) -> str:
+    if isinstance(value, str) and "\n" in value:
+        lines = value.split("\n")
+        return "\n".join(f"| {line}" if line.strip() else "|" for line in lines)
+    return str(value)
 
 def format_value(value) -> str:
     if isinstance(value, str):
@@ -43,6 +49,7 @@ class CodeGenerator:
             autoescape=select_autoescape()
         )
         self.env.filters['format_value'] = format_value
+        self.env.filters['format_table_cell'] = format_table_cell
 
     def render_pattern(self, pattern: Pattern) -> str:
         template = self.env.get_template('pattern.rst.j2')

--- a/src/templates/instance_table.rst.j2
+++ b/src/templates/instance_table.rst.j2
@@ -15,6 +15,6 @@
            {%- set ns.val = assignment.value -%}
          {%- endif -%}
        {%- endfor -%}
-       {{ ns.val|format_value }}
+       {{ ns.val|format_value|format_table_cell|indent(7) }}
 {%- endfor %}
 {%- endfor %}

--- a/src/transformer.py
+++ b/src/transformer.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import ast
 
 # Add src/generated to sys.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), 'generated')))
@@ -71,7 +72,7 @@ class SourcePatternsTransformer(SourcePatternsVisitor):
     def visitMetaDefinition(self, ctx: SourcePatternsParser.MetaDefinitionContext):
         key = ctx.IDENTIFIER(0).getText()
         if ctx.STRING():
-            value = ctx.STRING().getText()[1:-1]
+            value = ast.literal_eval(ctx.STRING().getText())
         else:
             value = ctx.IDENTIFIER(1).getText()
         return Metadata(key=key, value=value)
@@ -96,7 +97,7 @@ class SourcePatternsTransformer(SourcePatternsVisitor):
 
     def visitValue(self, ctx: SourcePatternsParser.ValueContext):
         if ctx.STRING():
-            return ctx.STRING().getText()[1:-1]
+            return ast.literal_eval(ctx.STRING().getText())
         if ctx.NUMBER():
             val = ctx.NUMBER().getText()
             return float(val) if '.' in val else int(val)
@@ -136,5 +137,5 @@ class SourcePatternsTransformer(SourcePatternsVisitor):
         return ReturnInstruction(value=value)
 
     def visitRawInstruction(self, ctx: SourcePatternsParser.RawInstructionContext):
-        snippet = ctx.STRING().getText()[1:-1]
+        snippet = ast.literal_eval(ctx.STRING().getText())
         return RawInstruction(snippet=snippet)


### PR DESCRIPTION
This change fixes the issue where multi-line examples in the documentation's comparison tables were rendered on a single line. 

Key changes:
1. **String Unescaping**: Updated the DSL transformer to use `ast.literal_eval`, which correctly handles escape sequences like `\n` and `\"` in the input `.patterns` files.
2. **reST Line Blocks**: Introduced a `format_table_cell` filter in the code generator that detects multi-line strings and formats them using reStructuredText line blocks (`| `).
3. **Table Alignment**: Updated the instance table template to apply the line-block filter and use an indentation of 7 spaces, ensuring that multi-line cell content is perfectly aligned within the `list-table` structure.

Verified with a reproduction script and by regenerating the documentation for all existing patterns.

Fixes #125

---
*PR created automatically by Jules for task [14470584651301233605](https://jules.google.com/task/14470584651301233605) started by @chatelao*