### PR TITLE
Add Prolog support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -22,6 +22,7 @@ This section compares languages based on common programming patterns.
 - CSS
 - CUDA
 - x86 Assembler
+- Prolog
 
 **Patterns to be compared:**
 - Variable declaration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,10 +131,10 @@
 ## Phase 5: Advanced Language Features
 - [x] Implement `Import` pattern <!-- issue #13 -->
     - [x] 13.1 Define `Import` pattern <!-- issue #13.1 -->
-    - [x] 13.2 Implement instances across all 14 languages <!-- issue #13.2 -->
+    - [x] 13.2 Implement instances across all 15 languages <!-- issue #13.2 -->
 - [ ] Implement `Constant` pattern <!-- issue #14 -->
     - [ ] 14.1 Define `Constant` pattern <!-- issue #14.1 -->
-    - [ ] 14.2 Implement instances across all 14 languages <!-- issue #14.2 -->
+    - [ ] 14.2 Implement instances across all 15 languages <!-- issue #14.2 -->
 
 ## Phase 6: Pivot Chapters (Language-specific Views)
 - [x] Implement Pivot Chapter generator logic <!-- issue #15 -->
@@ -152,3 +152,4 @@
 - [ ] Generate Pivot Chapter for CSS <!-- issue #15.12 -->
 - [ ] Generate Pivot Chapter for CUDA <!-- issue #15.13 -->
 - [ ] Generate Pivot Chapter for x86 Assembler <!-- issue #15.14 -->
+- [ ] Generate Pivot Chapter for Prolog <!-- issue #15.15 -->

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -20,6 +20,7 @@ This page provides an overview of the implementation status for all patterns acr
 | CSS | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | CUDA | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | x86 Assembler | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Prolog | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 *Legend: ✅ = Implemented, ❌ = Not yet implemented.*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Welcome to the Bible of Babylon Documentation
 
    sql_pivot
    c_pivot
+   prolog_pivot
 
 Indices and tables
 ==================

--- a/docs/prolog_pivot.rst
+++ b/docs/prolog_pivot.rst
@@ -1,0 +1,113 @@
+Prolog Pivot View
+=================
+
+.. list-table:: Prolog Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Single line
+     - Multi line
+     - String val
+     - Number val
+     - Boolean val
+     - Notes
+   * - VariableDeclaration
+     - ``X = 42.``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Uses unification for assignment; variables must start with an uppercase letter.
+   * - IfElse
+     - ``(X > 0 -> Result = 1 ; Result = 0)``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Uses the (Condition -> Then ; Else) control construct.
+   * - Loop
+     - ::
+           loop(0) :- !.
+           loop(X) :- X > 0, X1 is X - 1, loop(X1).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Prolog uses recursion and tail-call optimization for looping.
+   * - FunctionDefinition
+     - ``add(A, B, Res) :- Res is A + B.``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Functions are predicates; return values are typically unified with an output argument.
+   * - TryCatch
+     - ``catch(do_something, E, handle(E))``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Standard Prolog error handling using the catch/3 predicate.
+   * - Raise
+     - ``throw(error(Error))``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Uses throw/1 to raise an exception.
+   * - Thread
+     - ``thread_create(do_work, Id, []).``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Creates a new thread using thread_create/3 (ISO Prolog / SWI-Prolog).
+   * - SendMessage
+     - ``thread_send_message(Id, hello).``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Sends a message to a thread's message queue.
+   * - ReceiveMessage
+     - ``thread_get_message(hello).``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Retrieves a matching message from the current thread's queue.
+   * - Comment
+     - N/A
+     - ``% comment``
+     - ``/* line 1\n   line 2 */``
+     - N/A
+     - N/A
+     - N/A
+     - Uses % for single-line and /* */ for multi-line comments.
+   * - Print
+     - ``writeln('Hello, World!').``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Outputs text followed by a newline.
+   * - Import
+     - ``use_module(library(math)).``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Imports predicates from a library module.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -146,6 +146,14 @@ instance X86Var of VariableDeclaration {
     notes = "Defined in the .data section (Intel syntax)."
 }
 
