### PR TITLE
Add Java Bytecode Support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,6 +25,7 @@ This section compares languages based on common programming patterns.
 - x86 Assembler
 - RISC-V Assembler
 - Prolog
+- Java Bytecode
 
 **Patterns to be compared:**
 - Variable declaration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -159,3 +159,4 @@
 - [ ] Generate Pivot Chapter for x86 Assembler <!-- issue #15.14 -->
 - [x] Generate Pivot Chapter for RISC-V Assembler
 - [x] Generate Pivot Chapter for Prolog <!-- issue #15.15 -->
+- [ ] Generate Pivot Chapter for Java Bytecode

--- a/docs/c_pivot.rst
+++ b/docs/c_pivot.rst
@@ -1,5 +1,5 @@
-C Pivot
-=======
+C Pivot View
+============
 
 .. list-table:: C Pivot Table
    :widths: auto
@@ -9,12 +9,12 @@ C Pivot
      - Syntax
      - Notes
    * - VariableDeclaration
-     - ::
+     - .. code-block:: c
 
            int x = 42;
      - Static typing, terminated by semicolon.
    * - IfElse
-     - ::
+     - .. code-block:: c
 
            if (x > 0) {
                return 1;
@@ -23,14 +23,14 @@ C Pivot
            }
      - Standard C if-else statement.
    * - Loop
-     - ::
+     - .. code-block:: c
 
            while (x > 0) {
                x = x - 1;
            }
      - Standard C while loop.
    * - FunctionDefinition
