### PR TITLE
Add Java Bitcode to the supported languages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,6 +25,7 @@ This section compares languages based on common programming patterns.
 - x86 Assembler
 - RISC-V Assembler
 - Prolog
+- Java Bitcode
 
 **Patterns to be compared:**
 - Variable declaration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -154,6 +154,7 @@
 - [ ] Generate Pivot Chapter for PowerShell <!-- issue #15.10 -->
 - [ ] Generate Pivot Chapter for Python <!-- issue #15.11 -->
 - [x] Generate Pivot Chapter for PHP <!-- issue #15.16 -->
+- [x] Generate Pivot Chapter for Java Bitcode
 - [ ] Generate Pivot Chapter for CSS <!-- issue #15.12 -->
 - [ ] Generate Pivot Chapter for CUDA <!-- issue #15.13 -->
 - [ ] Generate Pivot Chapter for x86 Assembler <!-- issue #15.14 -->

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -23,6 +23,7 @@ This page provides an overview of the implementation status for all patterns acr
 | x86 Assembler | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | RISC-V Assembler | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Prolog | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Java Bitcode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 *Legend: ✅ = Implemented, ❌ = Not yet implemented.*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Welcome to the Bible of Babylon Documentation
    php_pivot
    riscv_pivot
    prolog_pivot
+   java_bitcode_pivot
 
 Indices and tables
 ==================

--- a/docs/java_bitcode_pivot.rst
+++ b/docs/java_bitcode_pivot.rst
@@ -1,0 +1,130 @@
+Java Bitcode Pivot Chapter
+==========================
+
+.. list-table:: Java Bitcode Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - ::
+
+           bipush 42
+           istore_1
+     - Variables are typically stored in local variable slots; 'istore_1' stores an integer in slot 1.
+   * - IfElse
+     - ::
+
+               iload_1
+               ifle L_else
+               iconst_1
+               ireturn
+           L_else:
+               iconst_0
+               ireturn
+     - Uses comparison instructions (like ifle) and labels for control flow.
+   * - Loop
+     - ::
+
+           L_loop:
+               iload_1
+               ifle L_end
+               iinc 1 -1
+               goto L_loop
+           L_end:
+     - Implemented using labels, conditional branches, and jumps.
+   * - FunctionDefinition
+     - ::
+
+           .method public static add(II)I
+               .limit stack 2
+               .limit locals 2
+               iload_0
+               iload_1
+               iadd
+               ireturn
+           .end method
+     - Defined using the .method directive (Jasmin syntax); arguments are loaded from local slots.
+   * - TryCatch
+     - ::
+
+           .catch java/lang/Exception from L_start to L_end using L_handler
+           L_start:
+               invokestatic do_something()V
+           L_end:
+               goto L_done
+           L_handler:
+               astore_1
+               aload_1
+               invokestatic handle(Ljava/lang/Exception;)V
+           L_done:
+     - Exception handlers are defined via a catch table mapping ranges to labels.
+   * - Raise
+     - ::
+
+           new java/lang/RuntimeException
+           dup
+           ldc "Error"
+           invokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V
+           athrow
+     - Uses 'athrow' instruction to raise an object from the stack as an exception.
+   * - Thread
+     - ::
+
+           new java/lang/Thread
+           dup
+           # lambda or runnable
+           invokespecial java/lang/Thread/<init>(Ljava/lang/Runnable;)V
+           invokevirtual java/lang/Thread/start()V
+     - Threads are objects; start() is invoked to begin execution.
+   * - SendMessage
+     - ::
+
+           aload_1 # queue
+           bipush 42
+           invokestatic java/lang/Integer/valueOf(I)Ljava/lang/Integer;
+           invokeinterface java/util/concurrent/BlockingQueue/put(Ljava/lang/Object;)V 2
+     - Typically involves calling methods on concurrent collection objects.
+   * - ReceiveMessage
+     - ::
+
+           aload_1 # queue
+           invokeinterface java/util/concurrent/BlockingQueue/take()Ljava/lang/Object; 1
+           astore_2 # msg
+           aload_2
+           invokestatic handle(Ljava/lang/Object;)V
+     - Blocks by calling take() on a BlockingQueue.
+   * - SingleLineComment
+     - ::
+
+           ; comment
+     - Jasmin and other JVM assemblers typically use the semicolon for comments.
+   * - MultiLineComment
+     - N/A
+     - Java Bytecode assemblers usually do not support native multi-line comments.
+   * - Print
+     - ::
+
+           getstatic java/lang/System/out Ljava/io/PrintStream;
+           ldc "Hello, World!"
+           invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
+     - Calls PrintStream.println on the System.out static field.
+   * - Import
+     - N/A
+     - Bytecode refers to classes by their fully qualified names; there is no 'import' directive in the bytecode itself.
+   * - SwitchCase
+     - ::
+
+           iload_1
+           tableswitch 1
+             1: L_case1
+             2: L_case2
+             default: L_default
+     - Uses 'tableswitch' (for contiguous values) or 'lookupswitch' (for sparse values).
+   * - Constant
+     - ::
+
+           .field public static final MAX I = 100
+     - Constants are defined as fields with the 'final' access flag.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -50,6 +50,14 @@ instance JavaVar of VariableDeclaration {
     notes = "Strongly typed, similar to C."
 }
 
