### PR TITLE
Improve readability of block-based pattern syntax examples

### DIFF
--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -150,14 +150,14 @@ instance CIfElse of IfElse {
     condition = "x > 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "if (x > 0) { return 1; } else { return 0; }"
+    syntax = "if (x > 0) {\n    return 1;\n} else {\n    return 0;\n}"
     notes = "Standard C if-else statement."
 }
 
 instance CLoop of Loop {
     condition = "x > 0"
     body = { raw "x = x - 1;" }
-    syntax = "while (x > 0) { x = x - 1; }"
+    syntax = "while (x > 0) {\n    x = x - 1;\n}"
     notes = "Standard C while loop."
 }
 
@@ -165,14 +165,14 @@ instance JavaIfElse of IfElse {
     condition = "x > 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "if (x > 0) { return 1; } else { return 0; }"
+    syntax = "if (x > 0) {\n    return 1;\n} else {\n    return 0;\n}"
     notes = "Identical to C."
 }
 
 instance JavaLoop of Loop {
     condition = "x > 0"
     body = { raw "x = x - 1;" }
-    syntax = "while (x > 0) { x = x - 1; }"
+    syntax = "while (x > 0) {\n    x = x - 1;\n}"
     notes = "Identical to C."
 }
 
@@ -180,14 +180,14 @@ instance RustIfElse of IfElse {
     condition = "x > 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "if x > 0 { 1 } else { 0 }"
+    syntax = "if x > 0 {\n    1\n} else {\n    0\n}"
     notes = "Rust if-else is an expression; parentheses around condition are not required."
 }
 
 instance RustLoop of Loop {
     condition = "x > 0"
     body = { raw "x -= 1;" }
-    syntax = "while x > 0 { x -= 1; }"
+    syntax = "while x > 0 {\n    x -= 1;\n}"
     notes = "Condition does not require parentheses."
 }
 
@@ -210,14 +210,14 @@ instance BashIfElse of IfElse {
     condition = "x -gt 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "if [ $x -gt 0 ]; then exit 1; else exit 0; fi"
+    syntax = "if [ $x -gt 0 ]; then\n    exit 1\nelse\n    exit 0\nfi"
     notes = "Uses if-then-else-fi structure; brackets are for test command."
 }
 
 instance BashLoop of Loop {
     condition = "x -gt 0"
     body = { raw "x=$((x-1))" }
-    syntax = "while [ $x -gt 0 ]; do x=$((x-1)); done"
+    syntax = "while [ $x -gt 0 ]; do\n    x=$((x-1))\ndone"
     notes = "Uses while-do-done structure."
 }
 
@@ -225,14 +225,14 @@ instance PowerShellIfElse of IfElse {
     condition = "$x -gt 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "if ($x -gt 0) { return 1 } else { return 0 }"
+    syntax = "if ($x -gt 0) {\n    return 1\n} else {\n    return 0\n}"
     notes = "Uses PowerShell comparison operators (e.g., -gt)."
 }
 
 instance PowerShellLoop of Loop {
     condition = "$x -gt 0"
     body = { raw "$x = $x - 1" }
-    syntax = "while ($x -gt 0) { $x = $x - 1 }"
+    syntax = "while ($x -gt 0) {\n    $x = $x - 1\n}"
     notes = "Standard while loop with C-like block syntax."
 }
 
@@ -255,14 +255,14 @@ instance SqlIfElse of IfElse {
     condition = "@x > 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "IF @x > 0 BEGIN RETURN 1 END ELSE BEGIN RETURN 0 END"
+    syntax = "IF @x > 0\nBEGIN\n    RETURN 1\nEND\nELSE\nBEGIN\n    RETURN 0\nEND"
     notes = "Uses IF-ELSE with BEGIN-END blocks."
 }
 
 instance SqlLoop of Loop {
     condition = "@x > 0"
     body = { raw "SET @x = @x - 1" }
-    syntax = "WHILE @x > 0 BEGIN SET @x = @x - 1 END"
+    syntax = "WHILE @x > 0\nBEGIN\n    SET @x = @x - 1\nEND"
     notes = "Standard WHILE loop in T-SQL."
 }
 
