### PR TITLE
Indent x86 assembler instructions according to usual conventions

### DIFF
--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -1,5 +1,5 @@
-Programming Language Patterns
-=============================
+Programming Patterns
+====================
 
 
 
@@ -201,8 +201,11 @@ Parameters:
      - add
      - [%1, %2]
      - ErrorLevel
-     - { raw "set /a res=%1+%2\nexit /b %res%" }
-     - :add\nset /a res=%~1+%~2\nexit /b %res%
+     - | { raw "set /a res=%1+%2
+       | exit /b %res%" }
+     - | :add
+       | set /a res=%~1+%~2
+       | exit /b %res%
      - Functions are labels; called with 'call :label'; arguments are %1, %2.
    * - SqlFunction
      - add
@@ -250,8 +253,11 @@ Parameters:
      - add
      - [eax, ebx]
      - eax
-     - { raw "add eax, ebx\nret" }
-     - add_func:\nadd eax, ebx\nret
+     - | { raw "    add eax, ebx
+       |     ret" }
+     - | add_func:
+       |     add eax, ebx
+       |     ret
      - Functions are labels; parameters usually passed via registers or stack.
 
 
@@ -369,7 +375,13 @@ Parameters:
      - eax > 0
      - { return 1 }
      - { return 0 }
-     - cmp eax, 0\njle .else\nmov eax, 1\njmp .end\n.else:\nmov eax, 0\n.end:
+     - |     cmp eax, 0
+       |     jle .else
+       |     mov eax, 1
+       |     jmp .end
+       | .else:
+       |     mov eax, 0
+       | .end:
      - Implemented using comparison and jump instructions (Intel syntax).
 
 
@@ -435,7 +447,8 @@ Parameters:
    * - CmdLoop
      - x GTR 0
      - { raw "set /a x=x-1" }
-     - :loop\nif %x% GTR 0 (set /a x=x-1 & goto loop)
+     - | :loop
+       | if %x% GTR 0 (set /a x=x-1 & goto loop)
      - Loops are typically implemented using labels and goto.
    * - SqlLoop
      - @x > 0
@@ -469,8 +482,13 @@ Parameters:
      - Standard C-like while loop.
    * - X86Loop
      - ecx > 0
-     - { raw "dec ecx" }
-     - .loop:\ncmp ecx, 0\njle .end\ndec ecx\njmp .loop\n.end:
+     - { raw "    dec ecx" }
+     - | .loop:
+       |     cmp ecx, 0
+       |     jle .end
+       |     dec ecx
+       |     jmp .loop
+       | .end:
      - Implemented using labels and conditional jumps.
 
 
@@ -535,7 +553,10 @@ Parameters:
      - Exception
      - e
      - { call handle(e) }
-     - try:\n    do_something()\nexcept Exception as e:\n    handle(e)
+     - | try:
+       |     do_something()
+       | except Exception as e:
+       |     handle(e)
      - Standard Python exception handling using try-except.
    * - BashTryCatch
      - { call do_something() }
@@ -563,7 +584,12 @@ Parameters:
      - Error
      - @@ERROR
      - { call handle_error() }
-     - BEGIN TRY\n    EXEC do_something;\nEND TRY\nBEGIN CATCH\n    EXEC handle_error;\nEND CATCH
+     - | BEGIN TRY
+       |     EXEC do_something;
+       | END TRY
+       | BEGIN CATCH
+       |     EXEC handle_error;
+       | END CATCH
      - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
    * - ErlangTryCatch
      - { call do_something() }
@@ -646,17 +672,17 @@ Parameters:
    * - JavaRaise
      - RuntimeException
      - Error
-     - throw new RuntimeException(\"Error\");
+     - throw new RuntimeException("Error");
      - Uses 'throw' to raise an exception.
    * - RustRaise
      - Panic
      - Error
-     - panic!(\"Error\");
+     - panic!("Error");
      - Uses 'panic!' for unrecoverable errors.
    * - PythonRaise
      - Exception
      - Error
-     - raise Exception(\"Error\")
+     - raise Exception("Error")
      - Uses 'raise' to trigger an exception.
    * - BashRaise
      - Exit
@@ -666,7 +692,7 @@ Parameters:
    * - PowerShellRaise
      - Exception
      - Error
-     - throw \"Error\"
+     - throw "Error"
      - Uses 'throw' to create a terminating error.
    * - CmdRaise
      - ErrorLevel
@@ -681,12 +707,12 @@ Parameters:
    * - ErlangRaise
      - error
      - Error
-     - error(\"Error\")
+     - error("Error")
      - The error/1 BIF is used to stop execution and provide a stack trace.
    * - LispRaise
      - error
      - Error
-     - (error \"Error\")
+     - (error "Error")
      - Signals a continuous error that must be handled or it enters the debugger.
    * - XQueryRaise
      - error
@@ -706,7 +732,7 @@ Parameters:
    * - X86Raise
      - Interrupt
      - Error
-     - int 3
+     -     int 3
      - Software interrupts (like int 3) can be used to signal errors or breakpoints.
 
 
@@ -754,7 +780,8 @@ Parameters:
      - Launches a grid of threads on the GPU.
    * - X86Thread
      - { call do_work() }
-     - push offset do_work\ncall CreateThread
+     - |     push offset do_work
+       |     call CreateThread
      - Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread).
 
 
@@ -810,7 +837,9 @@ Parameters:
    * - X86SendMessage
      - thread_id
      - msg
-     - push msg\npush thread_id\ncall PostThreadMessage
+     - |     push msg
+       |     push thread_id
+       |     call PostThreadMessage
      - Message passing is done via OS APIs.
 
 
@@ -866,13 +895,13 @@ Parameters:
    * - X86ReceiveMessage
      - msg
      - { call handle(msg) }
-     - call GetMessage
+     -     call GetMessage
      - Message retrieval via OS APIs.
 
 
 
 Comment
-=======
+-------
 
 
 :description: Way to add non-executable explanatory text to the source code.
@@ -898,19 +927,23 @@ Parameters:
      - notes
    * - CComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Standard C comment syntax.
    * - JavaComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Identical to C.
    * - RustComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Supports nested multi-line comments.
    * - PythonComment
      - # comment
-     - \"\"\" line 1\n    line 2 \"\"\"
+     - | """ line 1
+       |     line 2 """
      - Multi-line comments are typically implemented using docstrings.
    * - BashComment
      - # comment
@@ -918,7 +951,8 @@ Parameters:
      - Bash only supports single-line comments starting with #.
    * - PowerShellComment
      - # comment
-     - <# line 1\n   line 2 #>
+     - | <# line 1
+       |    line 2 #>
      - Uses <# and #> for block comments.
    * - CmdComment
      - REM comment
@@ -926,7 +960,8 @@ Parameters:
      - Uses REM or :: (label hack) for comments.
    * - SqlComment
      - -- comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Standard SQL comment syntax.
    * - ErlangComment
      - % comment
@@ -934,21 +969,25 @@ Parameters:
      - Erlang only supports single-line comments starting with %.
    * - LispComment
      - ; comment
-     - #| line 1\n   line 2 |#
+     - | #| line 1
+       |    line 2 |#
      - Single-line comments use semicolon; multi-line use #| |#.
    * - XQueryComment
      - (: comment :)
-     - (: line 1\n   line 2 :)
+     - | (: line 1
+       |    line 2 :)
      - XQuery uses (: :) for both single and multi-line comments.
    * - CssComment
      - N/A
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - CSS only supports block comments.
    * - CudaComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Standard C-like comment syntax.
    * - X86Comment
-     - ; comment
+     -     ; comment
      - N/A
      - Most assemblers use semicolon for comments (Intel syntax).

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -331,7 +331,7 @@ instance X86IfElse of IfElse {
     condition = "eax > 0"
     then_branch = { return 1 }
     else_branch = { return 0 }
-    syntax = "cmp eax, 0\njle .else\nmov eax, 1\njmp .end\n.else:\nmov eax, 0\n.end:"
+    syntax = "    cmp eax, 0\n    jle .else\n    mov eax, 1\n    jmp .end\n.else:\n    mov eax, 0\n.end:"
     notes = "Implemented using comparison and jump instructions (Intel syntax)."
 }
 
@@ -351,8 +351,8 @@ instance CudaLoop of Loop {
 
 instance X86Loop of Loop {
     condition = "ecx > 0"
-    body = { raw "dec ecx" }
-    syntax = ".loop:\ncmp ecx, 0\njle .end\ndec ecx\njmp .loop\n.end:"
+    body = { raw "    dec ecx" }
+    syntax = ".loop:\n    cmp ecx, 0\n    jle .end\n    dec ecx\n    jmp .loop\n.end:"
     notes = "Implemented using labels and conditional jumps."
 }
 
@@ -477,8 +477,8 @@ instance X86Function of FunctionDefinition {
     name = "add"
     parameters = ["eax", "ebx"]
     return_type = "eax"
-    body = { raw "add eax, ebx\nret" }
-    syntax = "add_func:\nadd eax, ebx\nret"
+    body = { raw "    add eax, ebx\n    ret" }
+    syntax = "add_func:\n    add eax, ebx\n    ret"
     notes = "Functions are labels; parameters usually passed via registers or stack."
 }
 
@@ -720,7 +720,7 @@ instance CudaRaise of Raise {
 instance X86Raise of Raise {
     exception_type = "Interrupt"
     message = "Error"
-    syntax = "int 3"
+    syntax = "    int 3"
     notes = "Software interrupts (like int 3) can be used to signal errors or breakpoints."
 }
 
@@ -801,7 +801,7 @@ instance CudaThread of Thread {
 
 instance X86Thread of Thread {
     body = { call do_work() }
-    syntax = "push offset do_work\ncall CreateThread"
+    syntax = "    push offset do_work\n    call CreateThread"
     notes = "Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread)."
 }
 
@@ -822,7 +822,7 @@ instance CudaSendMessage of SendMessage {
 instance X86SendMessage of SendMessage {
     recipient = "thread_id"
     message = "msg"
-    syntax = "push msg\npush thread_id\ncall PostThreadMessage"
+    syntax = "    push msg\n    push thread_id\n    call PostThreadMessage"
     notes = "Message passing is done via OS APIs."
 }
 
@@ -843,7 +843,7 @@ instance CudaReceiveMessage of ReceiveMessage {
 instance X86ReceiveMessage of ReceiveMessage {
     match_pattern = "msg"
     body = { call handle(msg) }
-    syntax = "call GetMessage"
+    syntax = "    call GetMessage"
     notes = "Message retrieval via OS APIs."
 }
 
@@ -933,7 +933,7 @@ instance CudaComment of Comment {
 }
 
 instance X86Comment of Comment {
-    single_line = "; comment"
+    single_line = "    ; comment"
     multi_line = "N/A"
     notes = "Most assemblers use semicolon for comments (Intel syntax)."
 }


### PR DESCRIPTION
This change indents x86 assembler instructions in the `patterns/programming.patterns` file and the generated `docs/programming.rst` documentation. Instructions (e.g., `mov`, `cmp`, `push`) are now indented by 4 spaces, while labels (e.g., `.loop:`, `add_func:`) remain flush left at column 0. This follows standard assembler conventions and improves readability of the comparative documentation. Additionally, the `body` parameter for x86 loops and functions was also updated to reflect this indentation.

Fixes #132

---
*PR created automatically by Jules for task [3974203820500240797](https://jules.google.com/task/3974203820500240797) started by @chatelao*