### PR TITLE
Implement dynamic pivot columns and independent comment pattern views

### DIFF
--- a/build.log
+++ b/build.log
@@ -1,0 +1,53 @@
+Running Sphinx v9.1.0
+loading translations [en]... done
+WARNING: html_static_path entry '_static' does not exist
+myst v5.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_sort=True, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
+building [mo]: targets for 0 po files that are out of date
+writing output...
+building [html]: targets for 11 source files that are out of date
+updating environment: [new config] 11 added, 0 changed, 0 removed
+reading sources... [  9%] c_pivot
+reading sources... [ 18%] coverage
+reading sources... [ 27%] data_formats
+reading sources... [ 36%] dsl_examples
+reading sources... [ 45%] dsl_specification
+reading sources... [ 55%] index
+reading sources... [ 64%] php_pivot
+reading sources... [ 73%] programming
+reading sources... [ 82%] prolog_pivot
+reading sources... [ 91%] sql_pivot
+reading sources... [100%] xquery_pivot
+
+looking for now-outdated files... none found
+pickling environment... done
+checking consistency... done
+preparing documents... done
+copying assets...
+copying static files...
+Writing evaluated template result to /app/docs/_build/_static/language_data.js
+Writing evaluated template result to /app/docs/_build/_static/documentation_options.js
+Writing evaluated template result to /app/docs/_build/_static/basic.css
+Writing evaluated template result to /app/docs/_build/_static/js/versions.js
+copying static files: done
+copying extra files...
+copying extra files: done
+copying assets: done
+writing output... [  9%] c_pivot
+writing output... [ 18%] coverage
+writing output... [ 27%] data_formats
+writing output... [ 36%] dsl_examples
+writing output... [ 45%] dsl_specification
+writing output... [ 55%] index
+writing output... [ 64%] php_pivot
+writing output... [ 73%] programming
+writing output... [ 82%] prolog_pivot
+writing output... [ 91%] sql_pivot
+writing output... [100%] xquery_pivot
+
+generating indices... genindex done
+writing additional pages... search done
+dumping search index in English (code: en)... done
+dumping object inventory... done
+build succeeded, 1 warning.
+
+The HTML pages are in docs/_build.

--- a/docs/c_pivot.rst
+++ b/docs/c_pivot.rst
@@ -7,17 +7,11 @@ C Pivot
 
    * - Pattern
      - Syntax
-     - Multi line
-     - String val
-     - Number val
-     - Boolean val
      - Notes
    * - VariableDeclaration
-     - ``int x = 42;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           int x = 42;
      - Static typing, terminated by semicolon.
    * - IfElse
      - ::
@@ -27,10 +21,6 @@ C Pivot
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C if-else statement.
    * - Loop
      - ::
