### PR TITLE
Fix Auto-Repeat triggering for automated agents

### DIFF
--- a/.github/workflows/auto_repeat.yml
+++ b/.github/workflows/auto_repeat.yml
@@ -101,9 +101,20 @@ jobs:
 
           # 5. Create new issue if needed
           if [ -n "$NEW_ITERATION_LABEL" ]; then
-            ISSUE_DATA=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --json title,body)
-            TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
-            echo "$ISSUE_DATA" | jq -r '.body' > issue_body.md
+            # Use Go templates to extract title, body, assignees, and milestone safely
+            TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --template '{{.title}}')
+            gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --template '{{.body}}' > issue_body.md
+            ASSIGNEES=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --template '{{range .assignees}}{{.login}} {{end}}' | xargs | tr ' ' ',' || true)
+            MILESTONE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPOSITORY" --template '{{if .milestone}}{{.milestone.title}}{{end}}')
+
+            # Create the issue without labels first to ensure it's "opened"
+            # Carrying over assignees and milestone if they exist
+            CREATE_ARGS=(--repo "$REPOSITORY" --title "$TITLE" --body-file issue_body.md)
+            if [ -n "$ASSIGNEES" ]; then CREATE_ARGS+=(--assignee "$ASSIGNEES"); fi
+            if [ -n "$MILESTONE" ]; then CREATE_ARGS+=(--milestone "$MILESTONE"); fi
+
+            NEW_ISSUE_URL=$(gh issue create "${CREATE_ARGS[@]}")
+            NEW_ISSUE_NUMBER=$(echo "$NEW_ISSUE_URL" | grep -oE '[0-9]+$' | head -n 1)
 
             # Collect other labels (excluding the current iteration label)
             OTHER_LABELS=$(echo "$LABELS" | grep -v "^$ITERATION_LABEL$" | grep . | paste -sd "," - || true)
@@ -120,5 +131,6 @@ jobs:
               NEW_LABELS="$NEW_LABELS,$OTHER_LABELS"
             fi
 
-            gh issue create --repo "$REPOSITORY" --title "$TITLE" --body-file issue_body.md --label "$NEW_LABELS"
+            # Add labels in a separate step to ensure "labeled" event is triggered
+            gh issue edit "$NEW_ISSUE_NUMBER" --repo "$REPOSITORY" --add-label "$NEW_LABELS"
           fi


### PR DESCRIPTION
The "Auto-Repeat" workflow was creating issues with labels already attached, which meant that the `labeled` event was not being emitted for the new issue. This caused issues for downstream automation (like Jules) that listens for this event.

This PR refactors the `auto_repeat.yml` workflow to:
1.  **Separate Creation and Labeling:** The issue is now created first (with its original assignees and milestone), and labels are added in a subsequent `gh issue edit` call.
2.  **Improve Fidelity:** Assignees and milestones are now correctly carried over to the duplicated issue.
3.  **Enhance Robustness:** Switched from `jq` parsing to Go templates for extracting issue metadata, which is more reliable for handling unquoted strings and complex fields in the GitHub CLI.

Fixes #161

---
*PR created automatically by Jules for task [725644518909310113](https://jules.google.com/task/725644518909310113) started by @chatelao*