### PR TITLE
Implement Constant Pattern Across All Languages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -133,9 +133,9 @@
 - [x] Implement `Import` pattern <!-- issue #13 -->
     - [x] 13.1 Define `Import` pattern <!-- issue #13.1 -->
     - [x] 13.2 Implement instances across all 15 languages <!-- issue #13.2 -->
-- [ ] Implement `Constant` pattern <!-- issue #14 -->
-    - [ ] 14.1 Define `Constant` pattern <!-- issue #14.1 -->
-    - [ ] 14.2 Implement instances across all 15 languages <!-- issue #14.2 -->
+- [x] Implement `Constant` pattern <!-- issue #14 -->
+    - [x] 14.1 Define `Constant` pattern <!-- issue #14.1 -->
+    - [x] 14.2 Implement instances across all 15 languages <!-- issue #14.2 -->
 - [x] Implement `SwitchCase` pattern <!-- issue #16 -->
     - [x] 16.1 Define `SwitchCase` pattern <!-- issue #16.1 -->
     - [x] 16.2 Implement instances across all 15 languages <!-- issue #16.2 -->
@@ -156,4 +156,4 @@
 - [ ] Generate Pivot Chapter for CSS <!-- issue #15.12 -->
 - [ ] Generate Pivot Chapter for CUDA <!-- issue #15.13 -->
 - [ ] Generate Pivot Chapter for x86 Assembler <!-- issue #15.14 -->
-- [ ] Generate Pivot Chapter for Prolog <!-- issue #15.15 -->
+- [x] Generate Pivot Chapter for Prolog <!-- issue #15.15 -->

--- a/docs/prolog_pivot.rst
+++ b/docs/prolog_pivot.rst
@@ -7,7 +7,6 @@ Prolog Pivot View
 
    * - Pattern
      - Syntax
-     - Single line
      - Multi line
      - String val
      - Number val
@@ -19,7 +18,6 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Uses unification for assignment; variables must start with an uppercase letter.
    * - IfElse
      - ``(X > 0 -> Result = 1 ; Result = 0)``
@@ -27,13 +25,12 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Uses the (Condition -> Then ; Else) control construct.
    * - Loop
      - ::
+
            loop(0) :- !.
            loop(X) :- X > 0, X1 is X - 1, loop(X1).
-     - N/A
      - N/A
      - N/A
      - N/A
@@ -45,11 +42,9 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Functions are predicates; return values are typically unified with an output argument.
    * - TryCatch
      - ``catch(do_something, E, handle(E))``
-     - N/A
      - N/A
      - N/A
      - N/A
@@ -61,11 +56,9 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Uses throw/1 to raise an exception.
    * - Thread
      - ``thread_create(do_work, Id, []).``
-     - N/A
      - N/A
      - N/A
      - N/A
@@ -77,7 +70,6 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Sends a message to a thread's message queue.
    * - ReceiveMessage
      - ``thread_get_message(hello).``
@@ -85,10 +77,8 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Retrieves a matching message from the current thread's queue.
    * - Comment
-     - N/A
      - ``% comment``
      - ``/* line 1\n   line 2 */``
      - N/A
@@ -101,7 +91,6 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Outputs text followed by a newline.
    * - Import
      - ``use_module(library(math)).``
@@ -109,5 +98,23 @@ Prolog Pivot View
      - N/A
      - N/A
      - N/A
-     - N/A
      - Imports predicates from a library module.
+   * - SwitchCase
+     - ::
+
+           (   X = 1 -> writeln('one')
+           ;   X = 2 -> writeln('two')
+           ;   writeln('none')
+           )
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Usually implemented using nested (If -> Then ; Else) or multiple clauses.
+   * - Constant
+     - ``max(100).``
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -1302,3 +1302,132 @@ instance PrologSwitchCase of SwitchCase {
     syntax = "(   X = 1 -> writeln('one')\n;   X = 2 -> writeln('two')\n;   writeln('none')\n)"
     notes = "Usually implemented using nested (If -> Then ; Else) or multiple clauses."
 }
