### PR TITLE
Format Syntax columns as code

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -6,11 +6,17 @@ from .models import (
     CallInstruction, AssignInstruction, ReturnInstruction, RawInstruction
 )
 
-def format_table_cell(value: Any) -> str:
-    if isinstance(value, str) and "\n" in value:
-        lines = value.split("\n")
+def format_table_cell(value: Any, is_code: bool = False) -> str:
+    val_str = str(value)
+    if "\n" in val_str:
+        lines = val_str.split("\n")
+        if is_code:
+            return "\n".join(f"| ``{line}``" if line.strip() else "|" for line in lines)
         return "\n".join(f"| {line}" if line.strip() else "|" for line in lines)
-    return str(value)
+
+    if is_code:
+        return f"``{val_str}``"
+    return val_str
 
 def format_value(value) -> str:
     if isinstance(value, str):

--- a/src/templates/instance_table.rst.j2
+++ b/src/templates/instance_table.rst.j2
@@ -15,6 +15,6 @@
            {%- set ns.val = assignment.value -%}
          {%- endif -%}
        {%- endfor -%}
-       {{ ns.val|format_value|format_table_cell|indent(7) }}
+       {{ ns.val|format_value|format_table_cell(param.name == 'syntax')|indent(7) }}
 {%- endfor %}
 {%- endfor %}

--- a/test/test_generator_formatting.py
+++ b/test/test_generator_formatting.py
@@ -1,0 +1,69 @@
+import pytest
+from src.models import Program, Pattern, Instance, Parameter, Type, Assignment
+from src.generator import CodeGenerator, format_table_cell
+
+def test_format_table_cell_basic():
+    assert format_table_cell("hello") == "hello"
+    assert format_table_cell(42) == "42"
+
+def test_format_table_cell_code():
+    assert format_table_cell("hello", is_code=True) == "``hello``"
+    assert format_table_cell(42, is_code=True) == "``42``"
+
+def test_format_table_cell_multiline():
+    val = "line 1\nline 2"
+    expected = "| line 1\n| line 2"
+    assert format_table_cell(val) == expected
+
+def test_format_table_cell_multiline_code():
+    val = "line 1\nline 2"
+    expected = "| ``line 1``\n| ``line 2``"
+    assert format_table_cell(val, is_code=True) == expected
+
+def test_render_syntax_column_as_code():
+    pattern = Pattern(
+        name="TestPattern",
+        parameters=[
+            Parameter(name="syntax", type=Type(name="String")),
+            Parameter(name="notes", type=Type(name="String"))
+        ]
+    )
+    instances = [
+        Instance(
+            name="TestInstance",
+            pattern_name="TestPattern",
+            assignments=[
+                Assignment(name="syntax", value="code_here"),
+                Assignment(name="notes", value="some notes")
+            ]
+        )
+    ]
+    program = Program(patterns=[pattern], instances=instances)
+    generator = CodeGenerator()
+    output = generator.render_program(program)
+
+    assert "  - ``code_here``" in output
+    assert "  - some notes" in output
+
+def test_render_multiline_syntax_column_as_code():
+    pattern = Pattern(
+        name="TestPattern",
+        parameters=[
+            Parameter(name="syntax", type=Type(name="String"))
+        ]
+    )
+    instances = [
+        Instance(
+            name="TestInstance",
+            pattern_name="TestPattern",
+            assignments=[
+                Assignment(name="syntax", value="line 1\nline 2")
+            ]
+        )
+    ]
+    program = Program(patterns=[pattern], instances=instances)
+    generator = CodeGenerator()
+    output = generator.render_program(program)
+
+    assert "  - | ``line 1``" in output
+    assert "    | ``line 2``" in output


### PR DESCRIPTION
This change formats the "Syntax" columns in the pattern comparison tables as code using fixed-width font (double backticks in reStructuredText). It correctly handles both single-line and multi-line syntax snippets while maintaining the table structure.

Fixes #146

---
*PR created automatically by Jules for task [4899883265468304812](https://jules.google.com/task/4899883265468304812) started by @chatelao*