@@ -323,7 +323,7 @@ instance CudaIfElse of IfElse {
     condition = "x > 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "if (x > 0) { return 1; } else { return 0; }"
+    syntax = "if (x > 0) {\n    return 1;\n} else {\n    return 0;\n}"
     notes = "Standard C-like if-else statement."
 }
 
@@ -345,7 +345,7 @@ instance CssLoop of Loop {
 instance CudaLoop of Loop {
     condition = "x > 0"
     body = { raw "x = x - 1;" }
-    syntax = "while (x > 0) { x = x - 1; }"
+    syntax = "while (x > 0) {\n    x = x - 1;\n}"
     notes = "Standard C-like while loop."
 }
 
@@ -361,7 +361,7 @@ instance CFunction of FunctionDefinition {
     parameters = ["int a", "int b"]
     return_type = "int"
     body = { raw "return a + b;" }
-    syntax = "int add(int a, int b) { return a + b; }"
+    syntax = "int add(int a, int b) {\n    return a + b;\n}"
     notes = "Standard C function with static types and curly braces."
 }
 
@@ -370,7 +370,7 @@ instance JavaFunction of FunctionDefinition {
     parameters = ["int a", "int b"]
     return_type = "int"
     body = { raw "return a + b;" }
-    syntax = "public int add(int a, int b) { return a + b; }"
+    syntax = "public int add(int a, int b) {\n    return a + b;\n}"
     notes = "Similar to C, but typically within a class with an access modifier."
 }
 
@@ -379,7 +379,7 @@ instance RustFunction of FunctionDefinition {
     parameters = ["a: i32", "b: i32"]
     return_type = "i32"
     body = { raw "a + b" }
-    syntax = "fn add(a: i32, b: i32) -> i32 { a + b }"
+    syntax = "fn add(a: i32, b: i32) -> i32 {\n    a + b\n}"
     notes = "Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly."
 }
 
@@ -388,7 +388,7 @@ instance PythonFunction of FunctionDefinition {
     parameters = ["a", "b"]
     return_type = "Dynamic"
     body = { raw "return a + b" }
-    syntax = "def add(a, b): return a + b"
+    syntax = "def add(a, b):\n    return a + b"
     notes = "Uses 'def' keyword; indentation defines the block."
 }
 
@@ -397,7 +397,7 @@ instance BashFunction of FunctionDefinition {
     parameters = ["$1", "$2"]
     return_type = "Exit Code / Stdout"
     body = { raw "echo $(($1 + $2))" }
-    syntax = "add() { echo $(($1 + $2)); }"
+    syntax = "add() {\n    echo $(($1 + $2))\n}"
     notes = "Parameters are accessed via $1, $2, etc.; return values are typically exit codes or printed to stdout."
 }
 
@@ -406,7 +406,7 @@ instance PowerShellFunction of FunctionDefinition {
     parameters = ["$a", "$b"]
     return_type = "Dynamic"
     body = { raw "return $a + $b" }
-    syntax = "function add($a, $b) { return $a + $b }"
+    syntax = "function add($a, $b) {\n    return $a + $b\n}"
     notes = "Uses 'function' keyword; parameters are variables starting with $."
 }
 
@@ -424,7 +424,7 @@ instance SqlFunction of FunctionDefinition {
     parameters = ["@a INT", "@b INT"]
     return_type = "INT"
     body = { raw "RETURN @a + @b" }
-    syntax = "CREATE FUNCTION add(@a INT, @b INT) RETURNS INT AS BEGIN RETURN @a + @b END"
+    syntax = "CREATE FUNCTION add(@a INT, @b INT)\nRETURNS INT AS\nBEGIN\n    RETURN @a + @b\nEND"
     notes = "T-SQL syntax for Scalar-Valued Functions."
 }
 
@@ -451,7 +451,7 @@ instance XQueryFunction of FunctionDefinition {
     parameters = ["$a as xs:integer", "$b as xs:integer"]
     return_type = "xs:integer"
     body = { raw "$a + $b" }
-    syntax = "declare function local:add($a as xs:integer, $b as xs:integer) as xs:integer { $a + $b };"
+    syntax = "declare function local:add(\n    $a as xs:integer,\n    $b as xs:integer\n) as xs:integer {\n    $a + $b\n};"
     notes = "Functions must be declared in a namespace (e.g., 'local')."
 }
 
@@ -469,7 +469,7 @@ instance CudaFunction of FunctionDefinition {
     parameters = ["int a", "int b"]
     return_type = "int"
     body = { raw "return a + b;" }
-    syntax = "__device__ int add(int a, int b) { return a + b; }"
+    syntax = "__device__ int add(int a, int b) {\n    return a + b;\n}"
     notes = "Functions can be qualified with __device__, __host__, or __global__."
 }
 
@@ -514,7 +514,7 @@ instance JavaTryCatch of TryCatch {
     exception_type = "Exception"
     error_variable = "e"
     catch_body = { call handle(e) }
-    syntax = "try { do_something(); } catch (Exception e) { handle(e); }"
+    syntax = "try {\n    do_something();\n} catch (Exception e) {\n    handle(e);\n}"
     notes = "Standard Java exception handling."
 }
 
@@ -523,7 +523,7 @@ instance RustTryCatch of TryCatch {
     exception_type = "Result"
     error_variable = "e"
     catch_body = { call handle(e) }
-    syntax = "match do_something() { Ok(v) => v, Err(e) => handle(e) }"
+    syntax = "match do_something() {\n    Ok(v) => v,\n    Err(e) => handle(e)\n}"
     notes = "Rust uses Result type and pattern matching instead of traditional try-catch."
 }
 
@@ -585,7 +585,7 @@ instance PowerShellTryCatch of TryCatch {
     exception_type = "ErrorRecord"
     error_variable = "PSItem"
     catch_body = { call handle_error(PSItem) }
-    syntax = "try { do_something } catch { handle_error($_) }"
+    syntax = "try {\n    do_something\n} catch {\n    handle_error($_)\n}"
     notes = "PowerShell supports try-catch-finally blocks; $_ (or $PSItem) refers to the current error."
 }
 
@@ -633,7 +633,7 @@ instance ErlangTryCatch of TryCatch {
     exception_type = "error"
     error_variable = "Reason"
     catch_body = { call handle(Reason) }
-    syntax = "try do_something() catch error:Reason -> handle(Reason) end"
+    syntax = "try\n    do_something()\ncatch\n    error:Reason -> handle(Reason)\nend"
     notes = "Erlang uses try...catch blocks; the type can be throw, error, or exit (defaulting to throw if omitted)."
 }
 
@@ -665,7 +665,7 @@ instance XQueryTryCatch of TryCatch {
     exception_type = "*"
     error_variable = "err"
     catch_body = { raw "handle($err)" }
-    syntax = "try { do_something() } catch * { handle($err) }"
+    syntax = "try {\n    do_something()\n} catch * {\n    handle($err)\n}"
     notes = "XQuery 3.0+ supports try-catch; $err is a variable containing error information."
 }
 


### PR DESCRIPTION
Reformatted block-based pattern syntax (Loop, IfElse, FunctionDefinition, TryCatch) in `patterns/programming.patterns` to use multi-line strings for better readability. Verified with tests and manual inspection.

Fixes #131

---
*PR created automatically by Jules for task [779278498530983813](https://jules.google.com/task/779278498530983813) started by @chatelao*