-     - ::
+     - .. code-block:: c
 
            int add(int a, int b) {
                return a + b;
@@ -40,33 +40,33 @@ C Pivot
      - N/A
      - C does not have native try-catch blocks; error handling is usually manual.
    * - Raise
-     - ::
+     - .. code-block:: c
 
            exit(1);
      - C uses exit() or signals for severe errors.
    * - SingleLineComment
-     - ::
+     - .. code-block:: c
 
            // comment
      - Standard C single-line comment.
    * - MultiLineComment
-     - ::
+     - .. code-block:: c
 
            /* line 1
               line 2 */
      - Standard C multi-line comment.
    * - Print
-     - ::
+     - .. code-block:: c
 
            printf("Hello, World!\n");
      - Uses the standard library's printf function; requires stdio.h.
    * - Import
-     - ::
+     - .. code-block:: c
 
            #include <stdio.h>
      - Standard C way to include header files.
    * - SwitchCase
-     - ::
+     - .. code-block:: c
 
            switch (x) {
                case 1:
@@ -78,7 +78,7 @@ C Pivot
            }
      - Standard C switch statement with case labels and default.
    * - Constant
-     - ::
+     - .. code-block:: c
 
            const int MAX = 100;
      - The 'const' qualifier makes the variable immutable after initialization.

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -23,6 +23,7 @@ This page provides an overview of the implementation status for all patterns acr
 | x86 Assembler | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | RISC-V Assembler | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Prolog | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Java Bytecode | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 *Legend: ✅ = Implemented, ❌ = Not yet implemented.*
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Welcome to the Bible of Babylon Documentation
    php_pivot
    riscv_pivot
    prolog_pivot
+   java_bytecode_pivot
 
 Indices and tables
 ==================

--- a/docs/java_bytecode_pivot.rst
+++ b/docs/java_bytecode_pivot.rst
@@ -1,0 +1,144 @@
+Java Bytecode Pivot View
+========================
+
+.. list-table:: Java Bytecode Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: jasm
+
+           .field private static x I = 42
+     - In Jasmin syntax, static fields represent global-like variables.
+   * - IfElse
+     - .. code-block:: jasm
+
+               getstatic MyClass/x I
+               ifgt LabelThen
+               iconst_0
+               ireturn
+           LabelThen:
+               iconst_1
+               ireturn
+     - Implemented using stack operations and branch instructions (ifgt).
+   * - Loop
+     - .. code-block:: jasm
+
+           LoopStart:
+               getstatic MyClass/x I
+               ifle LoopEnd
+               getstatic MyClass/x I
+               iconst_1
+               isub
+               putstatic MyClass/x I
+               goto LoopStart
+           LoopEnd:
+     - Loops are built with labels and jump instructions (goto, ifle).
+   * - FunctionDefinition
+     - .. code-block:: jasm
+
+           .method public static add(II)I
+               .limit stack 2
+               .limit locals 2
+               iload_0
+               iload_1
+               iadd
+               ireturn
+           .end method
+     - Methods define stack and local variable limits; parameters are accessed by index.
+   * - TryCatch
+     - .. code-block:: jasm
+
+           .catch java/lang/Exception from TryStart to TryEnd using CatchHandler
+           TryStart:
+               invokestatic MyClass/do_something()V
+           TryEnd:
+               goto Done
+           CatchHandler:
+               astore_1
+               aload_1
+               invokestatic MyClass/handle(Ljava/lang/Exception;)V
+           Done:
+     - Exception handlers are defined via .catch directives for specific code ranges.
+   * - Raise
+     - .. code-block:: jasm
+
+               new java/lang/RuntimeException
+               dup
+               ldc "Error"
+               invokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V
+               athrow
+     - Exceptions are instantiated and then thrown using the athrow instruction.
+   * - Print
+     - .. code-block:: jasm
+
+               getstatic java/lang/System/out Ljava/io/PrintStream;
+               ldc "Hello, World!"
+               invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
+     - Calls println on the static System.out field.
+   * - Thread
+     - .. code-block:: jasm
+
+               new java/lang/Thread
+               dup
+               new MyRunnable
+               dup
+               invokespecial MyRunnable/<init>()V
+               invokespecial java/lang/Thread/<init>(Ljava/lang/Runnable;)V
+               invokevirtual java/lang/Thread/start()V
+     - Involves instantiating a Thread object with a Runnable and calling start().
+   * - SendMessage
+     - .. code-block:: jasm
+
+               aload_0 ; queue
+               bipush 42
+               invokestatic java/lang/Integer/valueOf(I)Ljava/lang/Integer;
+               invokevirtual java/util/concurrent/BlockingQueue/put(Ljava/lang/Object;)V
+     - Typically uses standard Java concurrent collections like BlockingQueue.
+   * - ReceiveMessage
+     - .. code-block:: jasm
+
+               aload_0 ; queue
+               invokevirtual java/util/concurrent/BlockingQueue/take()Ljava/lang/Object;
+               checkcast java/lang/Integer
+               invokevirtual java/lang/Integer/intValue()I
+               istore_1 ; msg
+               iload_1
+               invokestatic MyClass/handle(I)V
+     - Blocking retrieval from a concurrent collection.
+   * - SingleLineComment
+     - .. code-block:: jasm
+
+           ; comment
+     - Jasmin uses semicolons for single-line comments.
+   * - MultiLineComment
+     - N/A
+     - Java Bitcode (Jasmin) does not have a native multi-line comment syntax; multiple semicolons are used.
+   * - Import
+     - .. code-block:: jasm
+
+           Ljava/util/List;
+     - Internal descriptors are used to reference external classes.
+   * - SwitchCase
+     - .. code-block:: jasm
+
+               getstatic MyClass/x I
+               lookupswitch
+                   1: Label1
+                   2: Label2
+                   default: LabelDefault
+           Label1:
+               ; ...
+           Label2:
+               ; ...
+           LabelDefault:
+               ; ...
+     - Uses lookupswitch or tableswitch instructions for multi-way branching.
+   * - Constant
+     - .. code-block:: jasm
+
+           .field public static final MAX I = 100
+     - Constants are represented as static final fields.

--- a/docs/php_pivot.rst
+++ b/docs/php_pivot.rst
@@ -1,5 +1,5 @@
-PHP Pivot
-=========
+PHP Pivot View
+==============
 
 .. list-table:: PHP Pivot Table
    :widths: auto
@@ -9,12 +9,12 @@ PHP Pivot
      - Syntax
      - Notes
    * - VariableDeclaration
-     - ::
+     - .. code-block:: php
 
            $x = 42;
      - Variables start with a dollar sign; dynamically typed but supports type declarations.
    * - IfElse
-     - ::
+     - .. code-block:: php
 
            if ($x > 0) {
                return 1;
@@ -23,21 +23,21 @@ PHP Pivot
            }
      - Standard C-like if-else statement.
    * - Loop
-     - ::
+     - .. code-block:: php
 
            while ($x > 0) {
                $x = $x - 1;
            }
      - Standard C-like while loop.
    * - FunctionDefinition
-     - ::
+     - .. code-block:: php
 
            function add(int $a, int $b): int {
                return $a + $b;
            }
      - Uses 'function' keyword; supports type hints for parameters and return values.
    * - TryCatch
-     - ::
+     - .. code-block:: php
 
            try {
                do_something();
@@ -46,33 +46,33 @@ PHP Pivot
            }
      - Standard PHP exception handling using try-catch blocks.
    * - Raise
-     - ::
+     - .. code-block:: php
 
            throw new Exception("Error");
      - Uses 'throw' to trigger an exception.
    * - SingleLineComment
-     - ::
+     - .. code-block:: php
 
            // comment
      - Supports // and # for single-line comments.
    * - MultiLineComment
-     - ::
+     - .. code-block:: php
 
            /* line 1
               line 2 */
      - Standard C-style block comments.
    * - Print
-     - ::
+     - .. code-block:: php
 
            echo "Hello, World!";
      - The echo statement is used to output text.
    * - Import
-     - ::
+     - .. code-block:: php
 
            require 'utils.php';
      - Uses include, require, include_once, or require_once to include other files.
    * - SwitchCase
-     - ::
+     - .. code-block:: php
 
            switch ($x) {
                case 1:
@@ -84,7 +84,7 @@ PHP Pivot
            }
      - Standard C-like switch statement; match expression is also available in PHP 8.0+.
    * - Constant
-     - ::
+     - .. code-block:: php
 
            define('MAX', 100);
      - Constants can be defined using define() or the 'const' keyword (for class constants or global constants in modern PHP).

--- a/docs/prolog_pivot.rst
+++ b/docs/prolog_pivot.rst
@@ -1,5 +1,5 @@
-Prolog Pivot
-============
+Prolog Pivot View
+=================
 
 .. list-table:: Prolog Pivot Table
    :widths: auto
@@ -9,73 +9,74 @@ Prolog Pivot
      - Syntax
      - Notes
    * - VariableDeclaration
-     - ::
+     - .. code-block:: prolog
 
            X = 42.
      - Uses unification for assignment; variables must start with an uppercase letter.
    * - IfElse
-     - ::
+     - .. code-block:: prolog
 
            (X > 0 -> Result = 1 ; Result = 0)
      - Uses the (Condition -> Then ; Else) control construct.
    * - Loop
-     - ::
+     - .. code-block:: prolog
 
            loop(0) :- !.
            loop(X) :- X > 0, X1 is X - 1, loop(X1).
      - Prolog uses recursion and tail-call optimization for looping.
    * - FunctionDefinition
-     - ::
+     - .. code-block:: prolog
 
            add(A, B, Res) :- Res is A + B.
      - Functions are predicates; return values are typically unified with an output argument.
    * - TryCatch
-     - ::
+     - .. code-block:: prolog
 
            catch(do_something, E, handle(E))
      - Standard Prolog error handling using the catch/3 predicate.
    * - Raise
-     - ::
+     - .. code-block:: prolog
 
            throw(error(Error))
      - Uses throw/1 to raise an exception.
    * - Thread
-     - ::
+     - .. code-block:: prolog
 
            thread_create(do_work, Id, []).
      - Creates a new thread using thread_create/3 (ISO Prolog / SWI-Prolog).
    * - SendMessage
-     - ::
+     - .. code-block:: prolog
 
            thread_send_message(Id, hello).
      - Sends a message to a thread's message queue.
    * - ReceiveMessage
-     - ::
+     - .. code-block:: prolog
 
            thread_get_message(hello).
      - Retrieves a matching message from the current thread's queue.
    * - SingleLineComment
-     - ::
+     - .. code-block:: prolog
 
            % comment
      - Standard Prolog single-line comment.
    * - MultiLineComment
-     - ::
+     - .. code-block:: prolog
 
-           /* line 1\n   line 2 */
+           /* line 1
+              line 2 */
      - Standard C-style block comment.
    * - Print
-     - ::
+     - .. code-block:: prolog
 
            writeln('Hello, World!').
      - Outputs text followed by a newline.
    * - Import
-     - ::
+     - .. code-block:: prolog
 
            use_module(library(math)).
      - Imports predicates from a library module.
    * - SwitchCase
-     - ::
+     - .. code-block:: prolog
 
            (   X = 1 -> writeln('one')
            ;   X = 2 -> writeln('two')
@@ -83,7 +84,7 @@ Prolog Pivot
            )
      - Usually implemented using nested (If -> Then ; Else) or multiple clauses.
    * - Constant
-     - ::
+     - .. code-block:: prolog
 
            max(100).
      - Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment.

--- a/docs/riscv_pivot.rst
+++ b/docs/riscv_pivot.rst
@@ -1,7 +1,7 @@
-RISC-V Assembler Pivot
-======================
+RISC-V Assembler Pivot View
+===========================
 
-.. list-table:: Riscv Pivot Table
+.. list-table:: RISC-V Assembler Pivot Table
    :widths: auto
    :header-rows: 1
 
@@ -9,12 +9,12 @@ RISC-V Assembler Pivot
      - Syntax
      - Notes
    * - VariableDeclaration
-     - ::
+     - .. code-block:: asm
 
            x:  .word 42
      - Defined in the .data section.
    * - IfElse
-     - ::
+     - .. code-block:: asm
 
                blez t0, .else
                li a0, 1
@@ -24,7 +24,7 @@ RISC-V Assembler Pivot
            .end:
      - Uses branch instructions like blez (branch if less than or equal to zero).
    * - Loop
-     - ::
+     - .. code-block:: asm
 
            .loop:
                blez t0, .end
@@ -33,7 +33,7 @@ RISC-V Assembler Pivot
            .end:
      - Uses conditional branches and jumps to implement loops.
    * - FunctionDefinition
-     - ::
+     - .. code-block:: asm
 
            add:
                add a0, a0, a1
@@ -43,30 +43,30 @@ RISC-V Assembler Pivot
      - N/A
      - No native try-catch; relies on return codes or trap handlers for errors.
    * - Raise
-     - ::
+     - .. code-block:: asm
 
                ebreak
      - The ebreak instruction triggers a debug trap; ecall can be used for system calls.
    * - Thread
-     - ::
+     - .. code-block:: asm
 
                li a7, 220 # clone syscall
                ecall
      - Thread creation typically involves invoking OS system calls (e.g., clone in Linux).
    * - SendMessage
-     - ::
+     - .. code-block:: asm
 
                li a7, 139 # rt_sigqueueinfo
                ecall
      - Inter-process/thread communication is managed by the OS.
    * - ReceiveMessage
-     - ::
+     - .. code-block:: asm
 
                li a7, 128 # rt_sigtimedwait
                ecall
      - Receiving signals or messages involves OS system calls.
    * - SingleLineComment
-     - ::
+     - .. code-block:: asm
 
            # comment
      - RISC-V assembly typically uses the hash character for single-line comments.
@@ -74,18 +74,18 @@ RISC-V Assembler Pivot
      - N/A
      - RISC-V assembly does not have a native multi-line comment syntax.
    * - Print
-     - ::
+     - .. code-block:: asm
 
                la a0, hello_msg
                call printf
      - Typically uses the C library printf or writes to stdout via system calls.
    * - Import
-     - ::
+     - .. code-block:: asm
 
            .include "macros.s"
      - Uses the .include directive to include external source files.
    * - SwitchCase
-     - ::
+     - .. code-block:: asm
 
                li t1, 1
                beq t0, t1, .case1
@@ -94,7 +94,7 @@ RISC-V Assembler Pivot
                j .default
      - Typically implemented using comparison and branch instructions.
    * - Constant
-     - ::
+     - .. code-block:: asm
 
            .equiv MAX, 100
      - Uses the .equiv or .set directive to define constants.

--- a/docs/sql_pivot.rst
+++ b/docs/sql_pivot.rst
@@ -1,5 +1,5 @@
-SQL Pivot
-=========
+SQL Pivot View
+==============
 
 .. list-table:: SQL Pivot Table
    :widths: auto
@@ -9,12 +9,12 @@ SQL Pivot
      - Syntax
      - Notes
    * - VariableDeclaration
-     - ::
+     - .. code-block:: sql
 
            DECLARE @x INT = 42;
      - T-SQL syntax for variable declaration.
    * - IfElse
-     - ::
+     - .. code-block:: sql
 
            IF @x > 0
            BEGIN
@@ -26,7 +26,7 @@ SQL Pivot
            END
      - Uses IF-ELSE with BEGIN-END blocks.
    * - Loop
-     - ::
+     - .. code-block:: sql
 
            WHILE @x > 0
            BEGIN
@@ -34,7 +34,7 @@ SQL Pivot
            END
      - Standard WHILE loop in T-SQL.
    * - FunctionDefinition
-     - ::
+     - .. code-block:: sql
 
            CREATE FUNCTION add(@a INT, @b INT)
            RETURNS INT AS
@@ -43,7 +43,7 @@ SQL Pivot
            END
      - T-SQL syntax for Scalar-Valued Functions.
    * - TryCatch
-     - ::
+     - .. code-block:: sql
 
            BEGIN TRY
                EXEC do_something;
@@ -53,23 +53,23 @@ SQL Pivot
            END CATCH
      - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
    * - Raise
-     - ::
+     - .. code-block:: sql
 
            THROW 50000, 'Error', 1;
      - The THROW statement raises an exception and transfers execution to a CATCH block.
    * - SingleLineComment
-     - ::
+     - .. code-block:: sql
 
            -- comment
      - Standard SQL single-line comment.
    * - MultiLineComment
-     - ::
+     - .. code-block:: sql
 
            /* line 1
               line 2 */
      - Standard SQL multi-line comment.
    * - Print
-     - ::
+     - .. code-block:: sql
 
            PRINT 'Hello, World!';
      - T-SQL PRINT statement outputs a message to the client.
@@ -77,7 +77,7 @@ SQL Pivot
      - N/A
      - Standard SQL does not have a native 'import' keyword for code; database objects are globally accessible or schema-qualified.
    * - SwitchCase
-     - ::
+     - .. code-block:: sql
 
            CASE @x
                WHEN 1 THEN 'one'
@@ -86,7 +86,7 @@ SQL Pivot
            END
      - The CASE expression is used for conditional logic in SQL.
    * - Constant
-     - ::
+     - .. code-block:: sql
 
            DECLARE @MAX INT = 100;
      - T-SQL variables are not strictly constant, but can be treated as such within a batch or procedure.

--- a/docs/xquery_pivot.rst
+++ b/docs/xquery_pivot.rst
@@ -1,5 +1,5 @@
-XQuery Pivot
-============
+XQuery Pivot View
+=================
 
 .. list-table:: XQuery Pivot Table
    :widths: auto
@@ -9,22 +9,22 @@ XQuery Pivot
      - Syntax
      - Notes
    * - VariableDeclaration
-     - ::
+     - .. code-block:: xquery
 
            let $x := 42
      - XQuery uses 'let' for variable binding.
    * - IfElse
-     - ::
+     - .. code-block:: xquery
 
            if ($x > 0) then 1 else 0
      - Functional if-then-else expression; both branches are required.
    * - Loop
-     - ::
+     - .. code-block:: xquery
 
            for $i in 1 to $x return $i
      - XQuery uses 'for' expressions for iteration over sequences.
    * - FunctionDefinition
-     - ::
+     - .. code-block:: xquery
 
            declare function local:add(
                $a as xs:integer,
@@ -34,7 +34,7 @@ XQuery Pivot
            };
      - Functions must be declared in a namespace (e.g., 'local').
    * - TryCatch
-     - ::
+     - .. code-block:: xquery
 
            try {
                do_something()
@@ -43,33 +43,33 @@ XQuery Pivot
            }
      - XQuery 3.0+ supports try-catch; $err is a variable containing error information.
    * - Raise
-     - ::
+     - .. code-block:: xquery
 
            fn:error(fn:QName('http://example.com/errors', 'MY_ERROR'), 'Error')
      - The fn:error() function signals a dynamic error.
    * - SingleLineComment
-     - ::
+     - .. code-block:: xquery
 
            (: comment :)
      - XQuery uses (: :) for single-line comments.
    * - MultiLineComment
-     - ::
+     - .. code-block:: xquery
 
            (: line 1
               line 2 :)
      - XQuery uses (: :) for multi-line comments.
    * - Print
-     - ::
+     - .. code-block:: xquery
 
            "Hello, World!"
      - In XQuery, a string literal is often the result of an expression and is automatically serialized to output.
    * - Import
-     - ::
+     - .. code-block:: xquery
 
            import module namespace utils = "http://example.com/utils";
      - Imports a library module by its namespace URI.
    * - SwitchCase
-     - ::
+     - .. code-block:: xquery
 
            switch ($x)
              case 1 return "one"
@@ -77,7 +77,7 @@ XQuery Pivot
              default return "none"
      - The 'switch' expression was introduced in XQuery 3.0.
    * - Constant
-     - ::
+     - .. code-block:: xquery
 
            declare variable $MAX as xs:integer := 100;
      - In XQuery, variables declared in the prolog are immutable by default.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -1684,3 +1684,107 @@ instance PrologConstant of Constant {
     syntax = "max(100)."
     notes = "Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment."
 }
+
+instance JavaBytecodeVar of VariableDeclaration {
+    name = "x"
+    type = "I"
+    initial_value = 42
+    syntax = ".field private static x I = 42"
+    notes = "In Jasmin syntax, static fields represent global-like variables."
+}
+
+instance JavaBytecodeIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "    getstatic MyClass/x I\n    ifgt LabelThen\n    iconst_0\n    ireturn\nLabelThen:\n    iconst_1\n    ireturn"
+    notes = "Implemented using stack operations and branch instructions (ifgt)."
+}
+
+instance JavaBytecodeLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x = x - 1;" }
+    syntax = "LoopStart:\n    getstatic MyClass/x I\n    ifle LoopEnd\n    getstatic MyClass/x I\n    iconst_1\n    isub\n    putstatic MyClass/x I\n    goto LoopStart\nLoopEnd:"
+    notes = "Loops are built with labels and jump instructions (goto, ifle)."
+}
+
+instance JavaBytecodeFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["I", "I"]
+    return_type = "I"
+    body = { raw "iload_0\niload_1\niadd\nireturn" }
+    syntax = ".method public static add(II)I\n    .limit stack 2\n    .limit locals 2\n    iload_0\n    iload_1\n    iadd\n    ireturn\n.end method"
+    notes = "Methods define stack and local variable limits; parameters are accessed by index."
+}
+
+instance JavaBytecodeTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "java/lang/Exception"
+    error_variable = "e"
+    catch_body = { call handle(e) }
+    syntax = ".catch java/lang/Exception from TryStart to TryEnd using CatchHandler\nTryStart:\n    invokestatic MyClass/do_something()V\nTryEnd:\n    goto Done\nCatchHandler:\n    astore_1\n    aload_1\n    invokestatic MyClass/handle(Ljava/lang/Exception;)V\nDone:"
+    notes = "Exception handlers are defined via .catch directives for specific code ranges."
+}
+
+instance JavaBytecodeRaise of Raise {
+    exception_type = "java/lang/RuntimeException"
+    message = "Error"
+    syntax = "    new java/lang/RuntimeException\n    dup\n    ldc \"Error\"\n    invokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V\n    athrow"
+    notes = "Exceptions are instantiated and then thrown using the athrow instruction."
+}
+
+instance JavaBytecodePrint of Print {
+    value = "Hello, World!"
+    syntax = "    getstatic java/lang/System/out Ljava/io/PrintStream;\n    ldc \"Hello, World!\"\n    invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V"
+    notes = "Calls println on the static System.out field."
+}
+
+instance JavaBytecodeThread of Thread {
+    body = { call do_work() }
+    syntax = "    new java/lang/Thread\n    dup\n    new MyRunnable\n    dup\n    invokespecial MyRunnable/<init>()V\n    invokespecial java/lang/Thread/<init>(Ljava/lang/Runnable;)V\n    invokevirtual java/lang/Thread/start()V"
+    notes = "Involves instantiating a Thread object with a Runnable and calling start()."
+}
+
+instance JavaBytecodeSendMessage of SendMessage {
+    recipient = "queue"
+    message = "42"
+    syntax = "    aload_0 ; queue\n    bipush 42\n    invokestatic java/lang/Integer/valueOf(I)Ljava/lang/Integer;\n    invokevirtual java/util/concurrent/BlockingQueue/put(Ljava/lang/Object;)V"
+    notes = "Typically uses standard Java concurrent collections like BlockingQueue."
+}
+
+instance JavaBytecodeReceiveMessage of ReceiveMessage {
+    match_pattern = "msg"
+    body = { call handle(msg) }
+    syntax = "    aload_0 ; queue\n    invokevirtual java/util/concurrent/BlockingQueue/take()Ljava/lang/Object;\n    checkcast java/lang/Integer\n    invokevirtual java/lang/Integer/intValue()I\n    istore_1 ; msg\n    iload_1\n    invokestatic MyClass/handle(I)V"
+    notes = "Blocking retrieval from a concurrent collection."
+}
+
+instance JavaBytecodeSingleLineComment of SingleLineComment {
+    syntax = "; comment"
+    notes = "Jasmin uses semicolons for single-line comments."
+}
+
+instance JavaBytecodeMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "Java Bitcode (Jasmin) does not have a native multi-line comment syntax; multiple semicolons are used."
+}
+
+instance JavaBytecodeImport of Import {
+    module_name = "java/util/List"
+    syntax = "Ljava/util/List;"
+    notes = "Internal descriptors are used to reference external classes."
+}
+
+instance JavaBytecodeSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "    getstatic MyClass/x I\n    lookupswitch\n        1: Label1\n        2: Label2\n        default: LabelDefault\nLabel1:\n    ; ...\nLabel2:\n    ; ...\nLabelDefault:\n    ; ..."
+    notes = "Uses lookupswitch or tableswitch instructions for multi-way branching."
+}
+
+instance JavaBytecodeConstant of Constant {
+    name = "MAX"
+    type = "I"
+    value = "100"
+    syntax = ".field public static final MAX I = 100"
+    notes = "Constants are represented as static final fields."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -52,7 +52,7 @@ class CodeGenerator:
     PROGRAMMING_LANGUAGES = [
         "SQL", "C", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
-        "X86", "Riscv"
+        "X86", "Riscv", "Java Bytecode"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
@@ -79,6 +79,7 @@ class CodeGenerator:
         "RISC-V Assembler": "asm",
         "Riscv": "asm",
         "Prolog": "prolog",
+        "Java Bytecode": "jasm",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",
@@ -99,6 +100,13 @@ class CodeGenerator:
         self.env.filters['format_table_cell'] = format_table_cell
         self.env.filters['get_lexer'] = self.get_lexer
 
+    def _normalize(self, name: str) -> str:
+        """
+        Normalizes a language or format name for prefix matching by removing
+        spaces, hyphens, and the word 'assembler'.
+        """
+        return name.lower().replace(" ", "").replace("-", "").replace("assembler", "")
+
     def get_lexer(self, name: str) -> str:
         """
         Determines the Pygments lexer for a given instance or language name
@@ -106,7 +114,7 @@ class CodeGenerator:
         """
         best_match = None
         for key in self.LEXER_MAP:
-            if name.lower().startswith(key.lower()):
+            if name.lower().startswith(self._normalize(key)) or name.lower().startswith(key.lower()):
                 if best_match is None or len(key) > len(best_match):
                     best_match = key
 
@@ -164,10 +172,11 @@ class CodeGenerator:
         for instance in program.instances:
             # First, check if any OTHER language matches the instance name better
             other_matches = [lang for lang in self.ALL_SUPPORTED if lang.lower() != language.lower()
-                             and instance.name.lower().startswith(lang.lower())]
+                             and (instance.name.lower().startswith(self._normalize(lang))
+                                  or instance.name.lower().startswith(lang.lower()))]
 
             # If the requested language matches the prefix
-            if instance.name.lower().startswith(language.lower()):
+            if instance.name.lower().startswith(self._normalize(language)) or instance.name.lower().startswith(language.lower()):
                 # Ensure no OTHER language is a longer (better) match
                 is_best_match = True
                 for other in other_matches:
@@ -233,9 +242,9 @@ class CodeGenerator:
                 instance = None
 
                 for inst in program.instances:
-                    if inst.pattern_name == p_name and inst.name.lower().startswith(lang.lower()):
+                    if inst.pattern_name == p_name and (inst.name.lower().startswith(self._normalize(lang)) or inst.name.lower().startswith(lang.lower())):
                         other_matches = [l for l in self.ALL_SUPPORTED if l.lower() != lang.lower()
-                                         and inst.name.lower().startswith(l.lower())]
+                                         and (inst.name.lower().startswith(self._normalize(l)) or inst.name.lower().startswith(l.lower()))]
                         is_best_match = True
                         for other in other_matches:
                             if len(other) > len(lang):


### PR DESCRIPTION
This change adds comprehensive support for Java Bytecode (using Jasmin assembler syntax) to the "Bible of Babylon" project. 

Key improvements:
- **Java Bytecode Integration**: Added 15 new instances to `patterns/programming.patterns` covering core features like variable declarations, control flow, functions, error handling, and concurrency.
- **Robust Language Matching**: Enhanced `src/generator.py` with a `_normalize` method that allows the documentation generator to correctly map space-separated language names (e.g., "Java Bytecode", "RISC-V Assembler") to their corresponding DSL identifiers (e.g., `JavaBytecodeVar`, `RiscvIfElse`).
- **Documentation Updates**: Generated a new `java_bytecode_pivot.rst` chapter and updated the main documentation index, coverage matrix, and project roadmap.
- **Bug Fixes**: Resolved a regression where "RISC-V Assembler" patterns were not being correctly identified in pivot chapters.
- **Testing**: Verified changes with `pytest` and by manually inspecting the generated reStructuredText files.

Fixes #214

---
*PR created automatically by Jules for task [645405125377884317](https://jules.google.com/task/645405125377884317) started by @chatelao*