### PR TITLE
Implement Coverage Summary and Refine Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,6 +109,8 @@
             - [x] 9.5.2.2 XML (XSD/DTD) <!-- 2026-05-11, issue #9.5.2.2 -->
             - [x] 9.5.2.3 YAML (JSON Schema/Custom) <!-- 2026-05-11, issue #9.5.2.3 -->
             - [x] 9.5.2.4 TOML <!-- 2026-05-11, issue #9.5.2.4 -->
+    - [ ] 9.6 Implement CSV instances <!-- issue #9.6 -->
+    - [ ] 9.7 Implement Fixlength instances <!-- issue #9.7 -->
 
 ## Phase 4: Publication
 - [x] Configure ReadTheDocs integration <!-- 2026-05-03, issue #10 -->
@@ -118,5 +120,5 @@
 - [ ] Final review and polish of the comparative book <!-- issue #11 -->
     - [ ] 11.1 Verify consistency of pattern descriptions and parameter names <!-- issue #11.1 -->
     - [ ] 11.2 Review generated reST for formatting issues or table alignment problems <!-- issue #11.2 -->
-    - [ ] 11.3 Add a "Language/Format Coverage" summary to the documentation <!-- issue #11.3 -->
+    - [x] 11.3 Add a "Language/Format Coverage" summary to the documentation <!-- 2026-05-24, issue #11.3 -->
     - [ ] 11.4 Final verification of the Read the Docs build process <!-- issue #11.4 -->

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,37 @@
+# Language and Format Coverage
+
+This page provides an overview of the implementation status for all patterns across supported programming languages and data formats.
+
+## Programming Languages
+
+| Language | Var | Fun | If | Loop | Try | Raise | Thread | Send | Recv | Comment |
+|----------|:---:|:---:|:--:|:----:|:---:|:-----:|:------:|:----:|:----:|:-------:|
+| C | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Java | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Rust | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Python | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Bash | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| PowerShell | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Cmd | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| SQL | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Erlang | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Lisp | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| XQuery | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| CSS | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| CUDA | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| x86 Assembler | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+*Legend: ✅ = Implemented, ❌ = Not yet implemented.*
+
+## Data Formats
+
+| Format | Basic | Coll | Map | Meta | Comment | Schema |
+|--------|:-----:|:----:|:---:|:----:|:-------:|:------:|
+| JSON | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| XML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| YAML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| TOML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| CSV | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Fixlength | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+*Legend: ✅ = Implemented, ❌ = Not yet implemented.*

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -32,7 +32,7 @@ Parameters:
      - boolean_val
      - notes
    * - JsonBasic
-     - \"Hello\"
+     - "Hello"
      - 42 or 3.14
      - true / false
      - Standard JSON types; strings must be double-quoted.
@@ -42,12 +42,12 @@ Parameters:
      - <tag>true</tag>
      - XML is text-based; types are typically inferred or defined by a schema (XSD).
    * - YamlBasic
-     - Hello or 'Hello' or \"Hello\"
+     - Hello or 'Hello' or "Hello"
      - 42 or 3.14
      - true / false (or yes/no, on/off in YAML 1.1)
      - YAML supports plain, single-quoted, and double-quoted strings.
    * - TomlBasic
-     - \"Hello\"
+     - "Hello"
      - 42 or 3.14
      - true / false
      - TOML is strictly typed; strings must be double-quoted.
@@ -81,15 +81,20 @@ Parameters:
      - notes
    * - JsonCollection
      - Any JSON value