@@ -38,10 +28,6 @@ C Pivot
            while (x > 0) {
                x = x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C while loop.
    * - FunctionDefinition
      - ::
@@ -49,55 +35,35 @@ C Pivot
            int add(int a, int b) {
                return a + b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C function with static types and curly braces.
    * - TryCatch
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - C does not have native try-catch blocks; error handling is usually manual.
    * - Raise
-     - ``exit(1);``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           exit(1);
      - C uses exit() or signals for severe errors.
    * - SingleLineComment
-     - ``// comment``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           // comment
      - Standard C single-line comment.
    * - MultiLineComment
      - ::
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C multi-line comment.
    * - Print
-     - ``printf("Hello, World!\n");``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           printf("Hello, World!\n");
      - Uses the standard library's printf function; requires stdio.h.
    * - Import
-     - ``#include <stdio.h>``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           #include <stdio.h>
      - Standard C way to include header files.
    * - SwitchCase
      - ::
@@ -110,15 +76,9 @@ C Pivot
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C switch statement with case labels and default.
    * - Constant
-     - ``const int MAX = 100;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           const int MAX = 100;
      - The 'const' qualifier makes the variable immutable after initialization.

--- a/docs/php_pivot.rst
+++ b/docs/php_pivot.rst
@@ -7,17 +7,11 @@ PHP Pivot
 
    * - Pattern
      - Syntax
-     - Multi line
-     - String val
-     - Number val
-     - Boolean val
      - Notes
    * - VariableDeclaration
-     - ``$x = 42;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           $x = 42;
      - Variables start with a dollar sign; dynamically typed but supports type declarations.
    * - IfElse
      - ::
@@ -27,10 +21,6 @@ PHP Pivot
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like if-else statement.
    * - Loop
      - ::
@@ -38,10 +28,6 @@ PHP Pivot
            while ($x > 0) {
                $x = $x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like while loop.
    * - FunctionDefinition
      - ::
@@ -49,10 +35,6 @@ PHP Pivot
            function add(int $a, int $b): int {
                return $a + $b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'function' keyword; supports type hints for parameters and return values.
    * - TryCatch
      - ::
@@ -62,48 +44,32 @@ PHP Pivot
            } catch (Exception $e) {
                handle($e);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP exception handling using try-catch blocks.
    * - Raise
-     - ``throw new Exception("Error");``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           throw new Exception("Error");
      - Uses 'throw' to trigger an exception.
    * - SingleLineComment
-     - ``// comment``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           // comment
      - Supports // and # for single-line comments.
    * - MultiLineComment
      - ::
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-style block comments.
    * - Print
-     - ``echo "Hello, World!";``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           echo "Hello, World!";
      - The echo statement is used to output text.
    * - Import
-     - ``require 'utils.php';``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           require 'utils.php';
      - Uses include, require, include_once, or require_once to include other files.
    * - SwitchCase
      - ::
@@ -116,15 +82,9 @@ PHP Pivot
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like switch statement; match expression is also available in PHP 8.0+.
    * - Constant
-     - ``define('MAX', 100);``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           define('MAX', 100);
      - Constants can be defined using define() or the 'const' keyword (for class constants or global constants in modern PHP).

--- a/docs/prolog_pivot.rst
+++ b/docs/prolog_pivot.rst
@@ -7,104 +7,72 @@ Prolog Pivot
 
    * - Pattern
      - Syntax
-     - Multi line
-     - String val
-     - Number val
-     - Boolean val
      - Notes
    * - VariableDeclaration
-     - ``X = 42.``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           X = 42.
      - Uses unification for assignment; variables must start with an uppercase letter.
    * - IfElse
-     - ``(X > 0 -> Result = 1 ; Result = 0)``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           (X > 0 -> Result = 1 ; Result = 0)
      - Uses the (Condition -> Then ; Else) control construct.
    * - Loop
      - ::
 
            loop(0) :- !.
            loop(X) :- X > 0, X1 is X - 1, loop(X1).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prolog uses recursion and tail-call optimization for looping.
    * - FunctionDefinition
-     - ``add(A, B, Res) :- Res is A + B.``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           add(A, B, Res) :- Res is A + B.
      - Functions are predicates; return values are typically unified with an output argument.
    * - TryCatch
-     - ``catch(do_something, E, handle(E))``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           catch(do_something, E, handle(E))
      - Standard Prolog error handling using the catch/3 predicate.
    * - Raise
-     - ``throw(error(Error))``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           throw(error(Error))
      - Uses throw/1 to raise an exception.
    * - Thread
-     - ``thread_create(do_work, Id, []).``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           thread_create(do_work, Id, []).
      - Creates a new thread using thread_create/3 (ISO Prolog / SWI-Prolog).
    * - SendMessage
-     - ``thread_send_message(Id, hello).``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           thread_send_message(Id, hello).
      - Sends a message to a thread's message queue.
    * - ReceiveMessage
-     - ``thread_get_message(hello).``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           thread_get_message(hello).
      - Retrieves a matching message from the current thread's queue.
    * - SingleLineComment
-     - ``% comment``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           % comment
      - Standard Prolog single-line comment.
    * - MultiLineComment
-     - ``/* line 1\n   line 2 */``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           /* line 1\n   line 2 */
      - Standard C-style block comment.
    * - Print
-     - ``writeln('Hello, World!').``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           writeln('Hello, World!').
      - Outputs text followed by a newline.
    * - Import
-     - ``use_module(library(math)).``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           use_module(library(math)).
      - Imports predicates from a library module.
    * - SwitchCase
      - ::
@@ -113,15 +81,9 @@ Prolog Pivot
            ;   X = 2 -> writeln('two')
            ;   writeln('none')
            )
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Usually implemented using nested (If -> Then ; Else) or multiple clauses.
    * - Constant
-     - ``max(100).``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           max(100).
      - Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment.

--- a/docs/sql_pivot.rst
+++ b/docs/sql_pivot.rst
@@ -7,17 +7,11 @@ SQL Pivot
 
    * - Pattern
      - Syntax
-     - Multi line
-     - String val
-     - Number val
-     - Boolean val
      - Notes
    * - VariableDeclaration
-     - ``DECLARE @x INT = 42;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           DECLARE @x INT = 42;
      - T-SQL syntax for variable declaration.
    * - IfElse
      - ::
@@ -30,10 +24,6 @@ SQL Pivot
            BEGIN
                RETURN 0
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses IF-ELSE with BEGIN-END blocks.
    * - Loop
      - ::
@@ -42,10 +32,6 @@ SQL Pivot
            BEGIN
                SET @x = @x - 1
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard WHILE loop in T-SQL.
    * - FunctionDefinition
      - ::
@@ -55,10 +41,6 @@ SQL Pivot
            BEGIN
                RETURN @a + @b
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL syntax for Scalar-Valued Functions.
    * - TryCatch
      - ::
@@ -69,47 +51,29 @@ SQL Pivot
            BEGIN CATCH
                EXEC handle_error;
            END CATCH
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
    * - Raise
-     - ``THROW 50000, 'Error', 1;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           THROW 50000, 'Error', 1;
      - The THROW statement raises an exception and transfers execution to a CATCH block.
    * - SingleLineComment
-     - ``-- comment``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           -- comment
      - Standard SQL single-line comment.
    * - MultiLineComment
      - ::
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL multi-line comment.
    * - Print
-     - ``PRINT 'Hello, World!';``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           PRINT 'Hello, World!';
      - T-SQL PRINT statement outputs a message to the client.
    * - Import
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Standard SQL does not have a native 'import' keyword for code; database objects are globally accessible or schema-qualified.
    * - SwitchCase
@@ -120,15 +84,9 @@ SQL Pivot
                WHEN 2 THEN 'two'
                ELSE 'none'
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The CASE expression is used for conditional logic in SQL.
    * - Constant
-     - ``DECLARE @MAX INT = 100;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           DECLARE @MAX INT = 100;
      - T-SQL variables are not strictly constant, but can be treated as such within a batch or procedure.

--- a/docs/xquery_pivot.rst
+++ b/docs/xquery_pivot.rst
@@ -7,31 +7,21 @@ XQuery Pivot
 
    * - Pattern
      - Syntax
-     - Multi line
-     - String val
-     - Number val
-     - Boolean val
      - Notes
    * - VariableDeclaration
-     - ``let $x := 42``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           let $x := 42
      - XQuery uses 'let' for variable binding.
    * - IfElse
-     - ``if ($x > 0) then 1 else 0``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           if ($x > 0) then 1 else 0
      - Functional if-then-else expression; both branches are required.
    * - Loop
-     - ``for $i in 1 to $x return $i``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           for $i in 1 to $x return $i
      - XQuery uses 'for' expressions for iteration over sequences.
    * - FunctionDefinition
      - ::
@@ -42,10 +32,6 @@ XQuery Pivot
            ) as xs:integer {
                $a + $b
            };
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions must be declared in a namespace (e.g., 'local').
    * - TryCatch
      - ::
@@ -55,48 +41,32 @@ XQuery Pivot
            } catch * {
                handle($err)
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - XQuery 3.0+ supports try-catch; $err is a variable containing error information.
    * - Raise
-     - ``fn:error(fn:QName('http://example.com/errors', 'MY_ERROR'), 'Error')``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           fn:error(fn:QName('http://example.com/errors', 'MY_ERROR'), 'Error')
      - The fn:error() function signals a dynamic error.
    * - SingleLineComment
-     - ``(: comment :)``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           (: comment :)
      - XQuery uses (: :) for single-line comments.
    * - MultiLineComment
      - ::
 
            (: line 1
               line 2 :)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - XQuery uses (: :) for multi-line comments.
    * - Print
-     - ``"Hello, World!"``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           "Hello, World!"
      - In XQuery, a string literal is often the result of an expression and is automatically serialized to output.
    * - Import
-     - ``import module namespace utils = "http://example.com/utils";``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           import module namespace utils = "http://example.com/utils";
      - Imports a library module by its namespace URI.
    * - SwitchCase
      - ::
@@ -105,15 +75,9 @@ XQuery Pivot
              case 1 return "one"
              case 2 return "two"
              default return "none"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'switch' expression was introduced in XQuery 3.0.
    * - Constant
-     - ``declare variable $MAX as xs:integer := 100;``
-     - N/A
-     - N/A
-     - N/A
-     - N/A
+     - ::
+
+           declare variable $MAX as xs:integer := 100;
      - In XQuery, variables declared in the prolog are immutable by default.

--- a/src/generator.py
+++ b/src/generator.py
@@ -63,7 +63,7 @@ class CodeGenerator:
         return template.render(pattern=pattern)
 
     def render_instance_table(self, pattern: Pattern, instances: List[Instance]) -> str:
-        syntax_params = {"syntax", "single_line", "multi_line", "string_val", "number_val", "boolean_val"}
+        syntax_params = {"syntax", "string_val", "number_val", "boolean_val"}
 
         display_parameters = [p for p in pattern.parameters if p.name in syntax_params]
         notes_param = next((p for p in pattern.parameters if p.name == "notes"), None)
@@ -103,7 +103,8 @@ class CodeGenerator:
         return "\n\n".join(results)
 
     def render_pivot_table(self, program: Program, language: str) -> str:
-        syntax_params = ["syntax", "multi_line", "string_val", "number_val", "boolean_val", "notes"]
+        # Candidate parameters for columns in pivot table
+        candidates = ["syntax", "string_val", "number_val", "boolean_val", "notes"]
 
         # List of all known languages from DESIGN.md to avoid prefix collisions (e.g., C vs CSS)
         all_languages = [
@@ -131,10 +132,6 @@ class CodeGenerator:
 
                 assignments = {a.name: a.value for a in instance.assignments}
 
-                # Merge single_line into syntax if syntax is missing or N/A
-                if assignments.get("syntax", "N/A") == "N/A" and "single_line" in assignments:
-                    assignments["syntax"] = assignments["single_line"]
-
                 pivot_data.append({
                     "pattern_name": instance.pattern_name,
                     "assignments": assignments
@@ -143,10 +140,24 @@ class CodeGenerator:
         if not pivot_data:
             return f"No data found for language: {language}"
 
+        # Dynamically determine which columns to show
+        display_parameters = []
+        for cand in candidates:
+            if any(item["assignments"].get(cand, "N/A") != "N/A" for item in pivot_data):
+                display_parameters.append(cand)
+
+        # Ensure 'syntax' is at the beginning and 'notes' at the end
+        if "notes" in display_parameters:
+            display_parameters.remove("notes")
+            display_parameters.append("notes")
+        if "syntax" in display_parameters:
+            display_parameters.remove("syntax")
+            display_parameters.insert(0, "syntax")
+
         template = self.env.get_template('pivot_table.rst.j2')
         return template.render(
             language=language,
-            display_parameters=syntax_params,
+            display_parameters=display_parameters,
             pivot_data=pivot_data
         )
 


### PR DESCRIPTION
This change improves the documentation layout by implementing dynamic column selection for language-specific pivot chapters. Redundant columns like 'Multi line' or empty data type variants are now automatically omitted if no instance in the table uses them. This directly addresses the goal of having clean, independent rows for SingleLineComment and MultiLineComment patterns with only relevant columns displayed. Additionally, legacy parameter merging logic was removed from the generator to favor a consistent 'syntax' parameter across all pattern types.

Fixes #199

---
*PR created automatically by Jules for task [5210599188812207288](https://jules.google.com/task/5210599188812207288) started by @chatelao*