### PR TITLE
Add 4-float vector dot product pattern

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,6 +27,7 @@ This section compares languages based on common programming patterns.
 - ARM AArch64 Assembler
 - Prolog
 - Java Bytecode
+- Camel/OCaml
 - Go
 - Haskell
 - TypeScript
@@ -56,6 +57,7 @@ This section compares languages based on common programming patterns.
 - Right shift
 - Bitwise operators
 - 4-float vector multiplication
+- 4-float vector dot product
 
 ### Part II: Data Formats
 This section compares data structures and serialization formats.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,6 +143,8 @@
     - [x] Define patterns and implement instances across all 18 languages
 - [x] Implement `Float4VectorMultiplication` pattern
     - [x] Define pattern and implement instances across all 24 languages
+- [x] Implement `Float4VectorDotProduct` pattern
+    - [x] Define pattern and implement instances across all 24 languages
 
 ## Phase 6: Pivot Chapters (Language-specific Views)
 - [x] Implement Pivot Chapter generator logic <!-- issue #15 -->

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -4377,3 +4377,129 @@ instance TclFloat4VectorMultiplication of Float4VectorMultiplication {
     syntax = "foreach ai $a bi $b { lappend c [expr {$ai * $bi}] }"
     notes = "Uses a multi-variable foreach loop to zip and multiply."
 }
+
+pattern Float4VectorDotProduct {
+    meta description: "Scalar product of two 4-component floating-point vectors."
+    parameter syntax: String
+    parameter notes: String
+}
+
+instance CFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "float dot = 0; for (int i = 0; i < 4; i++) dot += a[i] * b[i];"
+    notes = "Standard C implementation using a loop and an accumulator."
+}
+
+instance JavaFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "float dot = 0; for (int i = 0; i < 4; i++) dot += a[i] * b[i];"
+    notes = "Standard Java implementation using a loop; Vector API provides optimized dot product."
+}
+
+instance RustFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();"
+    notes = "Functional approach using iterators, zip, map, and sum."
+}
+
+instance PythonFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "dot = sum(ai * bi for ai, bi in zip(a, b))"
+    notes = "Uses a generator expression with zip and sum; NumPy's np.dot is standard for performance."
+}
+
+instance PhpFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "$dot = array_sum(array_map(fn($ai, $bi) => $ai * $bi, $a, $b));"
+    notes = "Combines array_map and array_sum."
+}
+
+instance BashFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "dot=0; for i in {0..3}; do dot=$(echo \"$dot + (${a[$i]} * ${b[$i]})\" | bc); done"
+    notes = "Requires bc for floating-point accumulation."
+}
+
+instance PowerShellFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "$dot = 0; 0..3 | ForEach-Object { $dot += $a[$_] * $b[$_] }"
+    notes = "Iterates over indices and accumulates the product."
+}
+
+instance CmdFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = "Cmd has no native support for floating-point arithmetic."
+}
+
+instance SqlFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "SELECT a1*b1 + a2*b2 + a3*b3 + a4*b4"
+    notes = "Calculated by manually summing component-wise products."
+}
+
+instance ErlangFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "Dot = lists:foldl(fun({Ai, Bi}, Acc) -> Ai * Bi + Acc end, 0.0, lists:zip(A, B))."
+    notes = "Uses lists:zip and lists:foldl to calculate the sum of products."
+}
+
+instance LispFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "(reduce #'+ (mapcar #'* a b))"
+    notes = "Maps multiplication over lists and reduces the result with addition."
+}
+
+instance XQueryFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "sum(for $i in 1 to 4 return $a[$i] * $b[$i])"
+    notes = "Uses the built-in sum() function over a sequence of products."
+}
+
+instance CssFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = "CSS does not support vector dot products."
+}
+
+instance CudaFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "float dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;"
+    notes = "Manually calculated using the components of the float4 struct."
+}
+
+instance X86Float4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "dpps xmm0, xmm1, 0xF1"
+    notes = "SSE4.1 instruction for Dot Product of Packed Singles. 0xF1 mask controls input/output lanes."
+}
+
+instance RiscvFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "vsetvli t0, x0, e32, m1\nvfmul.vv v1, v2, v3\nvfredusum.vs v4, v1, v5"
+    notes = "Uses vfmul.vv for multiplication and vfredusum.vs for a horizontal sum."
+}
+
+instance PrologFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "dot_product(A, B, Dot) :- maplist(multiply, A, B, Products), sum_list(Products, Dot)."
+    notes = "Commonly implemented using maplist and sum_list."
+}
+
+instance JavaBytecodeFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "fload_1 ; a[i]\nfload_2 ; b[i]\nfmul\nfadd"
+    notes = "Dot product is built by repeating fmul and fadd instructions on the stack."
+}
+
+instance CamelFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "let dot = List.fold_left2 (fun acc ai bi -> acc +. ai *. bi) 0.0 a b"
+    notes = "Uses fold_left2 for efficient simultaneous iteration over two lists."
+}
+
+instance ArmAarch64Float4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "fmul v0.4s, v1.4s, v2.4s\nfaddp v0.4s, v0.4s, v0.4s\nfaddp s0, v0.2s"
+    notes = "Uses fmul for component-wise multiplication and faddp for horizontal pairwise addition."
+}
+
+instance GoFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "dot := 0.0\nfor i := range a { dot += a[i] * b[i] }"
+    notes = "Standard imperative loop for accumulating the sum of products."
+}
+
+instance HaskellFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "dot = sum $ zipWith (*) a b"
+    notes = "Pure functional approach using zipWith, multiplication, and sum."
+}
+
+instance TypeScriptFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "const dot = a.reduce((acc, v, i) => acc + v * b[i], 0);"
+    notes = "Uses Array.reduce to accumulate the product of elements."
+}
+
+instance TclFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "set dot 0\nforeach ai $a bi $b { set dot [expr {$dot + ($ai * $bi)}] }"
+    notes = "Uses a multi-variable foreach loop to multiply and accumulate using expr."
+}


### PR DESCRIPTION
This PR adds the `Float4VectorDotProduct` pattern to the comparative book. It includes implementations for all 24 supported programming languages, ranging from high-level scripting languages (Python, JavaScript) to low-level assembly (x86 SSE, ARM NEON, RISC-V Vector). 

Key changes:
- New pattern definition in `patterns/programming.patterns`.
- 24 language-specific instances.
- Documentation updates in `DESIGN.md` and `ROADMAP.md`.
- Language list in `DESIGN.md` updated to include `Camel/OCaml`.

Fixes #243

---
*PR created automatically by Jules for task [16269468331295645229](https://jules.google.com/task/16269468331295645229) started by @chatelao*