### PR TITLE
Merge "Syntax" and "Single line" columns on pivot pages

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -105,7 +105,7 @@ class CodeGenerator:
         return "\n\n".join(results)
 
     def render_pivot_table(self, program: Program, language: str) -> str:
-        syntax_params = ["syntax", "single_line", "multi_line", "string_val", "number_val", "boolean_val", "notes"]
+        syntax_params = ["syntax", "multi_line", "string_val", "number_val", "boolean_val", "notes"]
 
         # List of all known languages from DESIGN.md to avoid prefix collisions (e.g., C vs CSS)
         all_languages = [
@@ -132,6 +132,11 @@ class CodeGenerator:
                     continue
 
                 assignments = {a.name: a.value for a in instance.assignments}
+
+                # Merge single_line into syntax if syntax is missing or N/A
+                if assignments.get("syntax", "N/A") == "N/A" and "single_line" in assignments:
+                    assignments["syntax"] = assignments["single_line"]
+
                 pivot_data.append({
                     "pattern_name": instance.pattern_name,
                     "assignments": assignments


### PR DESCRIPTION
Consolidated the "Syntax" and "Single line" columns into a single "Syntax" column for the language-specific pivot chapters.

Key changes:
- In `src/generator.py`, updated `render_pivot_table` to exclude `single_line` from the displayed parameters.
- Implemented logic within `render_pivot_table` to automatically merge the `single_line` value into the `syntax` field for any instance where `syntax` is either missing or set to the default "N/A" value.
- This results in a cleaner pivot table layout while ensuring that single-line syntax examples (like those used in the `Comment` pattern) are still prominently displayed.

Verification:
- Created and ran a reproduction script to confirm the visual merge in the generated rST output.
- Successfully ran the full test suite (`pytest`) to ensure no regressions in other documentation generation paths.
- Cleaned up all temporary verification files before submission.

Fixes #182

---
*PR created automatically by Jules for task [11606463075710671505](https://jules.google.com/task/11606463075710671505) started by @chatelao*