### PR TITLE
Restore GitHub Pages and promote Excel download links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,6 +52,10 @@ jobs:
           python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl" --excel -o docs/programming_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
+          # Ensure appendix exists
+          echo "Appendix" > docs/appendix.rst
+          echo "========" >> docs/appendix.rst
+
       - name: Build Documentation
         run: |
           # Sphinx build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,11 +13,21 @@ build:
       - echo "" >> docs/matrices.rst
       - echo "Programming Languages" >> docs/matrices.rst
       - echo "---------------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel" --pivot-matrix >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl" --pivot-matrix >> docs/matrices.rst
       - echo "" >> docs/matrices.rst
       - echo "Data Formats" >> docs/matrices.rst
       - echo "------------" >> docs/matrices.rst
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
+      # Generate Downloadable Matrices for Sphinx :download: role
+      # CSV
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl" --csv > docs/programming_matrix.csv
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
+      # Excel
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl" --excel -o docs/programming_matrix.xlsx
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
+      # Ensure appendix exists
+      - echo "Appendix" > docs/appendix.rst
+      - echo "========" >> docs/appendix.rst
 
 python:
   install:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,12 @@
 Welcome to the Bible of Babylon Documentation
 =============================================
 
+Downloads
+=========
+
+- **Programming Language Matrix:** :download:`CSV <programming_matrix.csv>` | :download:`Excel <programming_matrix.xlsx>`
+- **Data Format Matrix:** :download:`CSV <data_formats_matrix.csv>` | :download:`Excel <data_formats_matrix.xlsx>`
+
 .. toctree::
    :maxdepth: 2
    :caption: DSL Reference:
@@ -46,12 +52,6 @@ Welcome to the Bible of Babylon Documentation
    haskell_pivot
    typescript_pivot
    tcl_pivot
-
-Downloads
-=========
-
-- **Programming Language Matrix:** :download:`CSV <programming_matrix.csv>` | :download:`Excel <programming_matrix.xlsx>`
-- **Data Format Matrix:** :download:`CSV <data_formats_matrix.csv>` | :download:`Excel <data_formats_matrix.xlsx>`
 
 Indices and tables
 ==================

--- a/src/generator.py
+++ b/src/generator.py
@@ -84,7 +84,7 @@ class CodeGenerator:
         "ARM AArch64 Assembler": "asm",
         "Arm": "asm",
         "Prolog": "prolog",
-        "Java Bytecode": "jasm",
+        "Java Bytecode": "jasmin",
         "Camel": "ocaml",
         "OCaml": "ocaml",
         "Go": "go",


### PR DESCRIPTION
This PR restores the functional GitHub Pages site by resolving build failures caused by incorrect lexer mappings and missing documentation files. It also fulfills the user's request to make the generated Excel and CSV comparison matrices more prominent by moving the download links to the top of the documentation home page. CI/CD workflows for both GitHub Pages and Read the Docs have been updated to ensure all supported languages are included in the generated assets.

Fixes #245

---
*PR created automatically by Jules for task [3281886527622124924](https://jules.google.com/task/3281886527622124924) started by @chatelao*