### PR TITLE
Excel Export and GitHub Pages Deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,64 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Prepare Documentation Assets
+        run: |
+          export PYTHONPATH=$PYTHONPATH:.
+          # Generate RST files
+          python3 -m src.main patterns/programming.patterns -o docs/programming.rst --title "Programming Language Patterns"
+          python3 -m src.main patterns/data_formats.patterns -o docs/data_formats.rst --title "Data Format Patterns"
+
+          # Generate matrices for documentation
+          echo "Pattern Comparison Matrices" > docs/matrices.rst
+          echo "===========================" >> docs/matrices.rst
+          echo "" >> docs/matrices.rst
+          echo "Programming Languages" >> docs/matrices.rst
+          echo "---------------------" >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel" --pivot-matrix >> docs/matrices.rst
+          echo "" >> docs/matrices.rst
+          echo "Data Formats" >> docs/matrices.rst
+          echo "------------" >> docs/matrices.rst
+          python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
+
+          # Generate Downloadable Matrices for Sphinx :download: role
+          # Sphinx expects these files to be in the source tree during build
+          # By convention, we put them in docs/
+          # CSV
+          python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
+          # Excel
+          python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
+
+      - name: Build Documentation
+        run: |
+          # Sphinx build
+          sphinx-build -b html docs docs/_build/html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,14 +18,18 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Generate CSV Matrices
+      - name: Generate Matrices
         run: |
           export PYTHONPATH=$PYTHONPATH:.
+          # CSV
           python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel" --csv > programming_matrix.csv
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > data_formats_matrix.csv
+          # Excel
+          python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel" --excel -o programming_matrix.xlsx
+          python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o data_formats_matrix.xlsx
 
       - name: Upload Assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} programming_matrix.csv data_formats_matrix.csv
+          gh release upload ${{ github.event.release.tag_name }} programming_matrix.csv data_formats_matrix.csv programming_matrix.xlsx data_formats_matrix.xlsx

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/programming.rst
 docs/data_formats.rst
 docs/matrices.rst
 docs/appendix.rst
