### PR TITLE
Add Header pattern to data formats

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,6 +50,7 @@ This section compares data structures and serialization formats.
 - Metadata/Attributes
 - Comments support
 - Schema validation
+- Header
 
 ## Presentation Design: Comparison Tables
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,6 +116,7 @@
     - [x] 9.7 Implement Fixlength instances <!-- 2026-05-24, issue #9.7 -->
         - [x] 9.7.1 Basic types, Collections, and Mappings <!-- 2026-05-24, issue #9.7.1 -->
         - [x] 9.7.2 Metadata, Comments, and Schema links <!-- 2026-05-24, issue #9.7.2 -->
+    - [x] 9.8 Header <!-- 2026-05-24, issue #9.8 -->
 
 ## Phase 4: Publication
 - [x] Configure ReadTheDocs integration <!-- 2026-05-03, issue #10 -->

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -248,3 +248,39 @@ instance FixlengthSchemaLink of SchemaLink {
     syntax = "N/A"
     notes = "Schema definition is usually external (e.g., a Copybook or a COBOL file descriptor)."
 }
+
+pattern Header {
+    meta description: "Standardized header or declaration at the beginning of a file or document."
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance JsonHeader of Header {
+    syntax = "N/A"
+    notes = "JSON files do not have a standardized header; they start directly with the data (object or array)."
+}
+
+instance XmlHeader of Header {
+    syntax = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    notes = "XML declaration specifies the version and encoding of the document."
+}
+
+instance YamlHeader of Header {
+    syntax = "%YAML 1.2\n---"
+    notes = "The %YAML directive (optional) specifies the version, and the triple dash (---) marks the start of a document."
+}
+
+instance TomlHeader of Header {
+    syntax = "N/A"
+    notes = "TOML does not have a native file-level header or declaration."
+}
+
+instance CsvHeader of Header {
+    syntax = "Name,Age,City"
+    notes = "The first row of a CSV file often contains the column names (headers)."
+}
+
+instance FixlengthHeader of Header {
+    syntax = "H2026052400001"
+    notes = "Fixed-length formats often use a 'Header' record (e.g., starting with 'H') containing metadata like date or batch ID."
+}


### PR DESCRIPTION
This PR adds a new 'Header' pattern to the data format comparisons. It documents the standard declarations or starting records for various formats, specifically addressing the user request for XML (declarations), CSV (header rows), and Fixed-length (header records).

Key changes:
- New `Header` pattern in `patterns/data_formats.patterns`.
- Pattern instances for all 6 supported data formats.
- Documentation updates in `DESIGN.md` and `ROADMAP.md`.
- Refined YAML header syntax to follow standard directive-marker order.

Fixes #171

---
*PR created automatically by Jules for task [5964122636944931568](https://jules.google.com/task/5964122636944931568) started by @chatelao*