### PR TITLE
Implement CSV data format instances and refine roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -109,8 +109,12 @@
             - [x] 9.5.2.2 XML (XSD/DTD) <!-- 2026-05-11, issue #9.5.2.2 -->
             - [x] 9.5.2.3 YAML (JSON Schema/Custom) <!-- 2026-05-11, issue #9.5.2.3 -->
             - [x] 9.5.2.4 TOML <!-- 2026-05-11, issue #9.5.2.4 -->
-    - [ ] 9.6 Implement CSV instances <!-- issue #9.6 -->
+    - [x] 9.6 Implement CSV instances <!-- issue #9.6 -->
+        - [x] 9.6.1 Basic types, Collections, and Mappings <!-- issue #9.6.1 -->
+        - [x] 9.6.2 Metadata, Comments, and Schema links <!-- issue #9.6.2 -->
     - [ ] 9.7 Implement Fixlength instances <!-- issue #9.7 -->
+        - [ ] 9.7.1 Basic types, Collections, and Mappings <!-- issue #9.7.1 -->
+        - [ ] 9.7.2 Metadata, Comments, and Schema links <!-- issue #9.7.2 -->
 
 ## Phase 4: Publication
 - [x] Configure ReadTheDocs integration <!-- 2026-05-03, issue #10 -->

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -31,7 +31,7 @@ This page provides an overview of the implementation status for all patterns acr
 | XML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | YAML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | TOML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| CSV | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| CSV | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Fixlength | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 *Legend: ✅ = Implemented, ❌ = Not yet implemented.*

--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -51,6 +51,11 @@ Parameters:
      - 42 or 3.14
      - true / false
      - TOML is strictly typed; strings must be double-quoted.
+   * - CsvBasic
+     - Hello or "Hello"
+     - 42 or 3.14
+     - true / false
+     - CSV values are typically plain text; quoting is used for values containing delimiters or newlines.
 
 
 
@@ -100,6 +105,10 @@ Parameters:
      - Any TOML value
      - [1, 2, 3]
      - Arrays can contain values of different types since TOML 1.0.0.
+   * - CsvCollection
+     - Comma-separated values
+     - 1,two,true
+     - A single row represents a collection of fields.
 
 
 
@@ -149,6 +158,11 @@ Parameters:
      - | key = "value"
        | num = 42
      - Top-level or grouped using [headers].
+   * - CsvMapping
+     - Header to field mapping
+     - | Name,Age
+       | Alice,30
+     - Mappings are established by associating header names with column values.
 
 
 
@@ -186,6 +200,9 @@ Parameters:
    * - TomlMetadata
      - N/A
      - TOML does not support per-element metadata, though it uses headers for grouping.
+   * - CsvMetadata
+     - N/A
+     - Standard CSV (RFC 4180) does not support metadata or attributes.
 
 
 
@@ -235,6 +252,10 @@ Parameters:
      - | # line 1
        | # line 2
      - TOML only supports single-line comments starting with #.
+   * - CsvComment
+     - N/A
+     - N/A
+     - Standard CSV does not natively support comments; some variations use #.
 
 
 
@@ -273,3 +294,6 @@ Parameters:
    * - TomlSchemaLink
      - N/A
      - TOML does not have a native or widely standardized way to link to a schema within the file.
+   * - CsvSchemaLink
+     - N/A
+     - CSV does not have a native schema linking mechanism; often defined in a sidecar file (e.g., CSVW metadata).

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -34,6 +34,13 @@ instance TomlBasic of BasicTypes {
     notes = "TOML is strictly typed; strings must be double-quoted."
 }
 
+instance CsvBasic of BasicTypes {
+    string_val = "Hello or \"Hello\""
+    number_val = "42 or 3.14"
+    boolean_val = "true / false"
+    notes = "CSV values are typically plain text; quoting is used for values containing delimiters or newlines."
+}
+
 pattern Collection {
     meta description: "Ordered sequence of elements (Arrays, Lists, or Sequences)."
     parameter elements: String
@@ -63,6 +70,12 @@ instance TomlCollection of Collection {
     elements = "Any TOML value"
     syntax = "[1, 2, 3]"
     notes = "Arrays can contain values of different types since TOML 1.0.0."
+}
+
+instance CsvCollection of Collection {
+    elements = "Comma-separated values"
+    syntax = "1,two,true"
+    notes = "A single row represents a collection of fields."
 }
 
 pattern Mapping {
@@ -96,6 +109,12 @@ instance TomlMapping of Mapping {
     notes = "Top-level or grouped using [headers]."
 }
 
+instance CsvMapping of Mapping {
+    entries = "Header to field mapping"
+    syntax = "Name,Age\nAlice,30"
+    notes = "Mappings are established by associating header names with column values."
+}
+
 pattern Metadata {
     meta description: "Way to attach metadata or attributes to data elements."
     parameter syntax: String
@@ -120,6 +139,11 @@ instance YamlMetadata of Metadata {
 instance TomlMetadata of Metadata {
     syntax = "N/A"
     notes = "TOML does not support per-element metadata, though it uses headers for grouping."
+}
+
+instance CsvMetadata of Metadata {
+    syntax = "N/A"
+    notes = "Standard CSV (RFC 4180) does not support metadata or attributes."
 }
 
 pattern Comment {
@@ -153,6 +177,12 @@ instance TomlComment of Comment {
     notes = "TOML only supports single-line comments starting with #."
 }
 
+instance CsvComment of Comment {
+    single_line = "N/A"
+    multi_line = "N/A"
+    notes = "Standard CSV does not natively support comments; some variations use #."
+}
+
 pattern SchemaLink {
     meta description: "Linking a data file to a schema for validation (e.g., JSON Schema, XSD)."
     parameter syntax: String
@@ -177,4 +207,9 @@ instance YamlSchemaLink of SchemaLink {
 instance TomlSchemaLink of SchemaLink {
     syntax = "N/A"
     notes = "TOML does not have a native or widely standardized way to link to a schema within the file."
+}
+
+instance CsvSchemaLink of SchemaLink {
+    syntax = "N/A"
+    notes = "CSV does not have a native schema linking mechanism; often defined in a sidecar file (e.g., CSVW metadata)."
 }


### PR DESCRIPTION
This PR completes the implementation of CSV data format patterns as outlined in the project roadmap. It also decomposes the remaining CSV and Fixlength tasks in ROADMAP.md into smaller, more manageable sub-tasks to ensure steady progress.

Key changes:
1. **DSL Implementation**: Added 6 CSV instances (BasicTypes, Collection, Mapping, Metadata, Comment, SchemaLink) to `patterns/data_formats.patterns` according to RFC 4180 standards and common variations.
2. **Documentation**: Updated the coverage matrix in `docs/coverage.md` to show 100% implementation status for CSV.
3. **Roadmap Management**: Decomposed tasks 9.6 and 9.7 in `ROADMAP.md` into sub-tasks for structure (basic/collections/mappings) and advanced features (metadata/comments/schemas).
4. **Verification**: Successfully ran all 37 existing tests and generated the `docs/data_formats.rst` file to confirm correct table rendering and formatting.

Fixes #137

---
*PR created automatically by Jules for task [737033790382008999](https://jules.google.com/task/737033790382008999) started by @chatelao*