### PR TITLE
Unify single-line and multi-line code representation

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -12,9 +12,7 @@ def format_table_cell(value: Any, is_code: bool = False) -> str:
         str_value = str_value.rstrip()
 
     if is_code and str_value != "N/A":
-        if "\n" in str_value:
-            return "::\n\n" + "\n".join(f"    {line}" for line in str_value.splitlines())
-        return f"``{str_value}``"
+        return "::\n\n" + "\n".join(f"    {line}" for line in str_value.splitlines())
 
     if isinstance(value, str) and "\n" in str_value:
         lines = str_value.splitlines()

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -71,7 +71,7 @@ def test_render_instance_table():
     assert "* - Language" in output
     assert "  - Syntax" in output
     assert "* - Python" in output
-    assert "  - ``x = 42``" in output
+    assert "  - ::\n\n           x = 42" in output
     assert "* - Java" in output
     assert "  - N/A" in output
 


### PR DESCRIPTION
This change unifies the rendering of code snippets in the documentation tables. Previously, single-line code was rendered with inline backticks, while multi-line code used literal blocks. Now, all code snippets (where `is_code=True` and not 'N/A') use the literal block format, as requested.

Changes:
- Modified `format_table_cell` in `src/generator.py` to remove the special case for single-line strings.
- Updated `test/test_generator.py` to assert the new block-based formatting for single-line code.

Fixes #195

---
*PR created automatically by Jules for task [12435853590263488101](https://jules.google.com/task/12435853590263488101) started by @chatelao*