+docs/*.csv
+docs/*.xlsx

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,12 @@ Welcome to the Bible of Babylon Documentation
    arm_pivot
    camel_pivot
 
+Downloads
+=========
+
+- **Programming Language Matrix:** :download:`CSV <programming_matrix.csv>` | :download:`Excel <programming_matrix.xlsx>`
+- **Data Format Matrix:** :download:`CSV <data_formats_matrix.csv>` | :download:`Excel <data_formats_matrix.xlsx>`
+
 Indices and tables
 ==================
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 sphinx
 myst-parser
 sphinx-rtd-theme
+openpyxl

--- a/src/generator.py
+++ b/src/generator.py
@@ -1,6 +1,8 @@
+import io
 from pathlib import Path
 from typing import List, Dict, Any
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+import openpyxl
 from .models import (
     Pattern, Program, Instance, AnonymousInstance, Block, ListLiteral, Identifier,
     CallInstruction, AssignInstruction, ReturnInstruction, RawInstruction
@@ -337,6 +339,44 @@ class CodeGenerator:
             headers=headers,
             matrix=matrix
         )
+
+    def render_matrix_excel(self, program: Program, languages: List[str], pivoted: bool = False) -> bytes:
+        headers, matrix = self._build_matrix_data(program, languages, pivoted=pivoted)
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Matrix"
+
+        # Write headers
+        ws.append(headers)
+
+        # Write data
+        for row in matrix:
+            row_data = [row["label"]] + [cell["value"] for cell in row["cells"]]
+            # Convert all to strings and handle format_value if needed (already handled in _build_matrix_data for 'value')
+            # But wait, _build_matrix_data gives the raw value, format_value is a filter in Jinja2
+            # Let's ensure we use format_value here too.
+            formatted_row = [row["label"]]
+            for cell in row["cells"]:
+                formatted_row.append(format_value(cell["value"]))
+            ws.append(formatted_row)
+
+        # Auto-adjust column widths
+        for col in ws.columns:
+            max_length = 0
+            column = col[0].column_letter # Get the column name
+            for cell in col:
+                try:
+                    if len(str(cell.value)) > max_length:
+                        max_length = len(str(cell.value))
+                except:
+                    pass
+            adjusted_width = (max_length + 2)
+            ws.column_dimensions[column].width = adjusted_width
+
+        output = io.BytesIO()
+        wb.save(output)
+        return output.getvalue()
 
     def render_matrix_chapter(self, program: Program, languages: List[str], title: str = None, pivoted: bool = False) -> str:
         results = []

--- a/src/install.sh
+++ b/src/install.sh
@@ -12,4 +12,7 @@ pip install antlr4-tools
 echo "Installing ANTLR4 Python runtime..."
 pip install antlr4-python3-runtime==4.13.2
 
+echo "Installing openpyxl..."
+pip install openpyxl
+
 echo "Development environment setup complete."

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ def main():
     parser.add_argument("-m", "--matrix", help="Generate a matrix table for the specified comma-separated languages")
     parser.add_argument("--pivot-matrix", action="store_true", help="Pivot the matrix (patterns as rows, languages as columns)")
     parser.add_argument("--csv", action="store_true", help="Output in CSV format (only for matrix)")
+    parser.add_argument("--excel", action="store_true", help="Output in Excel format (only for matrix)")
 
     args = parser.parse_args()
 
@@ -53,24 +54,33 @@ def main():
 
     # 4. Generation
     generator = CodeGenerator()
+    output_data = None
     if args.pivot:
-        output_rst = generator.render_pivot_chapter(program_asg, args.pivot, title=args.title)
+        output_data = generator.render_pivot_chapter(program_asg, args.pivot, title=args.title)
     elif args.matrix:
         langs = [l.strip() for l in args.matrix.split(",")]
         if args.csv:
-            output_rst = generator.render_matrix_csv(program_asg, langs, pivoted=args.pivot_matrix)
+            output_data = generator.render_matrix_csv(program_asg, langs, pivoted=args.pivot_matrix)
+        elif args.excel:
+            output_data = generator.render_matrix_excel(program_asg, langs, pivoted=args.pivot_matrix)
         else:
-            output_rst = generator.render_matrix_chapter(program_asg, langs, title=args.title, pivoted=args.pivot_matrix)
+            output_data = generator.render_matrix_chapter(program_asg, langs, title=args.title, pivoted=args.pivot_matrix)
     else:
-        output_rst = generator.render_program(program_asg, title=args.title)
+        output_data = generator.render_program(program_asg, title=args.title)
 
     # 5. Output
     if args.output:
         output_path = Path(args.output)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(output_rst)
+        if isinstance(output_data, bytes):
+            output_path.write_bytes(output_data)
+        else:
+            output_path.write_text(output_data)
     else:
-        print(output_rst)
+        if isinstance(output_data, bytes):
+            sys.stdout.buffer.write(output_data)
+        else:
+            print(output_data)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This change adds support for exporting pattern comparison matrices to Excel format (.xlsx) and automates the deployment of the project's documentation and these matrices to GitHub Pages.

Key changes:
- **Excel Generation:** Added `render_matrix_excel` to `src/generator.py` using the `openpyxl` library. This method includes auto-adjusting column widths for better readability.
- **CLI Support:** Updated `src/main.py` to include an `--excel` flag. It now correctly handles binary output for Excel files, whether writing to a file or stdout.
- **CI/CD - GitHub Pages:** Introduced `.github/workflows/pages.yml`, which builds the Sphinx documentation and generates both CSV and Excel matrices. The matrices are generated before the Sphinx build to allow the `:download:` role to correctly link them.
- **CI/CD - Releases:** Updated `.github/workflows/release.yml` to include Excel versions of the programming and data format matrices as release assets.
- **Documentation:** Updated `docs/index.rst` with a new "Downloads" section providing direct links to the generated CSV and Excel matrices on the GitHub Pages site.
- **Maintenance:** Added `docs/*.csv` and `docs/*.xlsx` to `.gitignore` to prevent generated assets from being accidentally committed.

Fixes #232

---
*PR created automatically by Jules for task [6404697580534044433](https://jules.google.com/task/6404697580534044433) started by @chatelao*