### PR TITLE
Strip trailing newlines from table cells

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -8,6 +8,9 @@ from .models import (
 
 def format_table_cell(value: Any, is_code: bool = False) -> str:
     str_value = str(value)
+    if str_value != "N/A":
+        str_value = str_value.rstrip("\n")
+
     if is_code and str_value != "N/A":
         if "\n" in str_value:
             lines = str_value.split("\n")
@@ -15,7 +18,7 @@ def format_table_cell(value: Any, is_code: bool = False) -> str:
         return f"``{str_value}``"
 
     if isinstance(value, str) and "\n" in value:
-        lines = value.split("\n")
+        lines = str_value.split("\n")
         return "\n".join(f"| {line}" if line.strip() else "|" for line in lines)
     return str_value
 


### PR DESCRIPTION
Modified the format_table_cell function in src/generator.py to rstrip("\n") from values. This prevents an extra empty line block in reStructuredText table cells when the input string has a trailing newline, which often occurs with multiline syntax definitions.

Fixes #154

---
*PR created automatically by Jules for task [6971998447129284471](https://jules.google.com/task/6971998447129284471) started by @chatelao*