### PR TITLE
Remove appendix from documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,10 +52,6 @@ jobs:
           python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl" --excel -o docs/programming_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
-          # Ensure appendix exists
-          echo "Appendix" > docs/appendix.rst
-          echo "========" >> docs/appendix.rst
-
       - name: Build Documentation
         run: |
           # Sphinx build

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ docs/_build/
 docs/programming.rst
 docs/data_formats.rst
 docs/matrices.rst
-docs/appendix.rst
 docs/*.csv
 docs/*.xlsx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,9 +25,6 @@ build:
       # Excel
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl" --excel -o docs/programming_matrix.xlsx
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
-      # Ensure appendix exists
-      - echo "Appendix" > docs/appendix.rst
-      - echo "========" >> docs/appendix.rst
 
 python:
   install:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,8 +31,6 @@ by simply comparing the most often used patterns.
 - Use readthedocs.org to produce the documentation
 - Use reStructuredText  to document everything not markdown
 - Keep `src/install.sh` to install all tools and dependencies.
-- For every decision evaluate three options and archiv the discarded ones in a compressed way
-  in an appendix of the documentation.
 
 # Testing Locally & with Github Action Workflow
 - Maintain a CI/CD pipeline that runs on every commit and every push.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,6 @@ Downloads
    data_formats
    matrices
    coverage
-   appendix
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This change removes the "Appendix" section from the documentation as requested. It cleans up the build configurations (ReadTheDocs and GitHub Actions) that were previously generating a dummy appendix file, removes the reference from the documentation index, and updates the project guidelines in GEMINI.md.

Fixes #248

---
*PR created automatically by Jules for task [12249460421653222773](https://jules.google.com/task/12249460421653222773) started by @chatelao*