### PR TITLE
Fix multiline code rendering in documentation

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -13,7 +13,7 @@ def format_table_cell(value: Any, is_code: bool = False) -> str:
 
     if is_code and str_value != "N/A":
         if "\n" in str_value:
-            return "::\n" + "\n".join(f"    {line}" for line in str_value.splitlines())
+            return "::\n\n" + "\n".join(f"    {line}" for line in str_value.splitlines())
         return f"``{str_value}``"
 
     if isinstance(value, str) and "\n" in str_value:


### PR DESCRIPTION
Fixed an issue where multiline code examples (like loops and function definitions) were not rendering correctly in the Sphinx documentation. The fix involves adding a necessary blank line after the `::` literal block marker in the `format_table_cell` function within `src/generator.py`. Visual verification via Playwright and local Sphinx builds confirmed the fix, and the existing test suite passed without regressions.

Fixes #186

---
*PR created automatically by Jules for task [1502337169017099370](https://jules.google.com/task/1502337169017099370) started by @chatelao*