+
+pattern Constant {
+    meta description: "Declaration of an immutable value that remains unchanged throughout the program's execution."
+    parameter name: String
+    parameter type: String
+    parameter value: String
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance CConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "const int MAX = 100;"
+    notes = "The 'const' qualifier makes the variable immutable after initialization."
+}
+
+instance JavaConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "public static final int MAX = 100;"
+    notes = "Uses 'final' to prevent modification; typically combined with 'static' for class-level constants."
+}
+
+instance RustConstant of Constant {
+    name = "MAX"
+    type = "i32"
+    value = "100"
+    syntax = "const MAX: i32 = 100;"
+    notes = "Constants are always immutable and must have their types explicitly declared."
+}
+
+instance PythonConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "MAX = 100"
+    notes = "Python does not have true constants; uppercase naming is a convention to indicate immutability."
+}
+
+instance BashConstant of Constant {
+    name = "MAX"
+    type = "Untyped"
+    value = "100"
+    syntax = "readonly MAX=100"
+    notes = "The 'readonly' command prevents the variable from being redefined or unset."
+}
+
+instance PowerShellConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "Set-Variable -Name MAX -Value 100 -Option ReadOnly"
+    notes = "Using Set-Variable with the ReadOnly option; Constant option is even more restrictive."
+}
+
+instance CmdConstant of Constant {
+    name = "MAX"
+    type = "Untyped"
+    value = "100"
+    syntax = "set MAX=100"
+    notes = "Cmd has no native support for constants; developers must manually ensure the value is not changed."
+}
+
+instance SqlConstant of Constant {
+    name = "MAX"
+    type = "INT"
+    value = "100"
+    syntax = "DECLARE @MAX INT = 100;"
+    notes = "T-SQL variables are not strictly constant, but can be treated as such within a batch or procedure."
+}
+
+instance ErlangConstant of Constant {
+    name = "MAX"
+    type = "N/A"
+    value = "100"
+    syntax = "-define(MAX, 100)."
+    notes = "Uses preprocessor macros to define constants; replaced at compile time."
+}
+
+instance LispConstant of Constant {
+    name = "MAX"
+    type = "Dynamic"
+    value = "100"
+    syntax = "(defconstant +max+ 100)"
+    notes = "Defines a global constant; by convention, names are often wrapped in + signs."
+}
+
+instance XQueryConstant of Constant {
+    name = "MAX"
+    type = "xs:integer"
+    value = "100"
+    syntax = "declare variable $MAX as xs:integer := 100;"
+    notes = "In XQuery, variables declared in the prolog are immutable by default."
+}
+
+instance CssConstant of Constant {
+    name = "MAX"
+    type = "Number"
+    value = "100"
+    syntax = "--MAX: 100;"
+    notes = "CSS custom properties act as constants within their scope."
+}
+
+instance CudaConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "__constant__ int MAX = 100;"
+    notes = "The __constant__ qualifier places the variable in the constant memory space of the GPU."
+}
+
+instance X86Constant of Constant {
+    name = "MAX"
+    type = "Immediate"
+    value = "100"
+    syntax = "MAX equ 100"
+    notes = "Uses the EQU directive to define a symbolic constant (Intel syntax)."
+}
+
+instance PrologConstant of Constant {
+    name = "max"
+    type = "Atom/Integer"
+    value = "100"
+    syntax = "max(100)."
+    notes = "Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment."
+}


### PR DESCRIPTION
This PR implements the `Constant` pattern as outlined in the project roadmap. 

Key changes:
- **DSL Update**: Added the `Constant` pattern definition to `patterns/programming.patterns` with parameters for `name`, `type`, `value`, `syntax`, and `notes`.
- **Language Coverage**: Provided idiomatic implementations of the `Constant` pattern for all 15 supported programming languages, including notes on language-specific behaviors (e.g., Python naming conventions, Erlang macros, etc.).
- **Roadmap Progression**: Marked Phase 5 Task 14 (`Constant` pattern) and Phase 6 Task 15.15 (`Prolog` pivot) as complete in `ROADMAP.md`.
- **Verification**: Confirmed that the transpiler correctly generates documentation for the new pattern and that all existing tests pass.

Fixes #189

---
*PR created automatically by Jules for task [5994699394977788633](https://jules.google.com/task/5994699394977788633) started by @chatelao*