-     - [1, \"two\", true]
+     - [1, "two", true]
      - Elements are comma-separated and enclosed in square brackets.
    * - XmlCollection
      - Repeated child elements
-     - <list>\n  <item>1</item>\n  <item>2</item>\n</list>
+     - | <list>
+       |   <item>1</item>
+       |   <item>2</item>
+       | </list>
      - Collections are typically represented by repeating elements under a parent.
    * - YamlCollection
      - Any YAML value
-     - - 1\n- two\n- true
+     - | - 1
+       | - two
+       | - true
      - Uses a dash followed by a space for each element.
    * - TomlCollection
      - Any TOML value
@@ -125,19 +130,24 @@ Parameters:
      - notes
    * - JsonMapping
      - Key-value pairs
-     - {\"key\": \"value\", \"num\": 42}
+     - {"key": "value", "num": 42}
      - Keys must be double-quoted strings.
    * - XmlMapping
      - Child elements or attributes
-     - <object>\n  <key>value</key>\n  <num>42</num>\n</object>
+     - | <object>
+       |   <key>value</key>
+       |   <num>42</num>
+       | </object>
      - Mappings are represented as nested elements.
    * - YamlMapping
      - Key-value pairs
-     - key: value\nnum: 42
+     - | key: value
+       | num: 42
      - Uses a colon followed by a space to separate key and value.
    * - TomlMapping
      - Key-value pairs
-     - key = \"value\"\nnum = 42
+     - | key = "value"
+       | num = 42
      - Top-level or grouped using [headers].
 
 
@@ -166,12 +176,12 @@ Parameters:
      - notes
    * - JsonMetadata
      - N/A
-     - JSON does not support metadata or attributes on elements; often simulated using underscore-prefixed keys (e.g., \"_metadata\": { ... }).
+     - JSON does not support metadata or attributes on elements; often simulated using underscore-prefixed keys (e.g., "_metadata": { ... }).
    * - XmlMetadata
-     - <element attr=\"value\">Content</element>
+     - <element attr="value">Content</element>
      - XML has native support for attributes on elements.
    * - YamlMetadata
-     - !!str \"value\" or !custom { key: val }
+     - !!str "value" or !custom { key: val }
      - YAML supports tags to specify types or attach metadata to nodes.
    * - TomlMetadata
      - N/A
@@ -210,15 +220,20 @@ Parameters:
      - JSON does not natively support comments.
    * - XmlComment
      - <!-- comment -->
-     - <!--\n  line 1\n  line 2\n-->
+     - | <!--
+       |   line 1
+       |   line 2
+       | -->
      - XML uses the same syntax for single and multi-line comments.
    * - YamlComment
      - # comment
-     - # line 1\n# line 2
+     - | # line 1
+       | # line 2
      - YAML only supports single-line comments starting with #.
    * - TomlComment
      - # comment
-     - # line 1\n# line 2
+     - | # line 1
+       | # line 2
      - TOML only supports single-line comments starting with #.
 
 
@@ -246,10 +261,11 @@ Parameters:
      - syntax
      - notes
    * - JsonSchemaLink
-     - \"\$schema\": \"http://json-schema.org/draft-07/schema#\"
+     - "\$schema": "http://json-schema.org/draft-07/schema#"
      - JSON uses the \$schema keyword to point to a JSON Schema file.
    * - XmlSchemaLink
-     - <root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n      xsi:schemaLocation=\"http://example.com schema.xsd\">
+     - | <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       |       xsi:schemaLocation="http://example.com schema.xsd">
      - XML uses the xsi:schemaLocation attribute to link to an XSD.
    * - YamlSchemaLink
      - # yaml-language-server: \$schema=<url_or_path>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to the Bible of Babylon Documentation
 
    programming
    data_formats
+   coverage
 
 Indices and tables
 ==================

--- a/docs/programming.rst
+++ b/docs/programming.rst
@@ -201,8 +201,11 @@ Parameters:
      - add
      - [%1, %2]
      - ErrorLevel
-     - { raw "set /a res=%1+%2\nexit /b %res%" }
-     - :add\nset /a res=%~1+%~2\nexit /b %res%
+     - | { raw "set /a res=%1+%2
+       | exit /b %res%" }
+     - | :add
+       | set /a res=%~1+%~2
+       | exit /b %res%
      - Functions are labels; called with 'call :label'; arguments are %1, %2.
    * - SqlFunction
      - add
@@ -250,8 +253,11 @@ Parameters:
      - add
      - [eax, ebx]
      - eax
-     - { raw "add eax, ebx\nret" }
-     - add_func:\nadd eax, ebx\nret
+     - | { raw "add eax, ebx
+       | ret" }
+     - | add_func:
+       | add eax, ebx
+       | ret
      - Functions are labels; parameters usually passed via registers or stack.
 
 
@@ -369,7 +375,13 @@ Parameters:
      - eax > 0
      - { return 1 }
      - { return 0 }
-     - cmp eax, 0\njle .else\nmov eax, 1\njmp .end\n.else:\nmov eax, 0\n.end:
+     - | cmp eax, 0
+       | jle .else
+       | mov eax, 1
+       | jmp .end
+       | .else:
+       | mov eax, 0
+       | .end:
      - Implemented using comparison and jump instructions (Intel syntax).
 
 
@@ -435,7 +447,8 @@ Parameters:
    * - CmdLoop
      - x GTR 0
      - { raw "set /a x=x-1" }
-     - :loop\nif %x% GTR 0 (set /a x=x-1 & goto loop)
+     - | :loop
+       | if %x% GTR 0 (set /a x=x-1 & goto loop)
      - Loops are typically implemented using labels and goto.
    * - SqlLoop
      - @x > 0
@@ -470,7 +483,12 @@ Parameters:
    * - X86Loop
      - ecx > 0
      - { raw "dec ecx" }
-     - .loop:\ncmp ecx, 0\njle .end\ndec ecx\njmp .loop\n.end:
+     - | .loop:
+       | cmp ecx, 0
+       | jle .end
+       | dec ecx
+       | jmp .loop
+       | .end:
      - Implemented using labels and conditional jumps.
 
 
@@ -535,7 +553,10 @@ Parameters:
      - Exception
      - e
      - { call handle(e) }
-     - try:\n    do_something()\nexcept Exception as e:\n    handle(e)
+     - | try:
+       |     do_something()
+       | except Exception as e:
+       |     handle(e)
      - Standard Python exception handling using try-except.
    * - BashTryCatch
      - { call do_something() }
@@ -563,7 +584,12 @@ Parameters:
      - Error
      - @@ERROR
      - { call handle_error() }
-     - BEGIN TRY\n    EXEC do_something;\nEND TRY\nBEGIN CATCH\n    EXEC handle_error;\nEND CATCH
+     - | BEGIN TRY
+       |     EXEC do_something;
+       | END TRY
+       | BEGIN CATCH
+       |     EXEC handle_error;
+       | END CATCH
      - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
    * - ErlangTryCatch
      - { call do_something() }
@@ -646,17 +672,17 @@ Parameters:
    * - JavaRaise
      - RuntimeException
      - Error
-     - throw new RuntimeException(\"Error\");
+     - throw new RuntimeException("Error");
      - Uses 'throw' to raise an exception.
    * - RustRaise
      - Panic
      - Error
-     - panic!(\"Error\");
+     - panic!("Error");
      - Uses 'panic!' for unrecoverable errors.
    * - PythonRaise
      - Exception
      - Error
-     - raise Exception(\"Error\")
+     - raise Exception("Error")
      - Uses 'raise' to trigger an exception.
    * - BashRaise
      - Exit
@@ -666,7 +692,7 @@ Parameters:
    * - PowerShellRaise
      - Exception
      - Error
-     - throw \"Error\"
+     - throw "Error"
      - Uses 'throw' to create a terminating error.
    * - CmdRaise
      - ErrorLevel
@@ -681,12 +707,12 @@ Parameters:
    * - ErlangRaise
      - error
      - Error
-     - error(\"Error\")
+     - error("Error")
      - The error/1 BIF is used to stop execution and provide a stack trace.
    * - LispRaise
      - error
      - Error
-     - (error \"Error\")
+     - (error "Error")
      - Signals a continuous error that must be handled or it enters the debugger.
    * - XQueryRaise
      - error
@@ -754,7 +780,8 @@ Parameters:
      - Launches a grid of threads on the GPU.
    * - X86Thread
      - { call do_work() }
-     - push offset do_work\ncall CreateThread
+     - | push offset do_work
+       | call CreateThread
      - Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread).
 
 
@@ -810,7 +837,9 @@ Parameters:
    * - X86SendMessage
      - thread_id
      - msg
-     - push msg\npush thread_id\ncall PostThreadMessage
+     - | push msg
+       | push thread_id
+       | call PostThreadMessage
      - Message passing is done via OS APIs.
 
 
@@ -872,7 +901,7 @@ Parameters:
 
 
 Comment
-=======
+-------
 
 
 :description: Way to add non-executable explanatory text to the source code.
@@ -898,19 +927,23 @@ Parameters:
      - notes
    * - CComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Standard C comment syntax.
    * - JavaComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Identical to C.
    * - RustComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Supports nested multi-line comments.
    * - PythonComment
      - # comment
-     - \"\"\" line 1\n    line 2 \"\"\"
+     - | """ line 1
+       |     line 2 """
      - Multi-line comments are typically implemented using docstrings.
    * - BashComment
      - # comment
@@ -918,7 +951,8 @@ Parameters:
      - Bash only supports single-line comments starting with #.
    * - PowerShellComment
      - # comment
-     - <# line 1\n   line 2 #>
+     - | <# line 1
+       |    line 2 #>
      - Uses <# and #> for block comments.
    * - CmdComment
      - REM comment
@@ -926,7 +960,8 @@ Parameters:
      - Uses REM or :: (label hack) for comments.
    * - SqlComment
      - -- comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Standard SQL comment syntax.
    * - ErlangComment
      - % comment
@@ -934,19 +969,23 @@ Parameters:
      - Erlang only supports single-line comments starting with %.
    * - LispComment
      - ; comment
-     - #| line 1\n   line 2 |#
+     - | #| line 1
+       |    line 2 |#
      - Single-line comments use semicolon; multi-line use #| |#.
    * - XQueryComment
      - (: comment :)
-     - (: line 1\n   line 2 :)
+     - | (: line 1
+       |    line 2 :)
      - XQuery uses (: :) for both single and multi-line comments.
    * - CssComment
      - N/A
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - CSS only supports block comments.
    * - CudaComment
      - // comment
-     - /* line 1\n   line 2 */
+     - | /* line 1
+       |    line 2 */
      - Standard C-like comment syntax.
    * - X86Comment
      - ; comment


### PR DESCRIPTION
This change implements Roadmap task 11.3 by adding a Language/Format Coverage summary to the documentation. It also refines the ROADMAP.md by identifying and adding missing tasks for CSV and Fixlength data formats as per the project design. Additionally, it regenerates the existing .rst documentation files to ensure consistent formatting and readability.

Fixes #129

---
*PR created automatically by Jules for task [16212302190576292232](https://jules.google.com/task/16212302190576292232) started by @chatelao*