+instance JavaBitcodeVar of VariableDeclaration {
+    name = "x"
+    type = "I"
+    initial_value = 42
+    syntax = "bipush 42\nistore_1"
+    notes = "Variables are typically stored in local variable slots; 'istore_1' stores an integer in slot 1."
+}
+
 instance RustVar of VariableDeclaration {
     name = "x"
     type = "i32"
@@ -193,11 +201,26 @@ instance JavaIfElse of IfElse {
     notes = "Identical to C."
 }
 
+instance JavaBitcodeIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "    iload_1\n    ifle L_else\n    iconst_1\n    ireturn\nL_else:\n    iconst_0\n    ireturn"
+    notes = "Uses comparison instructions (like ifle) and labels for control flow."
+}
+
 instance JavaLoop of Loop {
     condition = "x > 0"
     body = { raw "x = x - 1;" }
     syntax = "while (x > 0) {\n    x = x - 1;\n}"
     notes = "Identical to C."
+}
+
+instance JavaBitcodeLoop of Loop {
+    condition = "x > 0"
+    body = { raw "iinc 1 -1" }
+    syntax = "L_loop:\n    iload_1\n    ifle L_end\n    iinc 1 -1\n    goto L_loop\nL_end:"
+    notes = "Implemented using labels, conditional branches, and jumps."
 }
 
 instance RustIfElse of IfElse {
@@ -443,6 +466,15 @@ instance JavaFunction of FunctionDefinition {
     notes = "Similar to C, but typically within a class with an access modifier."
 }
 
+instance JavaBitcodeFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["I", "I"]
+    return_type = "I"
+    body = { raw "iload_0\niload_1\niadd\nireturn" }
+    syntax = ".method public static add(II)I\n    .limit stack 2\n    .limit locals 2\n    iload_0\n    iload_1\n    iadd\n    ireturn\n.end method"
+    notes = "Defined using the .method directive (Jasmin syntax); arguments are loaded from local slots."
+}
+
 instance RustFunction of FunctionDefinition {
     name = "add"
     parameters = ["a: i32", "b: i32"]
@@ -614,6 +646,15 @@ instance JavaTryCatch of TryCatch {
     notes = "Standard Java exception handling."
 }
 
+instance JavaBitcodeTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "java/lang/Exception"
+    error_variable = "e"
+    catch_body = { call handle(e) }
+    syntax = ".catch java/lang/Exception from L_start to L_end using L_handler\nL_start:\n    invokestatic do_something()V\nL_end:\n    goto L_done\nL_handler:\n    astore_1\n    aload_1\n    invokestatic handle(Ljava/lang/Exception;)V\nL_done:"
+    notes = "Exception handlers are defined via a catch table mapping ranges to labels."
+}
+
 instance RustTryCatch of TryCatch {
     try_body = { call do_something() }
     exception_type = "Result"
@@ -635,6 +676,13 @@ instance JavaRaise of Raise {
     message = "Error"
     syntax = "throw new RuntimeException(\"Error\");"
     notes = "Uses 'throw' to raise an exception."
+}
+
+instance JavaBitcodeRaise of Raise {
+    exception_type = "java/lang/RuntimeException"
+    message = "Error"
+    syntax = "new java/lang/RuntimeException\ndup\nldc \"Error\"\ninvokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V\nathrow"
+    notes = "Uses 'athrow' instruction to raise an object from the stack as an exception."
 }
 
 instance RustRaise of Raise {
@@ -937,6 +985,12 @@ instance JavaThread of Thread {
     notes = "Spawns a new platform thread; virtual threads are available in newer versions."
 }
 
+instance JavaBitcodeThread of Thread {
+    body = { call do_work() }
+    syntax = "new java/lang/Thread\ndup\n# lambda or runnable\ninvokespecial java/lang/Thread/<init>(Ljava/lang/Runnable;)V\ninvokevirtual java/lang/Thread/start()V"
+    notes = "Threads are objects; start() is invoked to begin execution."
+}
+
 instance CudaThread of Thread {
     body = { call kernel() }
     syntax = "kernel<<<grid, block>>>();"
@@ -966,6 +1020,13 @@ instance JavaSendMessage of SendMessage {
     message = "42"
     syntax = "queue.put(42);"
     notes = "Commonly implemented using BlockingQueue; put() may block if the queue is full."
+}
+
+instance JavaBitcodeSendMessage of SendMessage {
+    recipient = "queue"
+    message = "42"
+    syntax = "aload_1 # queue\nbipush 42\ninvokestatic java/lang/Integer/valueOf(I)Ljava/lang/Integer;\ninvokeinterface java/util/concurrent/BlockingQueue/put(Ljava/lang/Object;)V 2"
+    notes = "Typically involves calling methods on concurrent collection objects."
 }
 
 instance CudaSendMessage of SendMessage {
@@ -1001,6 +1062,13 @@ instance JavaReceiveMessage of ReceiveMessage {
     body = { call handle(msg) }
     syntax = "int msg = queue.take(); handle(msg);"
     notes = "Using BlockingQueue.take(); blocks until an element becomes available."
+}
+
+instance JavaBitcodeReceiveMessage of ReceiveMessage {
+    match_pattern = "msg"
+    body = { call handle(msg) }
+    syntax = "aload_1 # queue\ninvokeinterface java/util/concurrent/BlockingQueue/take()Ljava/lang/Object; 1\nastore_2 # msg\naload_2\ninvokestatic handle(Ljava/lang/Object;)V"
+    notes = "Blocks by calling take() on a BlockingQueue."
 }
 
 instance CudaReceiveMessage of ReceiveMessage {
@@ -1058,9 +1126,19 @@ instance JavaSingleLineComment of SingleLineComment {
     notes = "Identical to C."
 }
 
+instance JavaBitcodeSingleLineComment of SingleLineComment {
+    syntax = "; comment"
+    notes = "Jasmin and other JVM assemblers typically use the semicolon for comments."
+}
+
 instance JavaMultiLineComment of MultiLineComment {
     syntax = "/* line 1\n   line 2 */"
     notes = "Identical to C."
+}
+
+instance JavaBitcodeMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "Java Bytecode assemblers usually do not support native multi-line comments."
 }
 
 instance RustSingleLineComment of SingleLineComment {
@@ -1232,6 +1310,12 @@ instance JavaPrint of Print {
     notes = "Uses System.out for standard output; includes a newline."
 }
 
+instance JavaBitcodePrint of Print {
+    value = "Hello, World!"
+    syntax = "getstatic java/lang/System/out Ljava/io/PrintStream;\nldc \"Hello, World!\"\ninvokevirtual java/io/PrintStream/println(Ljava/lang/String;)V"
+    notes = "Calls PrintStream.println on the System.out static field."
+}
+
 instance RustPrint of Print {
     value = "Hello, World!"
     syntax = "println!(\"Hello, World!\");"
@@ -1341,6 +1425,12 @@ instance JavaImport of Import {
     notes = "Imports a specific class; can use * for all classes in a package."
 }
 
+instance JavaBitcodeImport of Import {
+    module_name = "java/util/List"
+    syntax = "N/A"
+    notes = "Bytecode refers to classes by their fully qualified names; there is no 'import' directive in the bytecode itself."
+}
+
 instance RustImport of Import {
     module_name = "std::collections::HashMap"
     syntax = "use std::collections::HashMap;"
@@ -1448,6 +1538,12 @@ instance JavaSwitchCase of SwitchCase {
     expression = "x"
     syntax = "switch (x) {\n    case 1:\n        return 1;\n    case 2:\n        return 2;\n    default:\n        return 0;\n}"
     notes = "Identical to C; modern Java also supports switch expressions."
+}
+
+instance JavaBitcodeSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "iload_1\ntableswitch 1\n  1: L_case1\n  2: L_case2\n  default: L_default"
+    notes = "Uses 'tableswitch' (for contiguous values) or 'lookupswitch' (for sparse values)."
 }
 
 instance RustSwitchCase of SwitchCase {
@@ -1563,6 +1659,14 @@ instance JavaConstant of Constant {
     value = "100"
     syntax = "public static final int MAX = 100;"
     notes = "Uses 'final' to prevent modification; typically combined with 'static' for class-level constants."
+}
+
+instance JavaBitcodeConstant of Constant {
+    name = "MAX"
+    type = "I"
+    value = "100"
+    syntax = ".field public static final MAX I = 100"
+    notes = "Constants are defined as fields with the 'final' access flag."
 }
 
 instance RustConstant of Constant {

--- a/src/generator.py
+++ b/src/generator.py
@@ -108,7 +108,7 @@ class CodeGenerator:
 
         # List of all known languages from DESIGN.md to avoid prefix collisions (e.g., C vs CSS)
         all_languages = [
-            "SQL", "C", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
+            "SQL", "C", "XQuery", "Java Bitcode", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
             "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog"
         ]
 
@@ -116,10 +116,10 @@ class CodeGenerator:
         for instance in program.instances:
             # First, check if any OTHER language matches the instance name better
             other_matches = [lang for lang in all_languages if lang.lower() != language.lower()
-                             and instance.name.lower().startswith(lang.lower())]
+                             and (instance.name.lower().startswith(lang.lower().replace(" ", "")) or instance.name.lower().startswith(lang.lower()))]
 
             # If the requested language matches the prefix
-            if instance.name.lower().startswith(language.lower()):
+            if instance.name.lower().startswith(language.lower().replace(" ", "")) or instance.name.lower().startswith(language.lower()):
                 # Ensure no OTHER language is a longer (better) match
                 is_best_match = True
                 for other in other_matches:


### PR DESCRIPTION
This change adds "Java Bitcode" (JVM Bytecode) as the 18th supported programming language in the comparison project. It includes technically accurate JVM instruction sequences for all core patterns, ranging from variable declaration to concurrency and exception handling. The documentation has been updated with a new pivot chapter and coverage summary. Additionally, the generator logic was refined to support flexible naming conventions for languages with multiple words.

Fixes #207

---
*PR created automatically by Jules for task [24040870199427568](https://jules.google.com/task/24040870199427568) started by @chatelao*