### PR TITLE
Rework comparison table format to 'Language, Syntax..., Notes'

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -65,8 +65,19 @@ class CodeGenerator:
         return template.render(pattern=pattern)
 
     def render_instance_table(self, pattern: Pattern, instances: List[Instance]) -> str:
+        syntax_params = {"syntax", "single_line", "multi_line", "string_val", "number_val", "boolean_val"}
+
+        display_parameters = [p for p in pattern.parameters if p.name in syntax_params]
+        notes_param = next((p for p in pattern.parameters if p.name == "notes"), None)
+        if notes_param:
+            display_parameters.append(notes_param)
+
         template = self.env.get_template('instance_table.rst.j2')
-        return template.render(pattern=pattern, instances=instances)
+        return template.render(
+            pattern=pattern,
+            instances=instances,
+            display_parameters=display_parameters
+        )
 
     def render_program(self, program: Program, title: str = None) -> str:
         results = []

--- a/src/templates/instance_table.rst.j2
+++ b/src/templates/instance_table.rst.j2
@@ -2,19 +2,19 @@
    :widths: auto
    :header-rows: 1
 
-   * - Instance
-{%- for param in pattern.parameters %}
-     - {{ param.name }}
+   * - Language
+{%- for param in display_parameters %}
+     - {{ param.name|replace('_', ' ')|capitalize }}
 {%- endfor %}
 {%- for instance in instances %}
    * - {{ instance.name }}
-{%- for param in pattern.parameters %}
+{%- for param in display_parameters %}
      - {% set ns = namespace(val="N/A") -%}
        {%- for assignment in instance.assignments -%}
          {%- if assignment.name == param.name -%}
            {%- set ns.val = assignment.value -%}
          {%- endif -%}
        {%- endfor -%}
-       {{ ns.val|format_value|format_table_cell(is_code=(param.name == 'syntax'))|indent(7) }}
+       {{ ns.val|format_value|format_table_cell(is_code=(param.name != 'notes'))|indent(7) }}
 {%- endfor %}
 {%- endfor %}

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -68,14 +68,13 @@ def test_render_instance_table():
     output = generator.render_program(program)
 
     assert ".. list-table:: VarDec Comparison" in output
-    assert "* - Instance" in output
-    assert "  - name" in output
-    assert "  - value" in output
-    assert "  - syntax" in output
+    assert "* - Language" in output
+    assert "  - Syntax" in output
     assert "* - Python" in output
-    assert "  - x" in output
-    assert "  - 42" in output
     assert "  - ``x = 42``" in output
     assert "* - Java" in output
-    assert "  - y" in output
-    assert "  - 100" in output
+    assert "  - N/A" in output
+
+    # These should NOT be in the table anymore
+    assert "  - name" not in output
+    assert "  - value" not in output

--- a/test/test_generator_instructions.py
+++ b/test/test_generator_instructions.py
@@ -9,7 +9,7 @@ def test_render_instructions():
     pattern = Pattern(
         name="Function",
         parameters=[
-            Parameter(name="body", type=Type(name="Block"))
+            Parameter(name="syntax", type=Type(name="Block"))
         ]
     )
 
@@ -19,7 +19,7 @@ def test_render_instructions():
             pattern_name="Function",
             assignments=[
                 Assignment(
-                    name="body",
+                    name="syntax",
                     value=Block(instructions=[
                         CallInstruction(name="print", arguments=["hello"]),
                         AssignInstruction(target="x", value=10),
@@ -45,7 +45,7 @@ def test_render_nested_blocks():
     pattern = Pattern(
         name="ControlFlow",
         parameters=[
-            Parameter(name="nested", type=Type(name="Block"))
+            Parameter(name="syntax", type=Type(name="Block"))
         ]
     )
 
@@ -55,7 +55,7 @@ def test_render_nested_blocks():
             pattern_name="ControlFlow",
             assignments=[
                 Assignment(
-                    name="nested",
+                    name="syntax",
                     value=Block(instructions=[
                         AssignInstruction(
                             target="inner",

--- a/test/test_generator_nested.py
+++ b/test/test_generator_nested.py
@@ -6,7 +6,7 @@ def test_render_nested_list_and_instance():
     pattern = Pattern(
         name="DataMap",
         parameters=[
-            Parameter(name="entries", type=Type(name="List", inner_type=Type(name="MapEntry")))
+            Parameter(name="syntax", type=Type(name="List", inner_type=Type(name="MapEntry")))
         ]
     )
 
@@ -24,7 +24,7 @@ def test_render_nested_list_and_instance():
             pattern_name="DataMap",
             assignments=[
                 Assignment(
-                    name="entries",
+                    name="syntax",
                     value=ListLiteral(elements=[
                         AnonymousInstance(
                             pattern_name="MapEntry",


### PR DESCRIPTION
The comparison tables in the generated documentation have been reworked to provide a cleaner and more focused comparative view.

Key changes:
- The first column is now labeled "Language" and displays the instance names.
- Tables now only include syntax-related columns (e.g., `syntax`, `single_line`, `multi_line`) and the `notes` column.
- Non-essential parameters like internal `name`, `type`, or `body` are filtered out of the tables.
- The `notes` column is consistently placed at the end of the table.
- Column headers are now formatted for better readability (e.g., `single_line` becomes "Single line").
- Code formatting is automatically applied to all syntax columns while keeping the notes as plain text.

All existing tests have been updated to reflect these changes and are passing.

Fixes #163

---
*PR created automatically by Jules for task [18327853013530409589](https://jules.google.com/task/18327853013530409589) started by @chatelao*