### PR TITLE
Add procedures (functions without return value)

### DIFF
--- a/docs/c_pivot.rst
+++ b/docs/c_pivot.rst
@@ -7,11 +7,45 @@ C Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Floor
+     - Round
+     - Increment
+     - Decrement
+     - Lshift
+     - Rshift
+     - Bit and
+     - Bit or
+     - Bit xor
+     - Bit not
+     - Bit lshift
+     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: c
 
            int x = 42;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Static typing, terminated by semicolon.
    * - IfElse
      - .. code-block:: c
@@ -21,6 +55,23 @@ C Pivot View
            } else {
                return 0;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C if-else statement.
    * - Loop
      - .. code-block:: c
@@ -28,6 +79,23 @@ C Pivot View
            while (x > 0) {
                x = x - 1;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C while loop.
    * - FunctionDefinition
      - .. code-block:: c
@@ -35,35 +103,178 @@ C Pivot View
            int add(int a, int b) {
                return a + b;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C function with static types and curly braces.
+   * - ProcedureDefinition
+     - .. code-block:: c
+
+           void log_message(const char *msg) {
+               printf("%s\n", msg);
+           }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - In C, a procedure is a function with a void return type.
    * - TryCatch
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - C does not have native try-catch blocks; error handling is usually manual.
    * - Raise
      - .. code-block:: c
 
            exit(1);
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - C uses exit() or signals for severe errors.
    * - SingleLineComment
      - .. code-block:: c
 
            // comment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C single-line comment.
    * - MultiLineComment
      - .. code-block:: c
 
            /* line 1
               line 2 */
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C multi-line comment.
    * - Print
      - .. code-block:: c
 
            printf("Hello, World!\n");
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses the standard library's printf function; requires stdio.h.
    * - Import
      - .. code-block:: c
 
            #include <stdio.h>
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C way to include header files.
    * - SwitchCase
      - .. code-block:: c
@@ -76,9 +287,117 @@ C Pivot View
                default:
                    return 0;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C switch statement with case labels and default.
    * - Constant
      - .. code-block:: c
 
            const int MAX = 100;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The 'const' qualifier makes the variable immutable after initialization.
+   * - Arithmetic
+     - N/A
+     - .. code-block:: c
+
+           a + b
+     - .. code-block:: c
+
+           a - b
+     - .. code-block:: c
+
+           a * b
+     - .. code-block:: c
+
+           a / b
+     - .. code-block:: c
+
+           a % b
+     - .. code-block:: c
+
+           floor(a)
+     - .. code-block:: c
+
+           round(a)
+     - .. code-block:: c
+
+           a++
+     - .. code-block:: c
+
+           a--
+     - .. code-block:: c
+
+           a << b
+     - .. code-block:: c
+
+           a >> b
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Standard C operators; floor and round require math.h.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - .. code-block:: c
+
+           a & b
+     - .. code-block:: c
+
+           a | b
+     - .. code-block:: c
+
+           a ^ b
+     - .. code-block:: c
+
+           ~a
+     - .. code-block:: c
+
+           a << b
+     - .. code-block:: c
+
+           a >> b
+     - Standard bitwise operators in C.

--- a/docs/camel_pivot_table.rst
+++ b/docs/camel_pivot_table.rst
@@ -1,4 +1,4 @@
-Camel Pivot View
+OCaml Pivot View
 ================
 
 .. list-table:: Camel Pivot Table
@@ -14,6 +14,10 @@ Camel Pivot View
      - Mod
      - Floor
      - Round
+     - Increment
+     - Decrement
+     - Lshift
+     - Rshift
      - Bit and
      - Bit or
      - Bit xor
@@ -38,11 +42,19 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Immutable binding by default; type inference is used.
    * - IfElse
      - .. code-block:: ocaml
 
            if x > 0 then 1 else 0
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A
@@ -76,11 +88,19 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses references for mutable state in while loops.
    * - FunctionDefinition
      - .. code-block:: ocaml
 
            let add a b = a + b
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A
@@ -112,11 +132,19 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses the try...with construct for exception handling.
    * - Raise
      - .. code-block:: ocaml
 
            raise (Failure "Error")
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A
@@ -148,11 +176,19 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Requires the 'threads' library.
    * - SendMessage
      - .. code-block:: ocaml
 
            Event.sync (Event.send ch 42)
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A
@@ -184,11 +220,19 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Receives a message from a channel.
    * - SingleLineComment
      - .. code-block:: ocaml
 
            (* comment *)
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A
@@ -221,6 +265,10 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Supports nested comments.
    * - Print
      - .. code-block:: ocaml
@@ -239,11 +287,19 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Outputs a string followed by a newline.
    * - Import
      - .. code-block:: ocaml
 
            open List
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A
@@ -278,6 +334,10 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Structural pattern matching using the match expression.
    * - Constant
      - .. code-block:: ocaml
@@ -296,7 +356,33 @@ Camel Pivot View
      - N/A
      - N/A
      - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Top-level let bindings are effectively constant.
+   * - ProcedureDefinition
+     - .. code-block:: ocaml
+
+           let log_message msg = print_endline msg
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Procedures in OCaml return the unit type ().
    * - Arithmetic
      - N/A
      - .. code-block:: ocaml
@@ -320,6 +406,18 @@ Camel Pivot View
      - .. code-block:: ocaml
 
            Float.round a
+     - .. code-block:: ocaml
+
+           a + 1
+     - .. code-block:: ocaml
+
+           a - 1
+     - .. code-block:: ocaml
+
+           a lsl b
+     - .. code-block:: ocaml
+
+           a lsr b
      - N/A
      - N/A
      - N/A
@@ -328,6 +426,10 @@ Camel Pivot View
      - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - N/A
      - N/A

--- a/docs/java_bytecode_pivot.rst
+++ b/docs/java_bytecode_pivot.rst
@@ -7,11 +7,41 @@ Java Bytecode Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Increment
+     - Decrement
+     - Lshift
+     - Rshift
+     - Bit and
+     - Bit or
+     - Bit xor
+     - Bit not
+     - Bit lshift
+     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: jasm
 
            .field private static x I = 42
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - In Jasmin syntax, static fields represent global-like variables.
    * - IfElse
      - .. code-block:: jasm
@@ -23,6 +53,21 @@ Java Bytecode Pivot View
            LabelThen:
                iconst_1
                ireturn
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Implemented using stack operations and branch instructions (ifgt).
    * - Loop
      - .. code-block:: jasm
@@ -36,6 +81,21 @@ Java Bytecode Pivot View
                putstatic MyClass/x I
                goto LoopStart
            LoopEnd:
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Loops are built with labels and jump instructions (goto, ifle).
    * - FunctionDefinition
      - .. code-block:: jasm
@@ -48,6 +108,21 @@ Java Bytecode Pivot View
                iadd
                ireturn
            .end method
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Methods define stack and local variable limits; parameters are accessed by index.
    * - TryCatch
      - .. code-block:: jasm
@@ -62,6 +137,21 @@ Java Bytecode Pivot View
                aload_1
                invokestatic MyClass/handle(Ljava/lang/Exception;)V
            Done:
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Exception handlers are defined via .catch directives for specific code ranges.
    * - Raise
      - .. code-block:: jasm
@@ -71,6 +161,21 @@ Java Bytecode Pivot View
                ldc "Error"
                invokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V
                athrow
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Exceptions are instantiated and then thrown using the athrow instruction.
    * - Print
      - .. code-block:: jasm
@@ -78,6 +183,21 @@ Java Bytecode Pivot View
                getstatic java/lang/System/out Ljava/io/PrintStream;
                ldc "Hello, World!"
                invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Calls println on the static System.out field.
    * - Thread
      - .. code-block:: jasm
@@ -89,6 +209,21 @@ Java Bytecode Pivot View
                invokespecial MyRunnable/<init>()V
                invokespecial java/lang/Thread/<init>(Ljava/lang/Runnable;)V
                invokevirtual java/lang/Thread/start()V
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Involves instantiating a Thread object with a Runnable and calling start().
    * - SendMessage
      - .. code-block:: jasm
@@ -97,6 +232,21 @@ Java Bytecode Pivot View
                bipush 42
                invokestatic java/lang/Integer/valueOf(I)Ljava/lang/Integer;
                invokevirtual java/util/concurrent/BlockingQueue/put(Ljava/lang/Object;)V
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Typically uses standard Java concurrent collections like BlockingQueue.
    * - ReceiveMessage
      - .. code-block:: jasm
@@ -108,19 +258,79 @@ Java Bytecode Pivot View
                istore_1 ; msg
                iload_1
                invokestatic MyClass/handle(I)V
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Blocking retrieval from a concurrent collection.
    * - SingleLineComment
      - .. code-block:: jasm
 
            ; comment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Jasmin uses semicolons for single-line comments.
    * - MultiLineComment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - Java Bitcode (Jasmin) does not have a native multi-line comment syntax; multiple semicolons are used.
    * - Import
      - .. code-block:: jasm
 
            Ljava/util/List;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Internal descriptors are used to reference external classes.
    * - SwitchCase
      - .. code-block:: jasm
@@ -136,9 +346,133 @@ Java Bytecode Pivot View
                ; ...
            LabelDefault:
                ; ...
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses lookupswitch or tableswitch instructions for multi-way branching.
    * - Constant
      - .. code-block:: jasm
 
            .field public static final MAX I = 100
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Constants are represented as static final fields.
+   * - ProcedureDefinition
+     - .. code-block:: jasm
+
+           .method public static logMessage(Ljava/lang/String;)V
+               .limit stack 2
+               .limit locals 1
+               getstatic java/lang/System/out Ljava/io/PrintStream;
+               aload_0
+               invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
+               return
+           .end method
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Methods with a 'V' return descriptor are procedures; 'return' instruction is used for void return.
+   * - Arithmetic
+     - N/A
+     - .. code-block:: jasm
+
+           iadd
+     - .. code-block:: jasm
+
+           isub
+     - .. code-block:: jasm
+
+           imul
+     - .. code-block:: jasm
+
+           idiv
+     - .. code-block:: jasm
+
+           irem
+     - .. code-block:: jasm
+
+           iinc index, 1
+     - .. code-block:: jasm
+
+           iinc index, -1
+     - .. code-block:: jasm
+
+           ishl
+     - .. code-block:: jasm
+
+           ishr
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Stack-based arithmetic instructions for integers.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - .. code-block:: jasm
+
+           iand
+     - .. code-block:: jasm
+
+           ior
+     - .. code-block:: jasm
+
+           ixor
+     - .. code-block:: jasm
+
+           iconst_m1
+           ixor
+     - .. code-block:: jasm
+
+           ishl
+     - .. code-block:: jasm
+
+           ishr
+     - Stack-based bitwise instructions; NOT is implemented as XOR with -1.

--- a/docs/php_pivot.rst
+++ b/docs/php_pivot.rst
@@ -7,11 +7,45 @@ PHP Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Floor
+     - Round
+     - Increment
+     - Decrement
+     - Lshift
+     - Rshift
+     - Bit and
+     - Bit or
+     - Bit xor
+     - Bit not
+     - Bit lshift
+     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: php
 
            $x = 42;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Variables start with a dollar sign; dynamically typed but supports type declarations.
    * - IfElse
      - .. code-block:: php
@@ -21,6 +55,23 @@ PHP Pivot View
            } else {
                return 0;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C-like if-else statement.
    * - Loop
      - .. code-block:: php
@@ -28,6 +79,23 @@ PHP Pivot View
            while ($x > 0) {
                $x = $x - 1;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C-like while loop.
    * - FunctionDefinition
      - .. code-block:: php
@@ -35,7 +103,48 @@ PHP Pivot View
            function add(int $a, int $b): int {
                return $a + $b;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses 'function' keyword; supports type hints for parameters and return values.
+   * - ProcedureDefinition
+     - .. code-block:: php
+
+           function log_message(string $msg): void {
+               echo $msg;
+           }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Uses the 'void' return type hint (PHP 7.1+).
    * - TryCatch
      - .. code-block:: php
 
@@ -44,32 +153,134 @@ PHP Pivot View
            } catch (Exception $e) {
                handle($e);
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard PHP exception handling using try-catch blocks.
    * - Raise
      - .. code-block:: php
 
            throw new Exception("Error");
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses 'throw' to trigger an exception.
    * - SingleLineComment
      - .. code-block:: php
 
            // comment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Supports // and # for single-line comments.
    * - MultiLineComment
      - .. code-block:: php
 
            /* line 1
               line 2 */
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C-style block comments.
    * - Print
      - .. code-block:: php
 
            echo "Hello, World!";
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The echo statement is used to output text.
    * - Import
      - .. code-block:: php
 
            require 'utils.php';
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses include, require, include_once, or require_once to include other files.
    * - SwitchCase
      - .. code-block:: php
@@ -82,9 +293,117 @@ PHP Pivot View
                default:
                    return 0;
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C-like switch statement; match expression is also available in PHP 8.0+.
    * - Constant
      - .. code-block:: php
 
            define('MAX', 100);
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Constants can be defined using define() or the 'const' keyword (for class constants or global constants in modern PHP).
+   * - Arithmetic
+     - N/A
+     - .. code-block:: php
+
+           a + b
+     - .. code-block:: php
+
+           a - b
+     - .. code-block:: php
+
+           a * b
+     - .. code-block:: php
+
+           a / b
+     - .. code-block:: php
+
+           a % b
+     - .. code-block:: php
+
+           floor(a)
+     - .. code-block:: php
+
+           round(a)
+     - .. code-block:: php
+
+           a++
+     - .. code-block:: php
+
+           a--
+     - .. code-block:: php
+
+           a << b
+     - .. code-block:: php
+
+           a >> b
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Standard PHP arithmetic operators.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - .. code-block:: php
+
+           a & b
+     - .. code-block:: php
+
+           a | b
+     - .. code-block:: php
+
+           a ^ b
+     - .. code-block:: php
+
+           ~a
+     - .. code-block:: php
+
+           a << b
+     - .. code-block:: php
+
+           a >> b
+     - Standard bitwise operators.

--- a/docs/prolog_pivot.rst
+++ b/docs/prolog_pivot.rst
@@ -7,73 +7,333 @@ Prolog Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Floor
+     - Round
+     - Increment
+     - Decrement
+     - Lshift
+     - Rshift
+     - Bit and
+     - Bit or
+     - Bit xor
+     - Bit not
+     - Bit lshift
+     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: prolog
 
            X = 42.
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses unification for assignment; variables must start with an uppercase letter.
    * - IfElse
      - .. code-block:: prolog
 
            (X > 0 -> Result = 1 ; Result = 0)
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses the (Condition -> Then ; Else) control construct.
    * - Loop
      - .. code-block:: prolog
 
            loop(0) :- !.
            loop(X) :- X > 0, X1 is X - 1, loop(X1).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Prolog uses recursion and tail-call optimization for looping.
    * - FunctionDefinition
      - .. code-block:: prolog
 
            add(A, B, Res) :- Res is A + B.
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Functions are predicates; return values are typically unified with an output argument.
+   * - ProcedureDefinition
+     - .. code-block:: prolog
+
+           log_message(Msg) :- writeln(Msg).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Predicates without an output argument act as procedures.
    * - TryCatch
      - .. code-block:: prolog
 
            catch(do_something, E, handle(E))
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard Prolog error handling using the catch/3 predicate.
    * - Raise
      - .. code-block:: prolog
 
            throw(error(Error))
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses throw/1 to raise an exception.
    * - Thread
      - .. code-block:: prolog
 
            thread_create(do_work, Id, []).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Creates a new thread using thread_create/3 (ISO Prolog / SWI-Prolog).
    * - SendMessage
      - .. code-block:: prolog
 
            thread_send_message(Id, hello).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Sends a message to a thread's message queue.
    * - ReceiveMessage
      - .. code-block:: prolog
 
            thread_get_message(hello).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Retrieves a matching message from the current thread's queue.
    * - SingleLineComment
      - .. code-block:: prolog
 
            % comment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard Prolog single-line comment.
    * - MultiLineComment
      - .. code-block:: prolog
 
            /* line 1
               line 2 */
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard C-style block comment.
    * - Print
      - .. code-block:: prolog
 
            writeln('Hello, World!').
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Outputs text followed by a newline.
    * - Import
      - .. code-block:: prolog
 
            use_module(library(math)).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Imports predicates from a library module.
    * - SwitchCase
      - .. code-block:: prolog
@@ -82,9 +342,117 @@ Prolog Pivot View
            ;   X = 2 -> writeln('two')
            ;   writeln('none')
            )
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Usually implemented using nested (If -> Then ; Else) or multiple clauses.
    * - Constant
      - .. code-block:: prolog
 
            max(100).
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment.
+   * - Arithmetic
+     - N/A
+     - .. code-block:: prolog
+
+           Res is A + B
+     - .. code-block:: prolog
+
+           Res is A - B
+     - .. code-block:: prolog
+
+           Res is A * B
+     - .. code-block:: prolog
+
+           Res is A / B
+     - .. code-block:: prolog
+
+           Res is A mod B
+     - .. code-block:: prolog
+
+           Res is floor(A)
+     - .. code-block:: prolog
+
+           Res is round(A)
+     - .. code-block:: prolog
+
+           Res is A + 1
+     - .. code-block:: prolog
+
+           Res is A - 1
+     - .. code-block:: prolog
+
+           Res is A << B
+     - .. code-block:: prolog
+
+           Res is A >> B
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Uses the 'is' operator to evaluate arithmetic expressions.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - .. code-block:: prolog
+
+           Res is A /\ B
+     - .. code-block:: prolog
+
+           Res is A \/ B
+     - .. code-block:: prolog
+
+           Res is A xor B
+     - .. code-block:: prolog
+
+           Res is \ A
+     - .. code-block:: prolog
+
+           Res is A << B
+     - .. code-block:: prolog
+
+           Res is A >> B
+     - Bitwise operators within arithmetic expressions.

--- a/docs/riscv_pivot.rst
+++ b/docs/riscv_pivot.rst
@@ -7,11 +7,41 @@ RISC-V Assembler Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Increment
+     - Decrement
+     - Lshift
+     - Rshift
+     - Bit and
+     - Bit or
+     - Bit xor
+     - Bit not
+     - Bit lshift
+     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: asm
 
            x:  .word 42
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Defined in the .data section.
    * - IfElse
      - .. code-block:: asm
@@ -22,6 +52,21 @@ RISC-V Assembler Pivot View
            .else:
                li a0, 0
            .end:
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses branch instructions like blez (branch if less than or equal to zero).
    * - Loop
      - .. code-block:: asm
@@ -31,6 +76,21 @@ RISC-V Assembler Pivot View
                addi t0, t0, -1
                j .loop
            .end:
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses conditional branches and jumps to implement loops.
    * - FunctionDefinition
      - .. code-block:: asm
@@ -38,39 +98,185 @@ RISC-V Assembler Pivot View
            add:
                add a0, a0, a1
                ret
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Functions follow the RISC-V calling convention; a0-a7 are argument registers.
+   * - ProcedureDefinition
+     - .. code-block:: asm
+
+           log_message:
+               addi sp, sp, -16
+               sd ra, 8(sp)
+               call printf
+               ld ra, 8(sp)
+               addi sp, sp, 16
+               ret
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Follows standard calling convention; must save/restore return address (ra) if calling other functions.
    * - TryCatch
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - No native try-catch; relies on return codes or trap handlers for errors.
    * - Raise
      - .. code-block:: asm
 
                ebreak
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The ebreak instruction triggers a debug trap; ecall can be used for system calls.
    * - Thread
      - .. code-block:: asm
 
                li a7, 220 # clone syscall
                ecall
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Thread creation typically involves invoking OS system calls (e.g., clone in Linux).
    * - SendMessage
      - .. code-block:: asm
 
                li a7, 139 # rt_sigqueueinfo
                ecall
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Inter-process/thread communication is managed by the OS.
    * - ReceiveMessage
      - .. code-block:: asm
 
                li a7, 128 # rt_sigtimedwait
                ecall
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Receiving signals or messages involves OS system calls.
    * - SingleLineComment
      - .. code-block:: asm
 
            # comment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - RISC-V assembly typically uses the hash character for single-line comments.
    * - MultiLineComment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - RISC-V assembly does not have a native multi-line comment syntax.
    * - Print
@@ -78,11 +284,41 @@ RISC-V Assembler Pivot View
 
                la a0, hello_msg
                call printf
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Typically uses the C library printf or writes to stdout via system calls.
    * - Import
      - .. code-block:: asm
 
            .include "macros.s"
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses the .include directive to include external source files.
    * - SwitchCase
      - .. code-block:: asm
@@ -92,9 +328,105 @@ RISC-V Assembler Pivot View
                li t1, 2
                beq t0, t1, .case2
                j .default
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Typically implemented using comparison and branch instructions.
    * - Constant
      - .. code-block:: asm
 
            .equiv MAX, 100
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses the .equiv or .set directive to define constants.
+   * - Arithmetic
+     - N/A
+     - .. code-block:: asm
+
+           add t0, t1, t2
+     - .. code-block:: asm
+
+           sub t0, t1, t2
+     - .. code-block:: asm
+
+           mul t0, t1, t2
+     - .. code-block:: asm
+
+           div t0, t1, t2
+     - .. code-block:: asm
+
+           rem t0, t1, t2
+     - .. code-block:: asm
+
+           addi t0, t0, 1
+     - .. code-block:: asm
+
+           addi t0, t0, -1
+     - .. code-block:: asm
+
+           sll t0, t1, t2
+     - .. code-block:: asm
+
+           srl t0, t1, t2
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Standard RISC-V M-extension instructions.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - .. code-block:: asm
+
+           and t0, t1, t2
+     - .. code-block:: asm
+
+           or t0, t1, t2
+     - .. code-block:: asm
+
+           xor t0, t1, t2
+     - .. code-block:: asm
+
+           not t0, t1
+     - .. code-block:: asm
+
+           sll t0, t1, t2
+     - .. code-block:: asm
+
+           srl t0, t1, t2
+     - Core bitwise logical and shift instructions.

--- a/docs/sql_pivot.rst
+++ b/docs/sql_pivot.rst
@@ -7,11 +7,37 @@ SQL Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Floor
+     - Round
+     - Increment
+     - Decrement
+     - Bit and
+     - Bit or
+     - Bit xor
+     - Bit not
      - Notes
    * - VariableDeclaration
      - .. code-block:: sql
 
            DECLARE @x INT = 42;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - T-SQL syntax for variable declaration.
    * - IfElse
      - .. code-block:: sql
@@ -24,6 +50,19 @@ SQL Pivot View
            BEGIN
                RETURN 0
            END
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Uses IF-ELSE with BEGIN-END blocks.
    * - Loop
      - .. code-block:: sql
@@ -32,6 +71,19 @@ SQL Pivot View
            BEGIN
                SET @x = @x - 1
            END
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard WHILE loop in T-SQL.
    * - FunctionDefinition
      - .. code-block:: sql
@@ -41,7 +93,42 @@ SQL Pivot View
            BEGIN
                RETURN @a + @b
            END
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - T-SQL syntax for Scalar-Valued Functions.
+   * - ProcedureDefinition
+     - .. code-block:: sql
+
+           CREATE PROCEDURE log_message @msg NVARCHAR(MAX)
+           AS
+           BEGIN
+               PRINT @msg;
+           END
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - T-SQL uses CREATE PROCEDURE for blocks that perform actions.
    * - TryCatch
      - .. code-block:: sql
 
@@ -51,29 +138,107 @@ SQL Pivot View
            BEGIN CATCH
                EXEC handle_error;
            END CATCH
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
    * - Raise
      - .. code-block:: sql
 
            THROW 50000, 'Error', 1;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The THROW statement raises an exception and transfers execution to a CATCH block.
    * - SingleLineComment
      - .. code-block:: sql
 
            -- comment
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard SQL single-line comment.
    * - MultiLineComment
      - .. code-block:: sql
 
            /* line 1
               line 2 */
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Standard SQL multi-line comment.
    * - Print
      - .. code-block:: sql
 
            PRINT 'Hello, World!';
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - T-SQL PRINT statement outputs a message to the client.
    * - Import
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - N/A
      - Standard SQL does not have a native 'import' keyword for code; database objects are globally accessible or schema-qualified.
    * - SwitchCase
@@ -84,9 +249,93 @@ SQL Pivot View
                WHEN 2 THEN 'two'
                ELSE 'none'
            END
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The CASE expression is used for conditional logic in SQL.
    * - Constant
      - .. code-block:: sql
 
            DECLARE @MAX INT = 100;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - T-SQL variables are not strictly constant, but can be treated as such within a batch or procedure.
+   * - Arithmetic
+     - N/A
+     - .. code-block:: sql
+
+           a + b
+     - .. code-block:: sql
+
+           a - b
+     - .. code-block:: sql
+
+           a * b
+     - .. code-block:: sql
+
+           a / b
+     - .. code-block:: sql
+
+           a % b
+     - .. code-block:: sql
+
+           FLOOR(a)
+     - .. code-block:: sql
+
+           ROUND(a, 0)
+     - .. code-block:: sql
+
+           a + 1
+     - .. code-block:: sql
+
+           a - 1
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Standard SQL arithmetic functions.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - .. code-block:: sql
+
+           a & b
+     - .. code-block:: sql
+
+           a | b
+     - .. code-block:: sql
+
+           a ^ b
+     - .. code-block:: sql
+
+           ~a
+     - Bitwise support varies by SQL dialect; T-SQL supports &, |, ^, ~.

--- a/docs/xquery_pivot.rst
+++ b/docs/xquery_pivot.rst
@@ -7,21 +7,57 @@ XQuery Pivot View
 
    * - Pattern
      - Syntax
+     - Plus
+     - Minus
+     - Times
+     - Divide
+     - Mod
+     - Floor
+     - Round
+     - Increment
+     - Decrement
      - Notes
    * - VariableDeclaration
      - .. code-block:: xquery
 
            let $x := 42
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - XQuery uses 'let' for variable binding.
    * - IfElse
      - .. code-block:: xquery
 
            if ($x > 0) then 1 else 0
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Functional if-then-else expression; both branches are required.
    * - Loop
      - .. code-block:: xquery
 
            for $i in 1 to $x return $i
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - XQuery uses 'for' expressions for iteration over sequences.
    * - FunctionDefinition
      - .. code-block:: xquery
@@ -32,7 +68,34 @@ XQuery Pivot View
            ) as xs:integer {
                $a + $b
            };
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Functions must be declared in a namespace (e.g., 'local').
+   * - ProcedureDefinition
+     - .. code-block:: xquery
+
+           declare function local:log-message(
+               $msg as xs:string
+           ) as empty-sequence() {
+               (); (: side effects in XQuery are implementation-defined or via extensions :)
+           };
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - XQuery functions return empty-sequence() to simulate procedures.
    * - TryCatch
      - .. code-block:: xquery
 
@@ -41,32 +104,86 @@ XQuery Pivot View
            } catch * {
                handle($err)
            }
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - XQuery 3.0+ supports try-catch; $err is a variable containing error information.
    * - Raise
      - .. code-block:: xquery
 
            fn:error(fn:QName('http://example.com/errors', 'MY_ERROR'), 'Error')
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The fn:error() function signals a dynamic error.
    * - SingleLineComment
      - .. code-block:: xquery
 
            (: comment :)
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - XQuery uses (: :) for single-line comments.
    * - MultiLineComment
      - .. code-block:: xquery
 
            (: line 1
               line 2 :)
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - XQuery uses (: :) for multi-line comments.
    * - Print
      - .. code-block:: xquery
 
            "Hello, World!"
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - In XQuery, a string literal is often the result of an expression and is automatically serialized to output.
    * - Import
      - .. code-block:: xquery
 
            import module namespace utils = "http://example.com/utils";
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - Imports a library module by its namespace URI.
    * - SwitchCase
      - .. code-block:: xquery
@@ -75,9 +192,69 @@ XQuery Pivot View
              case 1 return "one"
              case 2 return "two"
              default return "none"
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - The 'switch' expression was introduced in XQuery 3.0.
    * - Constant
      - .. code-block:: xquery
 
            declare variable $MAX as xs:integer := 100;
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
      - In XQuery, variables declared in the prolog are immutable by default.
+   * - Arithmetic
+     - N/A
+     - .. code-block:: xquery
+
+           a + b
+     - .. code-block:: xquery
+
+           a - b
+     - .. code-block:: xquery
+
+           a * b
+     - .. code-block:: xquery
+
+           a div b
+     - .. code-block:: xquery
+
+           a mod b
+     - .. code-block:: xquery
+
+           floor(a)
+     - .. code-block:: xquery
+
+           round(a)
+     - .. code-block:: xquery
+
+           a + 1
+     - .. code-block:: xquery
+
+           a - 1
+     - Uses 'div' for division and 'idiv' for integer division.
+   * - Bitwise
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - N/A
+     - Standard XQuery does not have native bitwise operators.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -7,6 +7,15 @@ pattern VariableDeclaration {
     parameter notes: String
 }
 
+pattern ProcedureDefinition {
+    meta description: "Declaration of a reusable block of code with parameters and no return value."
+    parameter name: String
+    parameter parameters: List<String>
+    parameter body: Block
+    parameter syntax: String
+    parameter notes: String
+}
+
 pattern FunctionDefinition {
     meta description: "Declaration of a reusable block of code with parameters and a return value."
     parameter name: String
@@ -576,6 +585,142 @@ instance PrologFunctionDefinition of FunctionDefinition {
     body = { raw "Res is A + B" }
     syntax = "add(A, B, Res) :- Res is A + B."
     notes = "Functions are predicates; return values are typically unified with an output argument."
+}
+
+instance CProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["const char *msg"]
+    body = { raw "printf(msg);" }
+    syntax = "void log_message(const char *msg) {\n    printf(\"%s\\n\", msg);\n}"
+    notes = "In C, a procedure is a function with a void return type."
+}
+
+instance JavaProcedure of ProcedureDefinition {
+    name = "logMessage"
+    parameters = ["String msg"]
+    body = { raw "System.out.println(msg);" }
+    syntax = "public void logMessage(String msg) {\n    System.out.println(msg);\n}"
+    notes = "Uses the 'void' keyword to indicate no return value."
+}
+
+instance RustProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["msg: &str"]
+    body = { raw "println!(\"{}\", msg);" }
+    syntax = "fn log_message(msg: &str) {\n    println!(\"{}\", msg);\n}"
+    notes = "Functions without a return type implicitly return the unit type ()."
+}
+
+instance PythonProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["msg"]
+    body = { call print(msg) }
+    syntax = "def log_message(msg):\n    print(msg)"
+    notes = "Procedures in Python are functions that don't return a value (implicitly return None)."
+}
+
+instance PhpProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["string $msg"]
+    body = { raw "echo $msg;" }
+    syntax = "function log_message(string $msg): void {\n    echo $msg;\n}"
+    notes = "Uses the 'void' return type hint (PHP 7.1+)."
+}
+
+instance BashProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["$1"]
+    body = { raw "echo \"$1\"" }
+    syntax = "log_message() {\n    echo \"$1\"\n}"
+    notes = "In Bash, all functions are effectively procedures; return values are exit codes."
+}
+
+instance PowerShellProcedure of ProcedureDefinition {
+    name = "log-message"
+    parameters = ["$msg"]
+    body = { raw "Write-Host $msg" }
+    syntax = "function log-message($msg) {\n    Write-Host $msg\n}"
+    notes = "Functions without a return statement output nothing to the pipeline."
+}
+
+instance CmdProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["%1"]
+    body = { raw "echo %~1" }
+    syntax = ":log_message\necho %~1\ngoto :eof"
+    notes = "Procedures are labels called with 'call'; they return using 'goto :eof' or 'exit /b'."
+}
+
+instance SqlProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["@msg NVARCHAR(MAX)"]
+    body = { raw "PRINT @msg" }
+    syntax = "CREATE PROCEDURE log_message @msg NVARCHAR(MAX)\nAS\nBEGIN\n    PRINT @msg;\nEND"
+    notes = "T-SQL uses CREATE PROCEDURE for blocks that perform actions."
+}
+
+instance ErlangProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["Msg"]
+    body = { raw "io:format(\"~p~n\", [Msg])" }
+    syntax = "log_message(Msg) ->\n    io:format(\"~p~n\", [Msg])."
+    notes = "In Erlang, every function returns a value; 'ok' is commonly used for procedures."
+}
+
+instance LispProcedure of ProcedureDefinition {
+    name = "log-message"
+    parameters = ["msg"]
+    body = { raw "(format t msg)" }
+    syntax = "(defun log-message (msg)\n  (format t \"~A~%\" msg))"
+    notes = "Lisp functions always return the value of the last expression; procedures return nil or some status."
+}
+
+instance XQueryProcedure of ProcedureDefinition {
+    name = "local:log-message"
+    parameters = ["$msg as xs:string"]
+    body = { raw "()" }
+    syntax = "declare function local:log-message(\n    $msg as xs:string\n) as empty-sequence() {\n    (); (: side effects in XQuery are implementation-defined or via extensions :)\n};"
+    notes = "XQuery functions return empty-sequence() to simulate procedures."
+}
+
+instance CssProcedure of ProcedureDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "CSS does not support procedures."
+}
+
+instance CudaProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["const char *msg"]
+    body = { raw "printf(msg);" }
+    syntax = "__device__ void log_message(const char *msg) {\n    printf(\"%s\\n\", msg);\n}"
+    notes = "Similar to C, procedures use the void return type."
+}
+
+instance X86Procedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["edx"]
+    body = { raw "call printf" }
+    syntax = "log_message:\n    push edx\n    call printf\n    add esp, 4\n    ret"
+    notes = "Implemented as a label followed by code and a ret instruction."
+}
+
+instance RiscvProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["a0"]
+    body = { raw "call printf" }
+    syntax = "log_message:\n    addi sp, sp, -16\n    sd ra, 8(sp)\n    call printf\n    ld ra, 8(sp)\n    addi sp, sp, 16\n    ret"
+    notes = "Follows standard calling convention; must save/restore return address (ra) if calling other functions."
+}
+
+instance PrologProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["Msg"]
+    body = { raw "writeln(Msg)" }
+    syntax = "log_message(Msg) :- writeln(Msg)."
+    notes = "Predicates without an output argument act as procedures."
 }
 
 pattern TryCatch {
@@ -1789,6 +1934,14 @@ instance JavaBytecodeConstant of Constant {
     notes = "Constants are represented as static final fields."
 }
 
+instance JavaBytecodeProcedure of ProcedureDefinition {
+    name = "logMessage"
+    parameters = ["Ljava/lang/String;"]
+    body = { raw "invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V" }
+    syntax = ".method public static logMessage(Ljava/lang/String;)V\n    .limit stack 2\n    .limit locals 1\n    getstatic java/lang/System/out Ljava/io/PrintStream;\n    aload_0\n    invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V\n    return\n.end method"
+    notes = "Methods with a 'V' return descriptor are procedures; 'return' instruction is used for void return."
+}
+
 pattern Arithmetic {
     meta description: "Standard mathematical operations for numeric values."
     parameter plus: String
@@ -2368,6 +2521,14 @@ instance CamelConstant of Constant {
     value = "100"
     syntax = "let max = 100"
     notes = "Top-level let bindings are effectively constant."
+}
+
+instance CamelProcedure of ProcedureDefinition {
+    name = "log_message"
+    parameters = ["msg"]
+    body = { raw "print_endline msg" }
+    syntax = "let log_message msg = print_endline msg"
+    notes = "Procedures in OCaml return the unit type ()."
 }
 
 instance CamelArithmetic of Arithmetic {

--- a/src/generator.py
+++ b/src/generator.py
@@ -181,6 +181,7 @@ class CodeGenerator:
             "notes"
         ]
 
+        normalized_lang = self._normalize(language)
         pivot_data = []
         for instance in program.instances:
             # First, check if any OTHER language matches the instance name better
@@ -189,11 +190,18 @@ class CodeGenerator:
                                   or instance.name.lower().startswith(lang.lower()))]
 
             # If the requested language matches the prefix
