### PR TITLE
Pivot Pattern Comparison Matrices

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,11 +13,11 @@ build:
       - echo "" >> docs/matrices.rst
       - echo "Programming Languages" >> docs/matrices.rst
       - echo "---------------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog" >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog" --pivot-matrix >> docs/matrices.rst
       - echo "" >> docs/matrices.rst
       - echo "Data Formats" >> docs/matrices.rst
       - echo "------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
 
 python:
   install:

--- a/src/generator.py
+++ b/src/generator.py
@@ -237,74 +237,112 @@ class CodeGenerator:
 
         return "\n\n".join(results)
 
-    def _build_matrix_data(self, program: Program, languages: List[str]):
+    def _build_matrix_data(self, program: Program, languages: List[str], pivoted: bool = False):
         # 1. Get all pattern names in order
         pattern_names = [p.name for p in program.patterns]
 
         # 2. Build the matrix: row = language, column = pattern
         matrix = []
-        for lang in languages:
-            row = {"language": lang, "cells": []}
-            for p_name in pattern_names:
-                # Find the instance for this language and pattern
-                # Using the same "longest match" logic as in render_pivot_table
-                instance = None
 
-                for inst in program.instances:
-                    if inst.pattern_name == p_name and (inst.name.lower().startswith(self._normalize(lang)) or inst.name.lower().startswith(lang.lower())):
-                        other_matches = [l for l in self.ALL_SUPPORTED if l.lower() != lang.lower()
-                                         and (inst.name.lower().startswith(self._normalize(l)) or inst.name.lower().startswith(l.lower()))]
-                        is_best_match = True
-                        for other in other_matches:
-                            if len(other) > len(lang):
-                                is_best_match = False
+        if not pivoted:
+            # Traditional matrix: Rows = Languages, Columns = Patterns
+            for lang in languages:
+                row = {"label": lang, "cells": []}
+                for p_name in pattern_names:
+                    # Find the instance for this language and pattern
+                    instance = None
+                    for inst in program.instances:
+                        if inst.pattern_name == p_name and (inst.name.lower().startswith(self._normalize(lang)) or inst.name.lower().startswith(lang.lower())):
+                            other_matches = [l for l in self.ALL_SUPPORTED if l.lower() != lang.lower()
+                                             and (inst.name.lower().startswith(self._normalize(l)) or inst.name.lower().startswith(l.lower()))]
+                            is_best_match = True
+                            for other in other_matches:
+                                if len(other) > len(lang):
+                                    is_best_match = False
+                                    break
+                            if is_best_match:
+                                instance = inst
                                 break
-                        if is_best_match:
-                            instance = inst
-                            break
 
-                if instance:
-                    # Try to find a displayable value in priority order
-                    syntax = "N/A"
-                    priority_params = [
-                        "syntax", "string_val", "number_val", "boolean_val",
-                        "plus", "minus", "times", "divide", "mod", "floor", "round",
-                        "bit_and", "bit_or", "bit_xor", "bit_not", "bit_lshift", "bit_rshift"
-                    ]
-                    for param in priority_params:
-                        val = next((a.value for a in instance.assignments if a.name == param), None)
-                        if val and val != "N/A":
-                            syntax = val
-                            break
-                else:
-                    syntax = "N/A"
+                    if instance:
+                        syntax = "N/A"
+                        priority_params = [
+                            "syntax", "string_val", "number_val", "boolean_val",
+                            "plus", "minus", "times", "divide", "mod", "floor", "round",
+                            "bit_and", "bit_or", "bit_xor", "bit_not", "bit_lshift", "bit_rshift"
+                        ]
+                        for param in priority_params:
+                            val = next((a.value for a in instance.assignments if a.name == param), None)
+                            if val and val != "N/A":
+                                syntax = val
+                                break
+                    else:
+                        syntax = "N/A"
 
-                row["cells"].append(syntax)
-            matrix.append(row)
+                    row["cells"].append({"value": syntax, "lexer": self.get_lexer(lang)})
+                matrix.append(row)
+            headers = ["Language"] + pattern_names
+        else:
+            # Pivoted matrix: Rows = Patterns, Columns = Languages
+            for p_name in pattern_names:
+                row = {"label": p_name, "cells": []}
+                for lang in languages:
+                    instance = None
+                    for inst in program.instances:
+                        if inst.pattern_name == p_name and (inst.name.lower().startswith(self._normalize(lang)) or inst.name.lower().startswith(lang.lower())):
+                            other_matches = [l for l in self.ALL_SUPPORTED if l.lower() != lang.lower()
+                                             and (inst.name.lower().startswith(self._normalize(l)) or inst.name.lower().startswith(l.lower()))]
+                            is_best_match = True
+                            for other in other_matches:
+                                if len(other) > len(lang):
+                                    is_best_match = False
+                                    break
+                            if is_best_match:
+                                instance = inst
+                                break
 
