### PR TITLE
Format Syntax columns as monospaced code

### DIFF
--- a/docs/data_formats.rst
+++ b/docs/data_formats.rst
@@ -1,5 +1,5 @@
-Data Format Patterns
-====================
+Data Formats
+============
 
 
 
@@ -86,28 +86,28 @@ Parameters:
      - notes
    * - JsonCollection
      - Any JSON value
-     - [1, "two", true]
+     - ``[1, "two", true]``
      - Elements are comma-separated and enclosed in square brackets.
    * - XmlCollection
      - Repeated child elements
-     - | <list>
-       |   <item>1</item>
-       |   <item>2</item>
-       | </list>
+     - | ``<list>``
+       | ``  <item>1</item>``
+       | ``  <item>2</item>``
+       | ``</list>``
      - Collections are typically represented by repeating elements under a parent.
    * - YamlCollection
      - Any YAML value
-     - | - 1
-       | - two
-       | - true
+     - | ``- 1``
+       | ``- two``
+       | ``- true``
      - Uses a dash followed by a space for each element.
    * - TomlCollection
      - Any TOML value
-     - [1, 2, 3]
+     - ``[1, 2, 3]``
      - Arrays can contain values of different types since TOML 1.0.0.
    * - CsvCollection
      - Comma-separated values
-     - 1,two,true
+     - ``1,two,true``
      - A single row represents a collection of fields.
 
 
@@ -139,29 +139,29 @@ Parameters:
      - notes
    * - JsonMapping
      - Key-value pairs
-     - {"key": "value", "num": 42}
+     - ``{"key": "value", "num": 42}``
      - Keys must be double-quoted strings.
    * - XmlMapping
      - Child elements or attributes
-     - | <object>
-       |   <key>value</key>
-       |   <num>42</num>
-       | </object>
+     - | ``<object>``
+       | ``  <key>value</key>``
+       | ``  <num>42</num>``
+       | ``</object>``
      - Mappings are represented as nested elements.
    * - YamlMapping
      - Key-value pairs
-     - | key: value
-       | num: 42
+     - | ``key: value``
+       | ``num: 42``
      - Uses a colon followed by a space to separate key and value.
    * - TomlMapping
      - Key-value pairs
-     - | key = "value"
-       | num = 42
+     - | ``key = "value"``
+       | ``num = 42``
      - Top-level or grouped using [headers].
    * - CsvMapping
      - Header to field mapping
-     - | Name,Age
-       | Alice,30
+     - | ``Name,Age``
+       | ``Alice,30``
      - Mappings are established by associating header names with column values.
 
 
@@ -192,10 +192,10 @@ Parameters:
      - N/A
      - JSON does not support metadata or attributes on elements; often simulated using underscore-prefixed keys (e.g., "_metadata": { ... }).
    * - XmlMetadata
-     - <element attr="value">Content</element>
+     - ``<element attr="value">Content</element>``
      - XML has native support for attributes on elements.
    * - YamlMetadata
-     - !!str "value" or !custom { key: val }
+     - ``!!str "value" or !custom { key: val }``
      - YAML supports tags to specify types or attach metadata to nodes.
    * - TomlMetadata
      - N/A
@@ -282,14 +282,14 @@ Parameters:
      - syntax
      - notes
    * - JsonSchemaLink
-     - "\$schema": "http://json-schema.org/draft-07/schema#"
+     - ``"\$schema": "http://json-schema.org/draft-07/schema#"``
      - JSON uses the \$schema keyword to point to a JSON Schema file.
    * - XmlSchemaLink
-     - | <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       |       xsi:schemaLocation="http://example.com schema.xsd">
+     - | ``<root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"``
+       | ``      xsi:schemaLocation="http://example.com schema.xsd">``
      - XML uses the xsi:schemaLocation attribute to link to an XSD.
    * - YamlSchemaLink
-     - # yaml-language-server: \$schema=<url_or_path>
+     - ``# yaml-language-server: \$schema=<url_or_path>``
      - YAML often relies on editor-specific comments (like VS Code's language server) for schema linking.
    * - TomlSchemaLink
      - N/A

--- a/src/generator.py
+++ b/src/generator.py
@@ -6,11 +6,18 @@ from .models import (
     CallInstruction, AssignInstruction, ReturnInstruction, RawInstruction
 )
 
-def format_table_cell(value: Any) -> str:
+def format_table_cell(value: Any, is_code: bool = False) -> str:
+    str_value = str(value)
+    if is_code and str_value != "N/A":
+        if "\n" in str_value:
+            lines = str_value.split("\n")
+            return "\n".join(f"| ``{line}``" if line.strip() else "|" for line in lines)
+        return f"``{str_value}``"
+
     if isinstance(value, str) and "\n" in value:
         lines = value.split("\n")
         return "\n".join(f"| {line}" if line.strip() else "|" for line in lines)
-    return str(value)
+    return str_value
 
 def format_value(value) -> str:
     if isinstance(value, str):

--- a/src/templates/instance_table.rst.j2
+++ b/src/templates/instance_table.rst.j2
@@ -15,6 +15,6 @@
            {%- set ns.val = assignment.value -%}
          {%- endif -%}
        {%- endfor -%}
-       {{ ns.val|format_value|format_table_cell|indent(7) }}
+       {{ ns.val|format_value|format_table_cell(is_code=(param.name == 'syntax'))|indent(7) }}
 {%- endfor %}
 {%- endfor %}

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -40,7 +40,8 @@ def test_render_instance_table():
         name="VarDec",
         parameters=[
             Parameter(name="name", type=Type(name="Identifier")),
-            Parameter(name="value", type=Type(name="Expression"))
+            Parameter(name="value", type=Type(name="Expression")),
+            Parameter(name="syntax", type=Type(name="String"))
         ]
     )
     instances = [
@@ -49,7 +50,8 @@ def test_render_instance_table():
             pattern_name="VarDec",
             assignments=[
                 Assignment(name="name", value="x"),
-                Assignment(name="value", value=42)
+                Assignment(name="value", value=42),
+                Assignment(name="syntax", value="x = 42")
             ]
         ),
         Instance(
@@ -69,9 +71,11 @@ def test_render_instance_table():
     assert "* - Instance" in output
     assert "  - name" in output
     assert "  - value" in output
+    assert "  - syntax" in output
     assert "* - Python" in output
     assert "  - x" in output
     assert "  - 42" in output
+    assert "  - ``x = 42``" in output
     assert "* - Java" in output
     assert "  - y" in output
     assert "  - 100" in output


### PR DESCRIPTION
This change ensures that the "Syntax" columns in the pattern comparison tables are rendered using a monospaced font (inline literals in reStructuredText). 

Key changes:
- `src/generator.py`: Added an `is_code` parameter to `format_table_cell`. When true, non-"N/A" values are wrapped in double backticks (``). For multi-line values, each line of the line block is individually wrapped to preserve layout and font.
- `src/templates/instance_table.rst.j2`: Updated to pass `is_code=(param.name == 'syntax')` to the `format_table_cell` filter.
- `test/test_generator.py`: Updated test cases to expect monospaced syntax snippets.

Verified by running the full test suite and building the Sphinx documentation locally to inspect the resulting reStructuredText and HTML output.

Fixes #151

---
*PR created automatically by Jules for task [6674689930946161801](https://jules.google.com/task/6674689930946161801) started by @chatelao*