-            if instance.name.lower().startswith(self._normalize(language)) or instance.name.lower().startswith(language.lower()):
+            # Use strict matching for short language names like 'C'
+            if len(normalized_lang) <= 2:
+                matches = instance.name.lower().startswith(normalized_lang) and \
+                          (len(instance.name) == len(normalized_lang) or not instance.name[len(normalized_lang)].islower())
+            else:
+                matches = instance.name.lower().startswith(normalized_lang) or instance.name.lower().startswith(language.lower())
+
+            if matches:
                 # Ensure no OTHER language is a longer (better) match
                 is_best_match = True
                 for other in other_matches:
-                    if len(other) > len(language):
+                    if len(self._normalize(other)) > len(normalized_lang):
                         is_best_match = False
                         break
 


### PR DESCRIPTION
Implemented the `ProcedureDefinition` pattern to document functions without return values across all 20 supported programming languages. This included updating the DSL pattern file, providing idiomatic examples for each language, and regenerating the entire documentation suite (comparison matrices and pivot chapters). Additionally, improved the generator's language-matching logic to prevent cross-language contamination in pivot tables for short language identifiers like 'C'.

Fixes #165

---
*PR created automatically by Jules for task [10052283174497867953](https://jules.google.com/task/10052283174497867953) started by @chatelao*