-        return pattern_names, matrix
+                    if instance:
+                        syntax = "N/A"
+                        priority_params = [
+                            "syntax", "string_val", "number_val", "boolean_val",
+                            "plus", "minus", "times", "divide", "mod", "floor", "round",
+                            "bit_and", "bit_or", "bit_xor", "bit_not", "bit_lshift", "bit_rshift"
+                        ]
+                        for param in priority_params:
+                            val = next((a.value for a in instance.assignments if a.name == param), None)
+                            if val and val != "N/A":
+                                syntax = val
+                                break
+                    else:
+                        syntax = "N/A"
 
-    def render_matrix_table(self, program: Program, languages: List[str]) -> str:
-        pattern_names, matrix = self._build_matrix_data(program, languages)
+                    row["cells"].append({"value": syntax, "lexer": self.get_lexer(lang)})
+                matrix.append(row)
+            headers = ["Pattern"] + languages
+
+        return headers, matrix
+
+    def render_matrix_table(self, program: Program, languages: List[str], pivoted: bool = False) -> str:
+        headers, matrix = self._build_matrix_data(program, languages, pivoted=pivoted)
         template = self.env.get_template('matrix_table.rst.j2')
         return template.render(
-            pattern_names=pattern_names,
+            headers=headers,
             matrix=matrix
         )
 
-    def render_matrix_chapter(self, program: Program, languages: List[str], title: str = None) -> str:
+    def render_matrix_chapter(self, program: Program, languages: List[str], title: str = None, pivoted: bool = False) -> str:
         results = []
         if title:
             results.append(f"{title}\n{'=' * len(title)}")
 
-        results.append(self.render_matrix_table(program, languages))
+        results.append(self.render_matrix_table(program, languages, pivoted=pivoted))
 
         return "\n\n".join(results)
 
-    def render_matrix_csv(self, program: Program, languages: List[str]) -> str:
-        pattern_names, matrix = self._build_matrix_data(program, languages)
+    def render_matrix_csv(self, program: Program, languages: List[str], pivoted: bool = False) -> str:
+        headers, matrix = self._build_matrix_data(program, languages, pivoted=pivoted)
         template = self.env.get_template('matrix_table.csv.j2')
         return template.render(
-            pattern_names=pattern_names,
+            headers=headers,
             matrix=matrix
         )

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ def main():
     parser.add_argument("-t", "--title", help="Top-level title for the generated documentation")
     parser.add_argument("-p", "--pivot", help="Generate a pivot table for the specified language")
     parser.add_argument("-m", "--matrix", help="Generate a matrix table for the specified comma-separated languages")
+    parser.add_argument("--pivot-matrix", action="store_true", help="Pivot the matrix (patterns as rows, languages as columns)")
     parser.add_argument("--csv", action="store_true", help="Output in CSV format (only for matrix)")
 
     args = parser.parse_args()
@@ -57,9 +58,9 @@ def main():
     elif args.matrix:
         langs = [l.strip() for l in args.matrix.split(",")]
         if args.csv:
-            output_rst = generator.render_matrix_csv(program_asg, langs)
+            output_rst = generator.render_matrix_csv(program_asg, langs, pivoted=args.pivot_matrix)
         else:
-            output_rst = generator.render_matrix_chapter(program_asg, langs, title=args.title)
+            output_rst = generator.render_matrix_chapter(program_asg, langs, title=args.title, pivoted=args.pivot_matrix)
     else:
         output_rst = generator.render_program(program_asg, title=args.title)
 

--- a/src/templates/matrix_table.csv.j2
+++ b/src/templates/matrix_table.csv.j2
@@ -1,6 +1,6 @@
-Language,{{ pattern_names|join(',') }}
+{{ headers|join(',') }}
 {%- for row in matrix %}
-"{{ row.language }}",{% for cell in row.cells -%}
-"{{ cell|format_value|replace('"', '""') }}"{{ "," if not loop.last }}
+"{{ row.label }}",{% for cell in row.cells -%}
+"{{ cell.value|format_value|replace('"', '""') }}"{{ "," if not loop.last }}
 {%- endfor %}
 {%- endfor -%}

--- a/src/templates/matrix_table.rst.j2
+++ b/src/templates/matrix_table.rst.j2
@@ -2,13 +2,12 @@
    :widths: auto
    :header-rows: 1
 
-   * - Language
-{%- for p_name in pattern_names %}
-     - {{ p_name }}
-{%- endfor %}
+   * {% for header in headers -%}
+     - {{ header }}
+     {% endfor %}
 {%- for row in matrix %}
-   * - {{ row.language }}
+   * - {{ row.label }}
 {%- for cell in row.cells %}
-     - {{ cell|format_value|format_table_cell(is_code=True, lexer=row.language|get_lexer)|indent(7) }}
+     - {{ cell.value|format_value|format_table_cell(is_code=True, lexer=cell.lexer)|indent(7) }}
 {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
The pattern comparison matrices for programming languages and data formats have been pivoted (transposed) to improve readability. Patterns now appear as rows, and languages/formats as columns. This was achieved by updating the generator logic to support transposing the data while preserving language-specific syntax highlighting for each cell, and updating the documentation build configuration to enable this layout.

Fixes #220

---
*PR created automatically by Jules for task [17984095882507964767](https://jules.google.com/task/17984095882507964767) started by @chatelao*