### PR TITLE
Dedicated Matrix Documentation and CSV Export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release Assets
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  generate-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Generate CSV Matrices
+        run: |
+          export PYTHONPATH=$PYTHONPATH:.
+          python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog" --csv > programming_matrix.csv
+          python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > data_formats_matrix.csv
+
+      - name: Upload Assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} programming_matrix.csv data_formats_matrix.csv

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__/
 docs/_build/
 docs/programming.rst
 docs/data_formats.rst
+docs/matrices.rst
 docs/appendix.rst

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,16 @@ build:
     pre_build:
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -o docs/programming.rst --title "Programming Language Patterns"
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -o docs/data_formats.rst --title "Data Format Patterns"
+      - echo "Pattern Comparison Matrices" > docs/matrices.rst
+      - echo "===========================" >> docs/matrices.rst
+      - echo "" >> docs/matrices.rst
+      - echo "Programming Languages" >> docs/matrices.rst
+      - echo "---------------------" >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog" >> docs/matrices.rst
+      - echo "" >> docs/matrices.rst
+      - echo "Data Formats" >> docs/matrices.rst
+      - echo "------------" >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" >> docs/matrices.rst
 
 python:
   install:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to the Bible of Babylon Documentation
 
    programming
    data_formats
+   matrices
    coverage
    appendix
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -219,7 +219,7 @@ class CodeGenerator:
 
         return "\n\n".join(results)
 
-    def render_matrix_table(self, program: Program, languages: List[str]) -> str:
+    def _build_matrix_data(self, program: Program, languages: List[str]):
         # 1. Get all pattern names in order
         pattern_names = [p.name for p in program.patterns]
 
@@ -259,6 +259,10 @@ class CodeGenerator:
                 row["cells"].append(syntax)
             matrix.append(row)
 
+        return pattern_names, matrix
+
+    def render_matrix_table(self, program: Program, languages: List[str]) -> str:
+        pattern_names, matrix = self._build_matrix_data(program, languages)
         template = self.env.get_template('matrix_table.rst.j2')
         return template.render(
             pattern_names=pattern_names,
@@ -273,3 +277,11 @@ class CodeGenerator:
         results.append(self.render_matrix_table(program, languages))
 
         return "\n\n".join(results)
+
+    def render_matrix_csv(self, program: Program, languages: List[str]) -> str:
+        pattern_names, matrix = self._build_matrix_data(program, languages)
+        template = self.env.get_template('matrix_table.csv.j2')
+        return template.render(
+            pattern_names=pattern_names,
+            matrix=matrix
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ def main():
     parser.add_argument("-t", "--title", help="Top-level title for the generated documentation")
     parser.add_argument("-p", "--pivot", help="Generate a pivot table for the specified language")
     parser.add_argument("-m", "--matrix", help="Generate a matrix table for the specified comma-separated languages")
+    parser.add_argument("--csv", action="store_true", help="Output in CSV format (only for matrix)")
 
     args = parser.parse_args()
 
@@ -55,7 +56,10 @@ def main():
         output_rst = generator.render_pivot_chapter(program_asg, args.pivot, title=args.title)
     elif args.matrix:
         langs = [l.strip() for l in args.matrix.split(",")]
-        output_rst = generator.render_matrix_chapter(program_asg, langs, title=args.title)
+        if args.csv:
+            output_rst = generator.render_matrix_csv(program_asg, langs)
+        else:
+            output_rst = generator.render_matrix_chapter(program_asg, langs, title=args.title)
     else:
         output_rst = generator.render_program(program_asg, title=args.title)
 

--- a/src/templates/matrix_table.csv.j2
+++ b/src/templates/matrix_table.csv.j2
@@ -1,0 +1,6 @@
+Language,{{ pattern_names|join(',') }}
+{%- for row in matrix %}
+"{{ row.language }}",{% for cell in row.cells -%}
+"{{ cell|format_value|replace('"', '""') }}"{{ "," if not loop.last }}
+{%- endfor %}
+{%- endfor -%}


### PR DESCRIPTION
This change moves the pattern comparison matrices to a dedicated documentation chapter (docs/matrices.rst) and adds the ability to export these matrices as CSV files. 

Key improvements:
- Documentation: Matrices are now in their own section, keeping programming.rst and data_formats.rst focused on individual patterns.
- Portability: The transpiler now supports a --csv flag for matrices, facilitating external analysis.
- Automation: A new release workflow automatically attaches programming and data format matrices as CSV assets to GitHub releases.
- Maintenance: Shared internal logic in CodeGenerator ensures consistency between RST and CSV outputs.

Fixes #216

---
*PR created automatically by Jules for task [2763779333356342731](https://jules.google.com/task/2763779333356342731) started by @chatelao*