+instance PrologVariableDeclaration of VariableDeclaration {
+    name = "X"
+    type = "Dynamic"
+    initial_value = 42
+    syntax = "X = 42."
+    notes = "Uses unification for assignment; variables must start with an uppercase letter."
+}
+
 instance CIfElse of IfElse {
     condition = "x > 0"
     then_branch = { return 1 }
@@ -335,6 +343,14 @@ instance X86IfElse of IfElse {
     notes = "Implemented using comparison and jump instructions (Intel syntax)."
 }
 
+instance PrologIfElse of IfElse {
+    condition = "X > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "(X > 0 -> Result = 1 ; Result = 0)"
+    notes = "Uses the (Condition -> Then ; Else) control construct."
+}
+
 instance CssLoop of Loop {
     condition = "N/A"
     body = { raw "N/A" }
@@ -354,6 +370,13 @@ instance X86Loop of Loop {
     body = { raw "    dec ecx" }
     syntax = ".loop:\n    cmp ecx, 0\n    jle .end\n    dec ecx\n    jmp .loop\n.end:"
     notes = "Implemented using labels and conditional jumps."
+}
+
+instance PrologLoop of Loop {
+    condition = "X > 0"
+    body = { raw "loop(X - 1)" }
+    syntax = "loop(0) :- !.\nloop(X) :- X > 0, X1 is X - 1, loop(X1)."
+    notes = "Prolog uses recursion and tail-call optimization for looping."
 }
 
 instance CFunction of FunctionDefinition {
@@ -480,6 +503,15 @@ instance X86Function of FunctionDefinition {
     body = { raw "    add eax, ebx\n    ret" }
     syntax = "add_func:\n    add eax, ebx\n    ret"
     notes = "Functions are labels; parameters usually passed via registers or stack."
+}
+
+instance PrologFunctionDefinition of FunctionDefinition {
+    name = "add"
+    parameters = ["A", "B", "Res"]
+    return_type = "is"
+    body = { raw "Res is A + B" }
+    syntax = "add(A, B, Res) :- Res is A + B."
+    notes = "Functions are predicates; return values are typically unified with an output argument."
 }
 
 pattern TryCatch {
@@ -703,6 +735,15 @@ instance X86TryCatch of TryCatch {
     notes = "No high-level try-catch; requires OS-specific mechanisms like SEH."
 }
 
+instance PrologTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "Error"
+    error_variable = "E"
+    catch_body = { call handle(E) }
+    syntax = "catch(do_something, E, handle(E))"
+    notes = "Standard Prolog error handling using the catch/3 predicate."
+}
+
 instance CssRaise of Raise {
     exception_type = "N/A"
     message = "N/A"
@@ -722,6 +763,13 @@ instance X86Raise of Raise {
     message = "Error"
     syntax = "    int 3"
     notes = "Software interrupts (like int 3) can be used to signal errors or breakpoints."
+}
+
+instance PrologRaise of Raise {
+    exception_type = "error"
+    message = "Error"
+    syntax = "throw(error(Error))"
+    notes = "Uses throw/1 to raise an exception."
 }
 
 pattern Thread {
@@ -805,6 +853,12 @@ instance X86Thread of Thread {
     notes = "Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread)."
 }
 
+instance PrologThread of Thread {
+    body = { call do_work() }
+    syntax = "thread_create(do_work, Id, [])."
+    notes = "Creates a new thread using thread_create/3 (ISO Prolog / SWI-Prolog)."
+}
+
 instance JavaSendMessage of SendMessage {
     recipient = "queue"
     message = "42"
@@ -826,6 +880,13 @@ instance X86SendMessage of SendMessage {
     notes = "Message passing is done via OS APIs."
 }
 
+instance PrologSendMessage of SendMessage {
+    recipient = "Id"
+    message = "hello"
+    syntax = "thread_send_message(Id, hello)."
+    notes = "Sends a message to a thread's message queue."
+}
+
 instance JavaReceiveMessage of ReceiveMessage {
     match_pattern = "msg"
     body = { call handle(msg) }
@@ -845,6 +906,13 @@ instance X86ReceiveMessage of ReceiveMessage {
     body = { call handle(msg) }
     syntax = "    call GetMessage"
     notes = "Message retrieval via OS APIs."
+}
+
+instance PrologReceiveMessage of ReceiveMessage {
+    match_pattern = "hello"
+    body = { call handle_hello() }
+    syntax = "thread_get_message(hello)."
+    notes = "Retrieves a matching message from the current thread's queue."
 }
 
 pattern Comment {
@@ -938,6 +1006,12 @@ instance X86Comment of Comment {
     notes = "Most assemblers use semicolon for comments (Intel syntax)."
 }
 
+instance PrologComment of Comment {
+    single_line = "% comment"
+    multi_line = "/* line 1\\n   line 2 */"
+    notes = "Uses % for single-line and /* */ for multi-line comments."
+}
+
 pattern Print {
     meta description: "Outputting text to the console or standard output."
     parameter value: String
@@ -1029,6 +1103,12 @@ instance X86Print of Print {
     notes = "Printing in assembler usually involves calling C library functions or OS-specific system calls."
 }
 
+instance PrologPrint of Print {
+    value = "Hello, World!"
+    syntax = "writeln('Hello, World!')."
+    notes = "Outputs text followed by a newline."
+}
+
 pattern Import {
     meta description: "Including external modules, packages, or files into the current scope."
     parameter module_name: String
@@ -1118,4 +1198,10 @@ instance X86Import of Import {
     module_name = "macros.inc"
     syntax = "include 'macros.inc'"
     notes = "Includes another assembly file; syntax varies by assembler (e.g., FASM uses 'include')."
+}
+
+instance PrologImport of Import {
+    module_name = "math"
+    syntax = "use_module(library(math))."
+    notes = "Imports predicates from a library module."
 }

--- a/src/generator.py
+++ b/src/generator.py
@@ -110,7 +110,7 @@ class CodeGenerator:
         # List of all known languages from DESIGN.md to avoid prefix collisions (e.g., C vs CSS)
         all_languages = [
             "SQL", "C", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
-            "PowerShell", "Python", "CSS", "CUDA", "x86 Assembler"
+            "PowerShell", "Python", "CSS", "CUDA", "x86 Assembler", "Prolog"
         ]
 
         pivot_data = []


### PR DESCRIPTION
This submission adds full support for the Prolog language to the "Bible of Babylon" comparative programming patterns project. 

Key changes include:
- Implementation of `PrologVariableDeclaration`, `PrologFunctionDefinition`, `PrologIfElse`, `PrologLoop`, `PrologTryCatch`, `PrologRaise`, `PrologThread`, `PrologSendMessage`, `PrologReceiveMessage`, `PrologComment`, `PrologPrint`, and `PrologImport` in the source DSL.
- Update to the transpiler's generator logic to recognize Prolog for pivot chapter generation.
- Addition of a new Prolog-specific pivot chapter in the documentation.
- Updates to the project's design and roadmap documents to include Prolog as a first-class supported language.
- Verification that all 40 project tests pass and the generated reStructuredText is well-formatted.

Fixes #166

---
*PR created automatically by Jules for task [3831398735006722821](https://jules.google.com/task/3831398735006722821) started by @chatelao*