### PR TITLE
Update all language pivot pages and correct pattern definitions

### DIFF
--- a/docs/arm_pivot.rst
+++ b/docs/arm_pivot.rst
@@ -7,23 +7,11 @@ ARM AArch64 Assembler Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: asm
 
            x:  .quad 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Defined in the .data section.
    * - IfElse
      - .. code-block:: asm
@@ -35,12 +23,6 @@ ARM AArch64 Assembler Pivot View
            .else:
                mov x0, #0
            .end:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented using comparison and branch instructions (ble).
    * - Loop
      - .. code-block:: asm
@@ -51,12 +33,6 @@ ARM AArch64 Assembler Pivot View
                sub x0, x0, #1
                b .loop
            .end:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses conditional branches to implement loops.
    * - FunctionDefinition
      - .. code-block:: asm
@@ -64,12 +40,6 @@ ARM AArch64 Assembler Pivot View
            add:
                add x0, x0, x1
                ret
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard AArch64 calling convention; x0-x7 are argument registers, x0 is the return register.
    * - ProcedureDefinition
      - .. code-block:: asm
@@ -80,87 +50,39 @@ ARM AArch64 Assembler Pivot View
                bl printf
                ldp x29, x30, [sp], 16
                ret
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses stp/ldp to save and restore the frame pointer (x29) and link register (x30).
    * - TryCatch
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - No native try-catch; relies on return codes or exception levels/traps for errors.
    * - Raise
      - .. code-block:: asm
 
                brk #0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The brk instruction triggers a breakpoint exception.
    * - Thread
      - .. code-block:: asm
 
                mov x8, #220 // clone syscall
                svc #0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Thread creation typically involves invoking OS system calls (e.g., clone on Linux).
    * - SendMessage
      - .. code-block:: asm
 
                mov x8, #139 // rt_sigqueueinfo
                svc #0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Inter-process/thread communication is managed via OS system calls.
    * - ReceiveMessage
      - .. code-block:: asm
 
                mov x8, #128 // rt_sigtimedwait
                svc #0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Receiving signals or messages involves OS system calls.
    * - SingleLineComment
      - .. code-block:: asm
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - AArch64 assembly often uses // or ; for single-line comments.
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - AArch64 assembly does not have a native multi-line comment syntax.
    * - Print
@@ -169,23 +91,11 @@ ARM AArch64 Assembler Pivot View
                adrp x0, hello_msg
                add x0, x0, :lo12:hello_msg
                bl printf
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Typically uses the C library printf; adrp/add are used for PC-relative addressing.
    * - Import
      - .. code-block:: asm
 
            .include "macros.s"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the .include directive for external source files.
    * - SwitchCase
      - .. code-block:: asm
@@ -195,157 +105,100 @@ ARM AArch64 Assembler Pivot View
                cmp x0, #2
                beq .case2
                b .default
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented using comparison and branch instructions.
    * - Constant
      - .. code-block:: asm
 
            .equiv MAX, 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the .equiv directive to define constants.
    * - Addition
      - .. code-block:: asm
 
            add x0, x1, x2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Subtraction
      - .. code-block:: asm
 
            sub x0, x1, x2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Multiplication
      - .. code-block:: asm
 
            mul x0, x1, x2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Division
      - .. code-block:: asm
 
            sdiv x0, x1, x2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Remainder
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Modulo is typically calculated via sdiv and msub.
    * - Floor
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Rounding
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Increment
      - .. code-block:: asm
 
            add x0, x0, #1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - Decrement
      - .. code-block:: asm
 
            sub x0, x0, #1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - LeftShift
      - .. code-block:: asm
 
            lsl x0, x1, x2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
+     - Standard A64 instructions.
    * - RightShift
      - .. code-block:: asm
 
            lsr x0, x1, x2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard A64 instructions; modulo is typically calculated via sdiv and msub.
-   * - Bitwise
-     - N/A
+     - Standard A64 instructions.
+   * - BitAnd
      - .. code-block:: asm
 
            and x0, x1, x2
+     - Core bitwise logical and shift instructions.
+   * - BitOr
      - .. code-block:: asm
 
            orr x0, x1, x2
+     - Core bitwise logical and shift instructions.
+   * - BitXor
      - .. code-block:: asm
 
            eor x0, x1, x2
+     - Core bitwise logical and shift instructions.
+   * - BitNot
      - .. code-block:: asm
 
            mvn x0, x1
-     - .. code-block:: asm
-
-           lsl x0, x1, x2
-     - .. code-block:: asm
-
-           lsr x0, x1, x2
      - Core bitwise logical and shift instructions.
+   * - Float4VectorMultiplication
+     - .. code-block:: asm
+
+           fmul v0.4s, v1.4s, v2.4s
+     - NEON instruction for 4-lane single-precision floating-point multiplication.
+   * - Float4VectorDotProduct
+     - .. code-block:: asm
+
+           fmul v0.4s, v1.4s, v2.4s
+           faddp v0.4s, v0.4s, v0.4s
+           faddp s0, v0.2s
+     - Uses fmul for component-wise multiplication and faddp for horizontal pairwise addition.
+   * - Float4VectorCrossProduct
+     - .. code-block:: asm
+
+           fmul s2, v0.s[1], v1.s[2]
+           fmls s2, v0.s[2], v1.s[1]
+           fmul s3, v0.s[2], v1.s[0]
+           fmls s3, v0.s[0], v1.s[2]
+           fmul s4, v0.s[0], v1.s[1]
+           fmls s4, v0.s[1], v1.s[0]
+     - Calculated component-wise using scalar NEON instructions.

--- a/docs/bash_pivot.rst
+++ b/docs/bash_pivot.rst
@@ -7,23 +7,11 @@ Bash Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: bash
 
            x=42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - No spaces around the assignment operator.
    * - IfElse
      - .. code-block:: bash
@@ -33,12 +21,6 @@ Bash Pivot View
            else
                exit 0
            fi
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses if-then-else-fi structure; brackets are for test command.
    * - Loop
      - .. code-block:: bash
@@ -46,12 +28,6 @@ Bash Pivot View
            while [ $x -gt 0 ]; do
                x=$((x-1))
            done
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses while-do-done structure.
    * - FunctionDefinition
      - .. code-block:: bash
@@ -59,12 +35,6 @@ Bash Pivot View
            add() {
                echo $(($1 + $2))
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Parameters are accessed via $1, $2, etc.; return values are typically exit codes or printed to stdout.
    * - ProcedureDefinition
      - .. code-block:: bash
@@ -72,76 +42,34 @@ Bash Pivot View
            log_message() {
                echo "$1"
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - In Bash, all functions are effectively procedures; return values are exit codes.
    * - TryCatch
      - .. code-block:: bash
 
            do_something || handle_error
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Shells often use command chaining (||) for basic error handling based on exit codes; $? stores the exit status.
    * - Raise
      - .. code-block:: bash
 
            exit 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Terminates the script or subshell with a non-zero exit code.
    * - SingleLineComment
      - .. code-block:: bash
 
            # comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Bash only supports single-line comments starting with #.
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Bash does not have a native multi-line comment syntax; multiple single-line comments are used.
    * - Print
      - .. code-block:: bash
 
            echo "Hello, World!"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The echo command outputs text followed by a newline.
    * - Import
      - .. code-block:: bash
 
            source utils.sh
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'source' (or .) command executes a script in the current shell context.
    * - SwitchCase
      - .. code-block:: bash
@@ -157,163 +85,102 @@ Bash Pivot View
                    echo "none"
                    ;;
            esac
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses case-in-esac structure; patterns end with ) and blocks end with ;;.
    * - Constant
      - .. code-block:: bash
 
            readonly MAX=100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'readonly' command prevents the variable from being redefined or unset.
    * - Addition
      - .. code-block:: bash
 
            ((a + b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Subtraction
      - .. code-block:: bash
 
            ((a - b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Multiplication
      - .. code-block:: bash
 
            ((a * b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Division
      - .. code-block:: bash
 
            ((a / b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Remainder
      - .. code-block:: bash
 
            ((a % b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Floor
      - .. code-block:: bash
 
            echo "a / 1" | bc
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Rounding
      - .. code-block:: bash
 
            printf "%.0f" "$a"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Increment
      - .. code-block:: bash
 
            ((a++))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - Decrement
      - .. code-block:: bash
 
            ((a--))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - LeftShift
      - .. code-block:: bash
 
            ((a << b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
    * - RightShift
      - .. code-block:: bash
 
            ((a >> b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Arithmetic expansion handles integers; bc or printf used for floating point operations.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: bash
 
            ((a & b))
+     - Bitwise operations within double parentheses.
+   * - BitOr
      - .. code-block:: bash
 
            ((a | b))
+     - Bitwise operations within double parentheses.
+   * - BitXor
      - .. code-block:: bash
 
            ((a ^ b))
+     - Bitwise operations within double parentheses.
+   * - BitNot
      - .. code-block:: bash
 
            ((~a))
-     - .. code-block:: bash
-
-           ((a << b))
-     - .. code-block:: bash
-
-           ((a >> b))
      - Bitwise operations within double parentheses.
+   * - Float4VectorMultiplication
+     - .. code-block:: bash
+
+           for i in {0..3}; do c[$i]=$(echo "${a[$i]} * ${b[$i]}" | bc); done
+     - Requires external tools like bc for floating-point arithmetic.
+   * - Float4VectorDotProduct
+     - .. code-block:: bash
+
+           dot=0; for i in {0..3}; do dot=$(echo "$dot + (${a[$i]} * ${b[$i]})" | bc); done
+     - Requires bc for floating-point accumulation.
+   * - Float4VectorCrossProduct
+     - .. code-block:: bash
+
+           c[0]=$(echo "${a[1]}*${b[2]} - ${a[2]}*${b[1]}" | bc)
+           c[1]=$(echo "${a[2]}*${b[0]} - ${a[0]}*${b[2]}" | bc)
+           c[2]=$(echo "${a[0]}*${b[1]} - ${a[1]}*${b[0]}" | bc)
+           c[3]=0
+     - Requires bc for floating-point calculations.

--- a/docs/c_pivot.rst
+++ b/docs/c_pivot.rst
@@ -7,23 +7,11 @@ C Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: c
 
            int x = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Static typing, terminated by semicolon.
    * - IfElse
      - .. code-block:: c
@@ -33,12 +21,6 @@ C Pivot View
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C if-else statement.
    * - Loop
      - .. code-block:: c
@@ -46,12 +28,6 @@ C Pivot View
            while (x > 0) {
                x = x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C while loop.
    * - FunctionDefinition
      - .. code-block:: c
@@ -59,12 +35,6 @@ C Pivot View
            int add(int a, int b) {
                return a + b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C function with static types and curly braces.
    * - ProcedureDefinition
      - .. code-block:: c
@@ -72,77 +42,35 @@ C Pivot View
            void log_message(const char *msg) {
                printf("%s\n", msg);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - In C, a procedure is a function with a void return type.
    * - TryCatch
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - C does not have native try-catch blocks; error handling is usually manual.
    * - Raise
      - .. code-block:: c
 
            exit(1);
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - C uses exit() or signals for severe errors.
    * - SingleLineComment
      - .. code-block:: c
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C single-line comment.
    * - MultiLineComment
      - .. code-block:: c
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C multi-line comment.
    * - Print
      - .. code-block:: c
 
            printf("Hello, World!\n");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the standard library's printf function; requires stdio.h.
    * - Import
      - .. code-block:: c
 
            #include <stdio.h>
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C way to include header files.
    * - SwitchCase
      - .. code-block:: c
@@ -155,163 +83,102 @@ C Pivot View
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C switch statement with case labels and default.
    * - Constant
      - .. code-block:: c
 
            const int MAX = 100;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'const' qualifier makes the variable immutable after initialization.
    * - Addition
      - .. code-block:: c
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - Subtraction
      - .. code-block:: c
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - Multiplication
      - .. code-block:: c
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - Division
      - .. code-block:: c
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - Remainder
      - .. code-block:: c
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - Floor
      - .. code-block:: c
 
            floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C operators; floor and round require math.h.
    * - Rounding
      - .. code-block:: c
 
            round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C operators; floor and round require math.h.
    * - Increment
      - .. code-block:: c
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - Decrement
      - .. code-block:: c
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard C operators; floor and round require math.h.
+     - Standard C operators.
    * - LeftShift
      - .. code-block:: c
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C operators; floor and round require math.h.
    * - RightShift
      - .. code-block:: c
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C operators; floor and round require math.h.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: c
 
            a & b
+     - Standard bitwise operators in C.
+   * - BitOr
      - .. code-block:: c
 
            a | b
+     - Standard bitwise operators in C.
+   * - BitXor
      - .. code-block:: c
 
            a ^ b
+     - Standard bitwise operators in C.
+   * - BitNot
      - .. code-block:: c
 
            ~a
-     - .. code-block:: c
-
-           a << b
-     - .. code-block:: c
-
-           a >> b
      - Standard bitwise operators in C.
+   * - Float4VectorMultiplication
+     - .. code-block:: c
+
+           for (int i = 0; i < 4; i++) c[i] = a[i] * b[i];
+     - Standard C requires a loop for element-wise multiplication of arrays.
+   * - Float4VectorDotProduct
+     - .. code-block:: c
+
+           float dot = 0; for (int i = 0; i < 4; i++) dot += a[i] * b[i];
+     - Standard C implementation using a loop and an accumulator.
+   * - Float4VectorCrossProduct
+     - .. code-block:: c
+
+           c[0] = a[1]*b[2] - a[2]*b[1];
+           c[1] = a[2]*b[0] - a[0]*b[2];
+           c[2] = a[0]*b[1] - a[1]*b[0];
+           c[3] = 0.0f;
+     - Calculated manually for the first three components.

--- a/docs/camel_pivot.rst
+++ b/docs/camel_pivot.rst
@@ -7,34 +7,16 @@ Camel Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: ocaml
 
            let x = 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Immutable binding by default; type inference is used.
    * - IfElse
      - .. code-block:: ocaml
 
            if x > 0 then 1 else 0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - If-then-else is an expression; both branches must return the same type.
    * - Loop
      - .. code-block:: ocaml
@@ -42,123 +24,57 @@ Camel Pivot View
            while !x > 0 do
                x := !x - 1
            done
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses references for mutable state in while loops.
    * - FunctionDefinition
      - .. code-block:: ocaml
 
            let add a b = a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions are defined with let; parameters are space-separated.
    * - TryCatch
      - .. code-block:: ocaml
 
            try do_something () with e -> handle e
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the try...with construct for exception handling.
    * - Raise
      - .. code-block:: ocaml
 
            raise (Failure "Error")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard way to raise an exception.
    * - Thread
      - .. code-block:: ocaml
 
            Thread.create do_work ()
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Requires the 'threads' library.
    * - SendMessage
      - .. code-block:: ocaml
 
            Event.sync (Event.send ch 42)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Synchronous communication using the Event module.
    * - ReceiveMessage
      - .. code-block:: ocaml
 
            let msg = Event.sync (Event.receive ch) in handle msg
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Receives a message from a channel.
    * - SingleLineComment
      - .. code-block:: ocaml
 
            (* comment *)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - OCaml uses (* *) for all comments.
    * - MultiLineComment
      - .. code-block:: ocaml
 
            (* line 1
               line 2 *)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Supports nested comments.
    * - Print
      - .. code-block:: ocaml
 
            print_endline "Hello, World!"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Outputs a string followed by a newline.
    * - Import
      - .. code-block:: ocaml
 
            open List
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Opens a module namespace.
    * - SwitchCase
      - .. code-block:: ocaml
@@ -167,174 +83,107 @@ Camel Pivot View
            | 1 -> 1
            | 2 -> 2
            | _ -> 0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Structural pattern matching using the match expression.
    * - Constant
      - .. code-block:: ocaml
 
            let max = 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Top-level let bindings are effectively constant.
    * - ProcedureDefinition
      - .. code-block:: ocaml
 
            let log_message msg = print_endline msg
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures in OCaml return the unit type ().
    * - Addition
      - .. code-block:: ocaml
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Subtraction
      - .. code-block:: ocaml
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Multiplication
      - .. code-block:: ocaml
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Division
      - .. code-block:: ocaml
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Remainder
      - .. code-block:: ocaml
 
            a mod b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Floor
      - .. code-block:: ocaml
 
            floor a
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Rounding
      - .. code-block:: ocaml
 
            Float.round a
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Increment
      - .. code-block:: ocaml
 
            a + 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - Decrement
      - .. code-block:: ocaml
 
            a - 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - LeftShift
      - .. code-block:: ocaml
 
            a lsl b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
    * - RightShift
      - .. code-block:: ocaml
 
            a lsr b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; OCaml uses separate operators for floats (e.g., +.).
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: ocaml
 
            a land b
+     - Bitwise operators are keywords.
+   * - BitOr
      - .. code-block:: ocaml
 
            a lor b
+     - Bitwise operators are keywords.
+   * - BitXor
      - .. code-block:: ocaml
 
            a lxor b
+     - Bitwise operators are keywords.
+   * - BitNot
      - .. code-block:: ocaml
 
            lnot a
-     - .. code-block:: ocaml
-
-           a lsl b
-     - .. code-block:: ocaml
-
-           a lsr b
      - Bitwise operators are keywords.
+   * - Float4VectorMultiplication
+     - .. code-block:: ocaml
+
+           Array.map2 (fun ai bi -> ai *. bi) a b
+     - OCaml uses specific operators for floating-point arithmetic (*.).
+   * - Float4VectorDotProduct
+     - .. code-block:: ocaml
+
+           let dot = List.fold_left2 (fun acc ai bi -> acc +. ai *. bi) 0.0 a b
+     - Uses fold_left2 for efficient simultaneous iteration over two lists.
+   * - Float4VectorCrossProduct
+     - .. code-block:: ocaml
+
+           [| a.(1) *. b.(2) -. a.(2) *. b.(1);
+              a.(2) *. b.(0) -. a.(0) *. b.(2);
+              a.(0) *. b.(1) -. a.(1) *. b.(0);
+              0.0 |]
+     - Uses array indexing and floating-point operators (*. and -.).

--- a/docs/cmd_pivot.rst
+++ b/docs/cmd_pivot.rst
@@ -7,46 +7,22 @@ Cmd Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: doscon
 
            set x=42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Used in Windows Command Prompt.
    * - IfElse
      - .. code-block:: doscon
 
            if %x% GTR 0 (exit /b 1) else (exit /b 0)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses GTR for 'greater than'; blocks are enclosed in parentheses.
    * - Loop
      - .. code-block:: doscon
 
            :loop
            if %x% GTR 0 (set /a x=x-1 & goto loop)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Loops are typically implemented using labels and goto.
    * - FunctionDefinition
      - .. code-block:: doscon
@@ -54,12 +30,6 @@ Cmd Pivot View
            :add
            set /a res=%~1+%~2
            exit /b %res%
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions are labels; called with 'call :label'; arguments are %1, %2.
    * - ProcedureDefinition
      - .. code-block:: doscon
@@ -67,234 +37,122 @@ Cmd Pivot View
            :log_message
            echo %~1
            goto :eof
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures are labels called with 'call'; they return using 'goto :eof' or 'exit /b'.
    * - TryCatch
      - .. code-block:: doscon
 
            do_something || call :handle_error
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Cmd uses || to execute a command if the previous one failed (non-zero errorlevel).
    * - Raise
      - .. code-block:: doscon
 
            exit /b 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Sets the errorlevel and exits the current script or function.
    * - SingleLineComment
      - .. code-block:: doscon
 
            REM comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses REM or :: (label hack) for comments.
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Command Prompt does not support multi-line comments.
    * - Print
      - .. code-block:: doscon
 
            echo Hello, World!
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Echo displays messages in Windows Command Prompt.
    * - Import
      - .. code-block:: doscon
 
            call other.cmd
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'call' command is used to run another batch file from within one.
    * - SwitchCase
      - .. code-block:: doscon
 
            if "%x%"=="1" (goto :one) else if "%x%"=="2" (goto :two) else (goto :none)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Cmd does not have a native switch; it is typically simulated with if/else or goto.
    * - Constant
      - .. code-block:: doscon
 
            set MAX=100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Cmd has no native support for constants; developers must manually ensure the value is not changed.
    * - Addition
      - .. code-block:: doscon
 
            set /a res=a+b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Subtraction
      - .. code-block:: doscon
 
            set /a res=a-b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Multiplication
      - .. code-block:: doscon
 
            set /a res=a*b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Division
      - .. code-block:: doscon
 
            set /a res=a/b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Remainder
      - .. code-block:: doscon
 
            set /a res=a%%b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Floor
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Rounding
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Increment
      - .. code-block:: doscon
 
            set /a a+=1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - Decrement
      - .. code-block:: doscon
 
            set /a a-=1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - LeftShift
      - .. code-block:: doscon
 
            set /a res=a<<b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
    * - RightShift
      - .. code-block:: doscon
 
            set /a res=a>>b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses set /a for integer arithmetic; no native floating point support.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: doscon
 
            set /a res="a & b"
+     - Bitwise operators within set /a expressions.
+   * - BitOr
      - .. code-block:: doscon
 
            set /a res="a | b"
+     - Bitwise operators within set /a expressions.
+   * - BitXor
      - .. code-block:: doscon
 
            set /a res="a ^ b"
+     - Bitwise operators within set /a expressions.
+   * - BitNot
      - .. code-block:: doscon
 
            set /a res="~a"
-     - .. code-block:: doscon
-
-           set /a res="a << b"
-     - .. code-block:: doscon
-
-           set /a res="a >> b"
      - Bitwise operators within set /a expressions.
+   * - Float4VectorMultiplication
+     - N/A
+     - Cmd does not natively support floating-point arithmetic or vectors.
+   * - Float4VectorDotProduct
+     - N/A
+     - Cmd has no native support for floating-point arithmetic.
+   * - Float4VectorCrossProduct
+     - N/A
+     - Cmd does not support floating-point arithmetic.

--- a/docs/css_pivot.rst
+++ b/docs/css_pivot.rst
@@ -109,6 +109,24 @@ CSS Pivot View
    * - RightShift
      - N/A
      - calc() function allows basic math; mod() and round() are in newer CSS specs.
-   * - Bitwise
+   * - BitAnd
      - N/A
      - CSS does not support bitwise operations.
+   * - BitOr
+     - N/A
+     - CSS does not support bitwise operations.
+   * - BitXor
+     - N/A
+     - CSS does not support bitwise operations.
+   * - BitNot
+     - N/A
+     - CSS does not support bitwise operations.
+   * - Float4VectorMultiplication
+     - N/A
+     - CSS does not support vector types or element-wise multiplication.
+   * - Float4VectorDotProduct
+     - N/A
+     - CSS does not support vector dot products.
+   * - Float4VectorCrossProduct
+     - N/A
+     - CSS does not support vector cross products.

--- a/docs/cuda_pivot.rst
+++ b/docs/cuda_pivot.rst
@@ -7,23 +7,11 @@ CUDA Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: cpp
 
            __device__ int x = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses __device__ qualifier for GPU memory.
    * - IfElse
      - .. code-block:: cpp
@@ -33,12 +21,6 @@ CUDA Pivot View
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like if-else statement.
    * - Loop
      - .. code-block:: cpp
@@ -46,12 +28,6 @@ CUDA Pivot View
            while (x > 0) {
                x = x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like while loop.
    * - FunctionDefinition
      - .. code-block:: cpp
@@ -59,12 +35,6 @@ CUDA Pivot View
            __device__ int add(int a, int b) {
                return a + b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions can be qualified with __device__, __host__, or __global__.
    * - ProcedureDefinition
      - .. code-block:: cpp
@@ -72,104 +42,44 @@ CUDA Pivot View
            __device__ void log_message(const char *msg) {
                printf("%s\n", msg);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Similar to C, procedures use the void return type.
    * - TryCatch
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - CUDA does not support C++ exceptions in device code.
    * - Raise
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - No native exception mechanism in CUDA device code.
    * - Thread
      - .. code-block:: cpp
 
            kernel<<<grid, block>>>();
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Launches a grid of threads on the GPU.
    * - SendMessage
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - CUDA threads typically communicate via shared memory or atomics, not explicit message passing.
    * - ReceiveMessage
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Communication is memory-based.
    * - SingleLineComment
      - .. code-block:: cpp
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like single-line comment.
    * - MultiLineComment
      - .. code-block:: cpp
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like block comment.
    * - Print
      - .. code-block:: cpp
 
            printf("Hello, World!\n");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - CUDA supports printf within device kernels for debugging.
    * - Import
      - .. code-block:: cpp
 
            #include <cuda_runtime.h>
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; used to include CUDA runtime headers.
    * - SwitchCase
      - .. code-block:: cpp
@@ -182,163 +92,99 @@ CUDA Pivot View
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like switch statement.
    * - Constant
      - .. code-block:: cpp
 
            __constant__ int MAX = 100;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The __constant__ qualifier places the variable in the constant memory space of the GPU.
    * - Addition
      - .. code-block:: cpp
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Subtraction
      - .. code-block:: cpp
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Multiplication
      - .. code-block:: cpp
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Division
      - .. code-block:: cpp
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Remainder
      - .. code-block:: cpp
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Floor
      - .. code-block:: cpp
 
            floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Rounding
      - .. code-block:: cpp
 
            round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Increment
      - .. code-block:: cpp
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - Decrement
      - .. code-block:: cpp
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - LeftShift
      - .. code-block:: cpp
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
    * - RightShift
      - .. code-block:: cpp
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Same as C; device-side math functions are optimized for GPU.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: cpp
 
            a & b
+     - Standard bitwise operators supported in kernels.
+   * - BitOr
      - .. code-block:: cpp
 
            a | b
+     - Standard bitwise operators supported in kernels.
+   * - BitXor
      - .. code-block:: cpp
 
            a ^ b
+     - Standard bitwise operators supported in kernels.
+   * - BitNot
      - .. code-block:: cpp
 
            ~a
-     - .. code-block:: cpp
-
-           a << b
-     - .. code-block:: cpp
-
-           a >> b
      - Standard bitwise operators supported in kernels.
+   * - Float4VectorMultiplication
+     - .. code-block:: cpp
+
+           c.x = a.x * b.x; c.y = a.y * b.y; c.z = a.z * b.z; c.w = a.w * b.w;
+     - The float4 type in CUDA is a struct; multiplication is done per-component.
+   * - Float4VectorDotProduct
+     - .. code-block:: cpp
+
+           float dot = a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+     - Manually calculated using the components of the float4 struct.
+   * - Float4VectorCrossProduct
+     - .. code-block:: cpp
+
+           c.x = a.y*b.z - a.z*b.y; c.y = a.z*b.x - a.x*b.z; c.z = a.x*b.y - a.y*b.x;
+     - Manually calculated using the components of the float4 struct.

--- a/docs/erlang_pivot.rst
+++ b/docs/erlang_pivot.rst
@@ -7,68 +7,32 @@ Erlang Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: erlang
 
            X = 42.
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Single assignment; must start with an uppercase letter.
    * - IfElse
      - .. code-block:: erlang
 
            if X > 0 -> 1; true -> 0 end
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Erlang 'if' uses guards; 'true' acts as an 'else' branch.
    * - Loop
      - .. code-block:: erlang
 
            loop(0) -> ok; loop(X) when X > 0 -> loop(X - 1).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Erlang uses recursion for looping; there are no built-in while/for loops.
    * - FunctionDefinition
      - .. code-block:: erlang
 
            add(A, B) -> A + B.
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Erlang functions use pattern matching on arguments; the last expression's value is returned.
    * - ProcedureDefinition
      - .. code-block:: erlang
 
            log_message(Msg) ->
                io:format("~p~n", [Msg]).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - In Erlang, every function returns a value; 'ok' is commonly used for procedures.
    * - TryCatch
      - .. code-block:: erlang
@@ -78,98 +42,44 @@ Erlang Pivot View
            catch
                error:Reason -> handle(Reason)
            end
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Erlang uses try...catch blocks; the type can be throw, error, or exit (defaulting to throw if omitted).
    * - Raise
      - .. code-block:: erlang
 
            error("Error")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The error/1 BIF is used to stop execution and provide a stack trace.
    * - Thread
      - .. code-block:: erlang
 
            Pid = spawn(fun() -> do_work() end).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Creates a new process (lightweight thread) and returns its PID.
    * - SendMessage
      - .. code-block:: erlang
 
            Pid ! hello.
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Asynchronous message passing using the ! operator.
    * - ReceiveMessage
      - .. code-block:: erlang
 
            receive hello -> handle_hello() end.
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Selective receive; blocks until a matching message is in the mailbox.
    * - SingleLineComment
      - .. code-block:: erlang
 
            % comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Erlang only supports single-line comments starting with %.
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Erlang does not have a native multi-line comment syntax.
    * - Print
      - .. code-block:: erlang
 
            io:format("Hello, World!~n").
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The io:format function is used for formatted output; ~n is the newline sequence.
    * - Import
      - .. code-block:: erlang
 
            -include("header.hrl").
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Includes header files; module functions are typically called using Module:Function syntax.
    * - SwitchCase
      - .. code-block:: erlang
@@ -179,163 +89,101 @@ Erlang Pivot View
                2 -> two;
                _ -> none
            end
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'case' for pattern matching; _ is the catch-all pattern.
    * - Constant
      - .. code-block:: erlang
 
            -define(MAX, 100).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses preprocessor macros to define constants; replaced at compile time.
    * - Addition
      - .. code-block:: erlang
 
            A + B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Subtraction
      - .. code-block:: erlang
 
            A - B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Multiplication
      - .. code-block:: erlang
 
            A * B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Division
      - .. code-block:: erlang
 
            A / B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Remainder
      - .. code-block:: erlang
 
            A rem B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Floor
      - .. code-block:: erlang
 
            floor(A)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Rounding
      - .. code-block:: erlang
 
            round(A)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Increment
      - .. code-block:: erlang
 
            A + 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - Decrement
      - .. code-block:: erlang
 
            A - 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - LeftShift
      - .. code-block:: erlang
 
            A bsl B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
    * - RightShift
      - .. code-block:: erlang
 
            A bsr B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Erlang arithmetic operator.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: erlang
 
            A band B
+     - Bitwise operators are keywords (band, bor, bxor, bnot, bsl, bsr).
+   * - BitOr
      - .. code-block:: erlang
 
            A bor B
+     - Bitwise operators are keywords (band, bor, bxor, bnot, bsl, bsr).
+   * - BitXor
      - .. code-block:: erlang
 
            A bxor B
+     - Bitwise operators are keywords (band, bor, bxor, bnot, bsl, bsr).
+   * - BitNot
      - .. code-block:: erlang
 
            bnot A
-     - .. code-block:: erlang
-
-           A bsl B
-     - .. code-block:: erlang
-
-           A bsr B
      - Bitwise operators are keywords (band, bor, bxor, bnot, bsl, bsr).
+   * - Float4VectorMultiplication
+     - .. code-block:: erlang
+
+           [Ai * Bi || {Ai, Bi} <- lists:zip(A, B)].
+     - Uses list comprehension and lists:zip.
+   * - Float4VectorDotProduct
+     - .. code-block:: erlang
+
+           Dot = lists:foldl(fun({Ai, Bi}, Acc) -> Ai * Bi + Acc end, 0.0, lists:zip(A, B)).
+     - Uses lists:zip and lists:foldl to calculate the sum of products.
+   * - Float4VectorCrossProduct
+     - .. code-block:: erlang
+
+           C = [lists:nth(2,A)*lists:nth(3,B) - lists:nth(3,A)*lists:nth(2,B),
+                lists:nth(3,A)*lists:nth(1,B) - lists:nth(1,A)*lists:nth(3,B),
+                lists:nth(1,A)*lists:nth(2,B) - lists:nth(2,A)*lists:nth(1,B), 0.0].
+     - Uses lists:nth (1-indexed) to access vector components.

--- a/docs/go_pivot.rst
+++ b/docs/go_pivot.rst
@@ -7,23 +7,11 @@ Go Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: go
 
            var x int = 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Static typing with optional type inference.
    * - IfElse
      - .. code-block:: go
@@ -33,12 +21,6 @@ Go Pivot View
            } else {
                return 0
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Parentheses around condition are not required; braces are mandatory.
    * - Loop
      - .. code-block:: go
@@ -46,12 +28,6 @@ Go Pivot View
            for x > 0 {
                x = x - 1
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Go uses 'for' for all looping constructs, including while-like loops.
    * - FunctionDefinition
      - .. code-block:: go
@@ -59,12 +35,6 @@ Go Pivot View
            func add(a int, b int) int {
                return a + b
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions use the 'func' keyword; return type follows the parameter list.
    * - ProcedureDefinition
      - .. code-block:: go
@@ -72,12 +42,6 @@ Go Pivot View
            func logMessage(msg string) {
                fmt.Println(msg)
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures are functions with no return value.
    * - TryCatch
      - .. code-block:: go
@@ -85,102 +49,48 @@ Go Pivot View
            if err := do_something(); err != nil {
                handle(err)
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Go handles errors explicitly by returning them as values.
    * - Raise
      - .. code-block:: go
 
            panic("Error")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'panic' for unrecoverable errors.
    * - Thread
      - .. code-block:: go
 
            go do_work()
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'go' keyword starts a new goroutine (lightweight thread).
    * - SendMessage
      - .. code-block:: go
 
            ch <- 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Sends a value to a channel.
    * - ReceiveMessage
      - .. code-block:: go
 
            msg := <-ch
            handle(msg)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Receives a value from a channel; blocks until data is available.
    * - SingleLineComment
      - .. code-block:: go
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard single-line comment.
    * - MultiLineComment
      - .. code-block:: go
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard block comment.
    * - Print
      - .. code-block:: go
 
            fmt.Println("Hello, World!")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the fmt package for formatted I/O.
    * - Import
      - .. code-block:: go
 
            import "fmt"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Imports a package by its path.
    * - SwitchCase
      - .. code-block:: go
@@ -193,163 +103,105 @@ Go Pivot View
            default:
                return 0
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Switch cases do not fall through by default in Go.
    * - Constant
      - .. code-block:: go
 
            const MAX = 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Constants are declared with the 'const' keyword.
    * - Addition
      - .. code-block:: go
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard arithmetic operators.
    * - Subtraction
      - .. code-block:: go
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard arithmetic operators.
    * - Multiplication
      - .. code-block:: go
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard arithmetic operators.
    * - Division
      - .. code-block:: go
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard arithmetic operators.
    * - Remainder
      - .. code-block:: go
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard arithmetic operators.
    * - Floor
      - .. code-block:: go
 
            math.Floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Requires the math package.
    * - Rounding
      - .. code-block:: go
 
            math.Round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Requires the math package.
    * - Increment
      - .. code-block:: go
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Go supports postfix increment as a statement, not an expression.
    * - Decrement
      - .. code-block:: go
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Go supports postfix decrement as a statement, not an expression.
    * - LeftShift
      - .. code-block:: go
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard bitwise shift operators.
    * - RightShift
      - .. code-block:: go
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard bitwise shift operators.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: go
 
            a & b
+     - Bitwise NOT is implemented using the bitwise XOR operator with no left operand.
+   * - BitOr
      - .. code-block:: go
 
            a | b
+     - Bitwise NOT is implemented using the bitwise XOR operator with no left operand.
+   * - BitXor
      - .. code-block:: go
 
            a ^ b
+     - Bitwise NOT is implemented using the bitwise XOR operator with no left operand.
+   * - BitNot
      - .. code-block:: go
 
            ^a
-     - .. code-block:: go
-
-           a << b
-     - .. code-block:: go
-
-           a >> b
      - Bitwise NOT is implemented using the bitwise XOR operator with no left operand.
+   * - Float4VectorMultiplication
+     - .. code-block:: go
+
+           for i := range a { c[i] = a[i] * b[i] }
+     - Iterates over the indices of the slices or arrays.
+   * - Float4VectorDotProduct
+     - .. code-block:: go
+
+           dot := 0.0
+           for i := range a { dot += a[i] * b[i] }
+     - Standard imperative loop for accumulating the sum of products.
+   * - Float4VectorCrossProduct
+     - .. code-block:: go
+
+           c := [4]float64{
+               a[1]*b[2] - a[2]*b[1],
+               a[2]*b[0] - a[0]*b[2],
+               a[0]*b[1] - a[1]*b[0],
+               0,
+           }
+     - Calculated using array indexing in a composite literal.

--- a/docs/haskell_pivot.rst
+++ b/docs/haskell_pivot.rst
@@ -7,170 +7,80 @@ Haskell Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: haskell
 
            let x = 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Immutable binding within a scope; part of let-in or where clause.
    * - IfElse
      - .. code-block:: haskell
 
            if x > 0 then 1 else 0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - If-then-else is an expression; both branches must be present and have the same type.
    * - Loop
      - .. code-block:: haskell
 
            loop x = if x > 0 then loop (x - 1) else return ()
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Haskell uses recursion for iteration as it is a pure functional language.
    * - FunctionDefinition
      - .. code-block:: haskell
 
            add :: Int -> Int -> Int
            add a b = a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Function types are usually declared explicitly; arguments are space-separated.
    * - ProcedureDefinition
      - .. code-block:: haskell
 
            logMessage :: String -> IO ()
            logMessage msg = putStrLn msg
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures are functions that return an IO action.
    * - TryCatch
      - .. code-block:: haskell
 
            do_something `catch` \(e :: SomeException) -> handle e
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Exception handling using the catch function from Control.Exception.
    * - Raise
      - .. code-block:: haskell
 
            error "Error"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'error' function stops execution and displays a message.
    * - Thread
      - .. code-block:: haskell
 
            forkIO (do_work)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - forkIO creates a lightweight thread (requires Control.Concurrent).
    * - SendMessage
      - .. code-block:: haskell
 
            writeChan chan 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Writes a value to a Chan (unbounded FIFO channel).
    * - ReceiveMessage
      - .. code-block:: haskell
 
            msg <- readChan chan
            handle msg
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Reads a value from a Chan; blocks if the channel is empty.
    * - SingleLineComment
      - .. code-block:: haskell
 
            -- comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard single-line comment.
    * - MultiLineComment
      - .. code-block:: haskell
 
            {- line 1
               line 2 -}
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard block comment; can be nested.
    * - Print
      - .. code-block:: haskell
 
            putStrLn "Hello, World!"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Outputs a string followed by a newline in the IO monad.
    * - Import
      - .. code-block:: haskell
 
            import Data.List
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Imports symbols from a module into the current namespace.
    * - SwitchCase
      - .. code-block:: haskell
@@ -179,163 +89,99 @@ Haskell Pivot View
                1 -> 1
                2 -> 2
                _ -> 0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses pattern matching in a case expression.
    * - Constant
      - .. code-block:: haskell
 
            maxVal = 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Top-level bindings are immutable and effectively constant.
    * - Addition
      - .. code-block:: haskell
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard mathematical operators.
    * - Subtraction
      - .. code-block:: haskell
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard mathematical operators.
    * - Multiplication
      - .. code-block:: haskell
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard mathematical operators.
    * - Division
      - .. code-block:: haskell
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Haskell uses / for floating-point and 'div' or 'quot' for integer division.
    * - Remainder
      - .. code-block:: haskell
 
            a `mod` b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard mathematical operators.
    * - Floor
      - .. code-block:: haskell
 
            floor a
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard mathematical operators.
    * - Rounding
      - .. code-block:: haskell
 
            round a
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard mathematical operators.
    * - Increment
      - .. code-block:: haskell
 
            a + 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - No native increment operator; use addition.
    * - Decrement
      - .. code-block:: haskell
 
            a - 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - No native decrement operator; use subtraction.
    * - LeftShift
      - .. code-block:: haskell
 
            shiftL a b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Requires Data.Bits.
    * - RightShift
      - .. code-block:: haskell
 
            shiftR a b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Requires Data.Bits.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: haskell
 
            a .&. b
+     - Requires Data.Bits.
+   * - BitOr
      - .. code-block:: haskell
 
            a .|. b
+     - Requires Data.Bits.
+   * - BitXor
      - .. code-block:: haskell
 
            xor a b
+     - Requires Data.Bits.
+   * - BitNot
      - .. code-block:: haskell
 
            complement a
-     - .. code-block:: haskell
-
-           shiftL a b
-     - .. code-block:: haskell
-
-           shiftR a b
      - Requires Data.Bits.
+   * - Float4VectorMultiplication
+     - .. code-block:: haskell
+
+           zipWith (*) a b
+     - Applies multiplication element-wise to two lists.
+   * - Float4VectorDotProduct
+     - .. code-block:: haskell
+
+           dot = sum $ zipWith (*) a b
+     - Pure functional approach using zipWith, multiplication, and sum.
+   * - Float4VectorCrossProduct
+     - .. code-block:: haskell
+
+           cross [a1,a2,a3,_] [b1,b2,b3,_] = [a2*b3 - a3*b2, a3*b1 - a1*b3, a1*b2 - a2*b1, 0.0]
+     - Pure functional implementation using pattern matching.

--- a/docs/java_bytecode_pivot.rst
+++ b/docs/java_bytecode_pivot.rst
@@ -7,26 +7,14 @@ Java Bytecode Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            .field private static x I = 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - In Jasmin syntax, static fields represent global-like variables.
    * - IfElse
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                getstatic MyClass/x I
                ifgt LabelThen
@@ -35,15 +23,9 @@ Java Bytecode Pivot View
            LabelThen:
                iconst_1
                ireturn
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented using stack operations and branch instructions (ifgt).
    * - Loop
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            LoopStart:
                getstatic MyClass/x I
@@ -54,15 +36,9 @@ Java Bytecode Pivot View
                putstatic MyClass/x I
                goto LoopStart
            LoopEnd:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Loops are built with labels and jump instructions (goto, ifle).
    * - FunctionDefinition
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            .method public static add(II)I
                .limit stack 2
@@ -72,15 +48,9 @@ Java Bytecode Pivot View
                iadd
                ireturn
            .end method
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Methods define stack and local variable limits; parameters are accessed by index.
    * - TryCatch
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            .catch java/lang/Exception from TryStart to TryEnd using CatchHandler
            TryStart:
@@ -92,43 +62,25 @@ Java Bytecode Pivot View
                aload_1
                invokestatic MyClass/handle(Ljava/lang/Exception;)V
            Done:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Exception handlers are defined via .catch directives for specific code ranges.
    * - Raise
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                new java/lang/RuntimeException
                dup
                ldc "Error"
                invokespecial java/lang/RuntimeException/<init>(Ljava/lang/String;)V
                athrow
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Exceptions are instantiated and then thrown using the athrow instruction.
    * - Print
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                getstatic java/lang/System/out Ljava/io/PrintStream;
                ldc "Hello, World!"
                invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Calls println on the static System.out field.
    * - Thread
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                new java/lang/Thread
                dup
@@ -137,29 +89,17 @@ Java Bytecode Pivot View
                invokespecial MyRunnable/<init>()V
                invokespecial java/lang/Thread/<init>(Ljava/lang/Runnable;)V
                invokevirtual java/lang/Thread/start()V
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Involves instantiating a Thread object with a Runnable and calling start().
    * - SendMessage
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                aload_0 ; queue
                bipush 42
                invokestatic java/lang/Integer/valueOf(I)Ljava/lang/Integer;
                invokevirtual java/util/concurrent/BlockingQueue/put(Ljava/lang/Object;)V
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Typically uses standard Java concurrent collections like BlockingQueue.
    * - ReceiveMessage
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                aload_0 ; queue
                invokevirtual java/util/concurrent/BlockingQueue/take()Ljava/lang/Object;
@@ -168,46 +108,22 @@ Java Bytecode Pivot View
                istore_1 ; msg
                iload_1
                invokestatic MyClass/handle(I)V
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Blocking retrieval from a concurrent collection.
    * - SingleLineComment
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            ; comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Jasmin uses semicolons for single-line comments.
    * - MultiLineComment
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Java Bitcode (Jasmin) does not have a native multi-line comment syntax; multiple semicolons are used.
    * - Import
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            Ljava/util/List;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Internal descriptors are used to reference external classes.
    * - SwitchCase
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
                getstatic MyClass/x I
                lookupswitch
@@ -220,26 +136,14 @@ Java Bytecode Pivot View
                ; ...
            LabelDefault:
                ; ...
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses lookupswitch or tableswitch instructions for multi-way branching.
    * - Constant
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            .field public static final MAX I = 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Constants are represented as static final fields.
    * - ProcedureDefinition
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            .method public static logMessage(Ljava/lang/String;)V
                .limit stack 2
@@ -249,149 +153,116 @@ Java Bytecode Pivot View
                invokevirtual java/io/PrintStream/println(Ljava/lang/String;)V
                return
            .end method
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Methods with a 'V' return descriptor are procedures; 'return' instruction is used for void return.
    * - Addition
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            iadd
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Subtraction
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            isub
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Multiplication
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            imul
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Division
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            idiv
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Remainder
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            irem
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Floor
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Stack-based arithmetic instructions for integers.
    * - Rounding
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Increment
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            iinc index, 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - Decrement
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            iinc index, -1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - LeftShift
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            ishl
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
    * - RightShift
-     - .. code-block:: jasm
+     - .. code-block:: jasmin
 
            ishr
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Stack-based arithmetic instructions for integers.
-   * - Bitwise
-     - N/A
-     - .. code-block:: jasm
+   * - BitAnd
+     - .. code-block:: jasmin
 
            iand
-     - .. code-block:: jasm
+     - Stack-based bitwise instructions; NOT is implemented as XOR with -1.
+   * - BitOr
+     - .. code-block:: jasmin
 
            ior
-     - .. code-block:: jasm
+     - Stack-based bitwise instructions; NOT is implemented as XOR with -1.
+   * - BitXor
+     - .. code-block:: jasmin
 
            ixor
-     - .. code-block:: jasm
+     - Stack-based bitwise instructions; NOT is implemented as XOR with -1.
+   * - BitNot
+     - .. code-block:: jasmin
 
            iconst_m1
            ixor
-     - .. code-block:: jasm
-
-           ishl
-     - .. code-block:: jasm
-
-           ishr
      - Stack-based bitwise instructions; NOT is implemented as XOR with -1.
+   * - Float4VectorMultiplication
+     - .. code-block:: jasmin
+
+           fload_1
+           fload_2
+           fmul
+     - Java Bytecode uses fmul for individual floats; vectorization is typically handled by the JIT.
+   * - Float4VectorDotProduct
+     - .. code-block:: jasmin
+
+           fload_1 ; a[i]
+           fload_2 ; b[i]
+           fmul
+           fadd
+     - Dot product is built by repeating fmul and fadd instructions on the stack.
+   * - Float4VectorCrossProduct
+     - .. code-block:: jasmin
+
+           fload 1 ; ay
+           fload 6 ; bz
+           fmul
+           fload 2 ; az
+           fload 5 ; by
+           fmul
+           fsub ; -> cx
+           fload 2 ; az
+           fload 4 ; bx
+           fmul
+           fload 0 ; ax
+           fload 6 ; bz
+           fmul
+           fsub ; -> cy
+           fload 0 ; ax
+           fload 5 ; by
+           fmul
+           fload 1 ; ay
+           fload 4 ; bx
+           fmul
+           fsub ; -> cz
+     - Calculated component-wise using stack operations.

--- a/docs/java_pivot.rst
+++ b/docs/java_pivot.rst
@@ -7,23 +7,11 @@ Java Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: java
 
            int x = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Strongly typed, similar to C.
    * - IfElse
      - .. code-block:: java
@@ -33,12 +21,6 @@ Java Pivot View
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Identical to C.
    * - Loop
      - .. code-block:: java
@@ -46,12 +28,6 @@ Java Pivot View
            while (x > 0) {
                x = x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Identical to C.
    * - FunctionDefinition
      - .. code-block:: java
@@ -59,12 +35,6 @@ Java Pivot View
            public int add(int a, int b) {
                return a + b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Similar to C, but typically within a class with an access modifier.
    * - ProcedureDefinition
      - .. code-block:: java
@@ -72,12 +42,6 @@ Java Pivot View
            public void logMessage(String msg) {
                System.out.println(msg);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'void' keyword to indicate no return value.
    * - TryCatch
      - .. code-block:: java
@@ -87,101 +51,47 @@ Java Pivot View
            } catch (Exception e) {
                handle(e);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Java exception handling.
    * - Raise
      - .. code-block:: java
 
            throw new RuntimeException("Error");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'throw' to raise an exception.
    * - Thread
      - .. code-block:: java
 
            new Thread(() -> { do_work(); }).start();
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Spawns a new platform thread; virtual threads are available in newer versions.
    * - SendMessage
      - .. code-block:: java
 
            queue.put(42);
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Commonly implemented using BlockingQueue; put() may block if the queue is full.
    * - ReceiveMessage
      - .. code-block:: java
 
            int msg = queue.take(); handle(msg);
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Using BlockingQueue.take(); blocks until an element becomes available.
    * - SingleLineComment
      - .. code-block:: java
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Identical to C.
    * - MultiLineComment
      - .. code-block:: java
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Identical to C.
    * - Print
      - .. code-block:: java
 
            System.out.println("Hello, World!");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses System.out for standard output; includes a newline.
    * - Import
      - .. code-block:: java
 
            import java.util.List;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Imports a specific class; can use * for all classes in a package.
    * - SwitchCase
      - .. code-block:: java
@@ -194,163 +104,102 @@ Java Pivot View
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Identical to C; modern Java also supports switch expressions.
    * - Constant
      - .. code-block:: java
 
            public static final int MAX = 100;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'final' to prevent modification; typically combined with 'static' for class-level constants.
    * - Addition
      - .. code-block:: java
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Subtraction
      - .. code-block:: java
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Multiplication
      - .. code-block:: java
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Division
      - .. code-block:: java
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Remainder
      - .. code-block:: java
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Floor
      - .. code-block:: java
 
            Math.floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Rounding
      - .. code-block:: java
 
            Math.round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Increment
      - .. code-block:: java
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - Decrement
      - .. code-block:: java
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - LeftShift
      - .. code-block:: java
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
    * - RightShift
      - .. code-block:: java
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; Math class provides rounding and floor functions.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: java
 
            a & b
+     - Standard bitwise operators in Java.
+   * - BitOr
      - .. code-block:: java
 
            a | b
+     - Standard bitwise operators in Java.
+   * - BitXor
      - .. code-block:: java
 
            a ^ b
+     - Standard bitwise operators in Java.
+   * - BitNot
      - .. code-block:: java
 
            ~a
-     - .. code-block:: java
-
-           a << b
-     - .. code-block:: java
-
-           a >> b
      - Standard bitwise operators in Java.
+   * - Float4VectorMultiplication
+     - .. code-block:: java
+
+           for (int i = 0; i < 4; i++) c[i] = a[i] * b[i];
+     - Standard Java uses loops; the Vector API (incubating) provides SIMD support.
+   * - Float4VectorDotProduct
+     - .. code-block:: java
+
+           float dot = 0; for (int i = 0; i < 4; i++) dot += a[i] * b[i];
+     - Standard Java implementation using a loop; Vector API provides optimized dot product.
+   * - Float4VectorCrossProduct
+     - .. code-block:: java
+
+           c[0] = a[1]*b[2] - a[2]*b[1];
+           c[1] = a[2]*b[0] - a[0]*b[2];
+           c[2] = a[0]*b[1] - a[1]*b[0];
+           c[3] = 0.0f;
+     - Standard Java implementation using array indexing.

--- a/docs/lisp_pivot.rst
+++ b/docs/lisp_pivot.rst
@@ -7,135 +7,63 @@ Lisp Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: common-lisp
 
            (defparameter x 42)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Dynamic typing; defined using defparameter or defvar.
    * - IfElse
      - .. code-block:: common-lisp
 
            (if (> x 0) 1 0)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The 'if' expression evaluates the condition and returns the corresponding branch result.
    * - Loop
      - .. code-block:: common-lisp
 
            (loop while (> x 0) do (setq x (1- x)))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Common Lisp 'loop' macro provides a versatile way to iterate.
    * - FunctionDefinition
      - .. code-block:: common-lisp
 
            (defun add (a b) (+ a b))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions are defined with 'defun'; Lisp follows prefix notation.
    * - ProcedureDefinition
      - .. code-block:: common-lisp
 
            (defun log-message (msg)
              (format t "~A~%" msg))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Lisp functions always return the value of the last expression; procedures return nil or some status.
    * - TryCatch
      - .. code-block:: common-lisp
 
            (handler-case (do_something) (error (c) (handle c)))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Common Lisp uses handler-case for high-level error handling.
    * - Raise
      - .. code-block:: common-lisp
 
            (error "Error")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Signals a continuous error that must be handled or it enters the debugger.
    * - SingleLineComment
      - .. code-block:: common-lisp
 
            ; comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Lisp single-line comment using semicolon.
    * - MultiLineComment
      - .. code-block:: common-lisp
 
            #| line 1
               line 2 |#
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses ``#|`` and ``|#`` for block comments.
    * - Print
      - .. code-block:: common-lisp
 
            (format t "Hello, World!~%")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The format function with 't' outputs to standard output; ~% is a newline.
    * - Import
      - .. code-block:: common-lisp
 
            (use-package :iter)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Makes symbols from the specified package available in the current package.
    * - SwitchCase
      - .. code-block:: common-lisp
@@ -144,163 +72,102 @@ Lisp Pivot View
              (1 "one")
              (2 "two")
              (t "none"))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard 'case' macro; 't' or 'otherwise' is the default branch.
    * - Constant
      - .. code-block:: common-lisp
 
            (defconstant +max+ 100)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Defines a global constant; by convention, names are often wrapped in + signs.
    * - Addition
      - .. code-block:: common-lisp
 
            (+ a b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Subtraction
      - .. code-block:: common-lisp
 
            (- a b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Multiplication
      - .. code-block:: common-lisp
 
            (* a b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Division
      - .. code-block:: common-lisp
 
            (/ a b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Remainder
      - .. code-block:: common-lisp
 
            (mod a b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Floor
      - .. code-block:: common-lisp
 
            (floor a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Rounding
      - .. code-block:: common-lisp
 
            (round a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Increment
      - .. code-block:: common-lisp
 
            (1+ a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - Decrement
      - .. code-block:: common-lisp
 
            (1- a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - LeftShift
      - .. code-block:: common-lisp
 
            (ash a b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
    * - RightShift
      - .. code-block:: common-lisp
 
            (ash a -b)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prefix notation for all mathematical operations.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: common-lisp
 
            (logand a b)
+     - Common Lisp bitwise operations; ash is used for both left and right shifts.
+   * - BitOr
      - .. code-block:: common-lisp
 
            (logior a b)
+     - Common Lisp bitwise operations; ash is used for both left and right shifts.
+   * - BitXor
      - .. code-block:: common-lisp
 
            (logxor a b)
+     - Common Lisp bitwise operations; ash is used for both left and right shifts.
+   * - BitNot
      - .. code-block:: common-lisp
 
            (lognot a)
-     - .. code-block:: common-lisp
-
-           (ash a b)
-     - .. code-block:: common-lisp
-
-           (ash a -b)
      - Common Lisp bitwise operations; ash is used for both left and right shifts.
+   * - Float4VectorMultiplication
+     - .. code-block:: common-lisp
+
+           (mapcar #'* a b)
+     - Applies the multiplication function element-wise to the lists.
+   * - Float4VectorDotProduct
+     - .. code-block:: common-lisp
+
+           (reduce #'+ (mapcar #'* a b))
+     - Maps multiplication over lists and reduces the result with addition.
+   * - Float4VectorCrossProduct
+     - .. code-block:: common-lisp
+
+           (list (- (* (nth 1 a) (nth 2 b)) (* (nth 2 a) (nth 1 b)))
+                 (- (* (nth 2 a) (nth 0 b)) (* (nth 0 a) (nth 2 b)))
+                 (- (* (nth 0 a) (nth 1 b)) (* (nth 1 a) (nth 0 b)))
+                 0.0)
+     - Uses nth and basic arithmetic functions.

--- a/docs/php_pivot.rst
+++ b/docs/php_pivot.rst
@@ -7,23 +7,11 @@ PHP Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: php
 
            $x = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Variables start with a dollar sign; dynamically typed but supports type declarations.
    * - IfElse
      - .. code-block:: php
@@ -33,12 +21,6 @@ PHP Pivot View
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like if-else statement.
    * - Loop
      - .. code-block:: php
@@ -46,12 +28,6 @@ PHP Pivot View
            while ($x > 0) {
                $x = $x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like while loop.
    * - FunctionDefinition
      - .. code-block:: php
@@ -59,12 +35,6 @@ PHP Pivot View
            function add(int $a, int $b): int {
                return $a + $b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'function' keyword; supports type hints for parameters and return values.
    * - ProcedureDefinition
      - .. code-block:: php
@@ -72,12 +42,6 @@ PHP Pivot View
            function log_message(string $msg): void {
                echo $msg;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'void' return type hint (PHP 7.1+).
    * - TryCatch
      - .. code-block:: php
@@ -87,68 +51,32 @@ PHP Pivot View
            } catch (Exception $e) {
                handle($e);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP exception handling using try-catch blocks.
    * - Raise
      - .. code-block:: php
 
            throw new Exception("Error");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'throw' to trigger an exception.
    * - SingleLineComment
      - .. code-block:: php
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Supports // and # for single-line comments.
    * - MultiLineComment
      - .. code-block:: php
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-style block comments.
    * - Print
      - .. code-block:: php
 
            echo "Hello, World!";
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The echo statement is used to output text.
    * - Import
      - .. code-block:: php
 
            require 'utils.php';
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses include, require, include_once, or require_once to include other files.
    * - SwitchCase
      - .. code-block:: php
@@ -161,163 +89,99 @@ PHP Pivot View
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-like switch statement; match expression is also available in PHP 8.0+.
    * - Constant
      - .. code-block:: php
 
            define('MAX', 100);
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Constants can be defined using define() or the 'const' keyword (for class constants or global constants in modern PHP).
    * - Addition
      - .. code-block:: php
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Subtraction
      - .. code-block:: php
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Multiplication
      - .. code-block:: php
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Division
      - .. code-block:: php
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Remainder
      - .. code-block:: php
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Floor
      - .. code-block:: php
 
            floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Rounding
      - .. code-block:: php
 
            round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Increment
      - .. code-block:: php
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - Decrement
      - .. code-block:: php
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - LeftShift
      - .. code-block:: php
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
    * - RightShift
      - .. code-block:: php
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PHP arithmetic operators.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: php
 
            a & b
+     - Standard bitwise operators.
+   * - BitOr
      - .. code-block:: php
 
            a | b
+     - Standard bitwise operators.
+   * - BitXor
      - .. code-block:: php
 
            a ^ b
+     - Standard bitwise operators.
+   * - BitNot
      - .. code-block:: php
 
            ~a
-     - .. code-block:: php
-
-           a << b
-     - .. code-block:: php
-
-           a >> b
      - Standard bitwise operators.
+   * - Float4VectorMultiplication
+     - .. code-block:: php
+
+           $c = array_map(fn($ai, $bi) => $ai * $bi, $a, $b);
+     - Uses array_map with an arrow function.
+   * - Float4VectorDotProduct
+     - .. code-block:: php
+
+           $dot = array_sum(array_map(fn($ai, $bi) => $ai * $bi, $a, $b));
+     - Combines array_map and array_sum.
+   * - Float4VectorCrossProduct
+     - .. code-block:: php
+
+           $c = [$a[1]*$b[2] - $a[2]*$b[1], $a[2]*$b[0] - $a[0]*$b[2], $a[0]*$b[1] - $a[1]*$b[0], 0.0];
+     - Calculated using array indexing and the cross product formula.

--- a/docs/powershell_pivot.rst
+++ b/docs/powershell_pivot.rst
@@ -7,23 +7,11 @@ PowerShell Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: powershell
 
            $x = 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Variables start with a dollar sign.
    * - IfElse
      - .. code-block:: powershell
@@ -33,12 +21,6 @@ PowerShell Pivot View
            } else {
                return 0
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses PowerShell comparison operators (e.g., -gt).
    * - Loop
      - .. code-block:: powershell
@@ -46,12 +28,6 @@ PowerShell Pivot View
            while ($x -gt 0) {
                $x = $x - 1
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard while loop with C-like block syntax.
    * - FunctionDefinition
      - .. code-block:: powershell
@@ -59,12 +35,6 @@ PowerShell Pivot View
            function add($a, $b) {
                return $a + $b
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'function' keyword; parameters are variables starting with $.
    * - ProcedureDefinition
      - .. code-block:: powershell
@@ -72,12 +42,6 @@ PowerShell Pivot View
            function log-message($msg) {
                Write-Host $msg
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions without a return statement output nothing to the pipeline.
    * - TryCatch
      - .. code-block:: powershell
@@ -87,68 +51,32 @@ PowerShell Pivot View
            } catch {
                handle_error($_)
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - PowerShell supports try-catch-finally blocks; $_ (or $PSItem) refers to the current error.
    * - Raise
      - .. code-block:: powershell
 
            throw "Error"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'throw' to create a terminating error.
    * - SingleLineComment
      - .. code-block:: powershell
 
            # comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard PowerShell single-line comment.
    * - MultiLineComment
      - .. code-block:: powershell
 
            <# line 1
               line 2 #>
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses <# and #> for block comments.
    * - Print
      - .. code-block:: powershell
 
            Write-Host "Hello, World!"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Write-Host outputs directly to the console host.
    * - Import
      - .. code-block:: powershell
 
            Import-Module ActiveDirectory
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Loads a module into the current session.
    * - SwitchCase
      - .. code-block:: powershell
@@ -158,163 +86,99 @@ PowerShell Pivot View
                2 { "two" }
                default { "none" }
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Versatile switch statement that supports multiple types and patterns.
    * - Constant
      - .. code-block:: powershell
 
            Set-Variable -Name MAX -Value 100 -Option ReadOnly
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Using Set-Variable with the ReadOnly option; Constant option is even more restrictive.
    * - Addition
      - .. code-block:: powershell
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Subtraction
      - .. code-block:: powershell
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Multiplication
      - .. code-block:: powershell
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Division
      - .. code-block:: powershell
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Remainder
      - .. code-block:: powershell
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Floor
      - .. code-block:: powershell
 
            [Math]::Floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Rounding
      - .. code-block:: powershell
 
            [Math]::Round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Increment
      - .. code-block:: powershell
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - Decrement
      - .. code-block:: powershell
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - LeftShift
      - .. code-block:: powershell
 
            a -shl b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
    * - RightShift
      - .. code-block:: powershell
 
            a -shr b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard operators; uses .NET Math class for advanced functions.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: powershell
 
            a -band b
+     - Uses prefixed operators for bitwise logic.
+   * - BitOr
      - .. code-block:: powershell
 
            a -bor b
+     - Uses prefixed operators for bitwise logic.
+   * - BitXor
      - .. code-block:: powershell
 
            a -bxor b
+     - Uses prefixed operators for bitwise logic.
+   * - BitNot
      - .. code-block:: powershell
 
            -bnot a
-     - .. code-block:: powershell
-
-           a -shl b
-     - .. code-block:: powershell
-
-           a -shr b
      - Uses prefixed operators for bitwise logic.
+   * - Float4VectorMultiplication
+     - .. code-block:: powershell
+
+           $c = 0..3 | ForEach-Object { $a[$_] * $b[$_] }
+     - Uses a pipeline and ForEach-Object to iterate over indices.
+   * - Float4VectorDotProduct
+     - .. code-block:: powershell
+
+           $dot = 0; 0..3 | ForEach-Object { $dot += $a[$_] * $b[$_] }
+     - Iterates over indices and accumulates the product.
+   * - Float4VectorCrossProduct
+     - .. code-block:: powershell
+
+           $c = @($a[1]*$b[2] - $a[2]*$b[1], $a[2]*$b[0] - $a[0]*$b[2], $a[0]*$b[1] - $a[1]*$b[0], 0.0)
+     - Uses array literal syntax with expressions.

--- a/docs/prolog_pivot.rst
+++ b/docs/prolog_pivot.rst
@@ -7,168 +7,78 @@ Prolog Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: prolog
 
            X = 42.
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses unification for assignment; variables must start with an uppercase letter.
    * - IfElse
      - .. code-block:: prolog
 
            (X > 0 -> Result = 1 ; Result = 0)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the (Condition -> Then ; Else) control construct.
    * - Loop
      - .. code-block:: prolog
 
            loop(0) :- !.
            loop(X) :- X > 0, X1 is X - 1, loop(X1).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Prolog uses recursion and tail-call optimization for looping.
    * - FunctionDefinition
      - .. code-block:: prolog
 
            add(A, B, Res) :- Res is A + B.
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions are predicates; return values are typically unified with an output argument.
    * - ProcedureDefinition
      - .. code-block:: prolog
 
            log_message(Msg) :- writeln(Msg).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Predicates without an output argument act as procedures.
    * - TryCatch
      - .. code-block:: prolog
 
            catch(do_something, E, handle(E))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Prolog error handling using the catch/3 predicate.
    * - Raise
      - .. code-block:: prolog
 
            throw(error(Error))
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses throw/1 to raise an exception.
    * - Thread
      - .. code-block:: prolog
 
            thread_create(do_work, Id, []).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Creates a new thread using thread_create/3 (ISO Prolog / SWI-Prolog).
    * - SendMessage
      - .. code-block:: prolog
 
            thread_send_message(Id, hello).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Sends a message to a thread's message queue.
    * - ReceiveMessage
      - .. code-block:: prolog
 
            thread_get_message(hello).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Retrieves a matching message from the current thread's queue.
    * - SingleLineComment
      - .. code-block:: prolog
 
            % comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Prolog single-line comment.
    * - MultiLineComment
      - .. code-block:: prolog
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-style block comment.
    * - Print
      - .. code-block:: prolog
 
            writeln('Hello, World!').
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Outputs text followed by a newline.
    * - Import
      - .. code-block:: prolog
 
            use_module(library(math)).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Imports predicates from a library module.
    * - SwitchCase
      - .. code-block:: prolog
@@ -177,163 +87,102 @@ Prolog Pivot View
            ;   X = 2 -> writeln('two')
            ;   writeln('none')
            )
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Usually implemented using nested (If -> Then ; Else) or multiple clauses.
    * - Constant
      - .. code-block:: prolog
 
            max(100).
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Constants are represented as atomic values or facts; Prolog variables themselves are single-assignment.
    * - Addition
      - .. code-block:: prolog
 
            Res is A + B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Subtraction
      - .. code-block:: prolog
 
            Res is A - B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Multiplication
      - .. code-block:: prolog
 
            Res is A * B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Division
      - .. code-block:: prolog
 
            Res is A / B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Remainder
      - .. code-block:: prolog
 
            Res is A mod B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Floor
      - .. code-block:: prolog
 
            Res is floor(A)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Rounding
      - .. code-block:: prolog
 
            Res is round(A)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Increment
      - .. code-block:: prolog
 
            Res is A + 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - Decrement
      - .. code-block:: prolog
 
            Res is A - 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - LeftShift
      - .. code-block:: prolog
 
            Res is A << B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
    * - RightShift
      - .. code-block:: prolog
 
            Res is A >> B
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the 'is' operator to evaluate arithmetic expressions.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: prolog
 
            Res is A /\ B
+     - Bitwise operators within arithmetic expressions.
+   * - BitOr
      - .. code-block:: prolog
 
            Res is A \/ B
+     - Bitwise operators within arithmetic expressions.
+   * - BitXor
      - .. code-block:: prolog
 
            Res is A xor B
+     - Bitwise operators within arithmetic expressions.
+   * - BitNot
      - .. code-block:: prolog
 
            Res is \ A
-     - .. code-block:: prolog
-
-           Res is A << B
-     - .. code-block:: prolog
-
-           Res is A >> B
      - Bitwise operators within arithmetic expressions.
+   * - Float4VectorMultiplication
+     - .. code-block:: prolog
+
+           maplist(multiply, A, B, C).
+     - Uses maplist to apply a predicate element-wise.
+   * - Float4VectorDotProduct
+     - .. code-block:: prolog
+
+           dot_product(A, B, Dot) :- maplist(multiply, A, B, Products), sum_list(Products, Dot).
+     - Commonly implemented using maplist and sum_list.
+   * - Float4VectorCrossProduct
+     - .. code-block:: prolog
+
+           cross_product([A1,A2,A3|_], [B1,B2,B3|_], [C1,C2,C3,0.0]) :-
+               C1 is A2*B3 - A3*B2,
+               C2 is A3*B1 - A1*B3,
+               C3 is A1*B2 - A2*B1.
+     - Implemented using list pattern matching and arithmetic evaluation.

--- a/docs/python_pivot.rst
+++ b/docs/python_pivot.rst
@@ -7,69 +7,33 @@ Python Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: python
 
            x = 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Dynamically typed, no explicit type declaration needed.
    * - IfElse
      - .. code-block:: python
 
            1 if x > 0 else 0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses ternary expression; multi-line if-else uses colons and indentation.
    * - Loop
      - .. code-block:: python
 
            while x > 0: x = x - 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses colon and indentation for the body; parentheses around condition are not required.
    * - FunctionDefinition
      - .. code-block:: python
 
            def add(a, b):
                return a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'def' keyword; indentation defines the block.
    * - ProcedureDefinition
      - .. code-block:: python
 
            def log_message(msg):
                print(msg)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures in Python are functions that don't return a value (implicitly return None).
    * - TryCatch
      - .. code-block:: python
@@ -78,68 +42,32 @@ Python Pivot View
                do_something()
            except Exception as e:
                handle(e)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python exception handling using try-except.
    * - Raise
      - .. code-block:: python
 
            raise Exception("Error")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'raise' to trigger an exception.
    * - SingleLineComment
      - .. code-block:: python
 
            # comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python single-line comment.
    * - MultiLineComment
      - .. code-block:: python
 
            """ line 1
                line 2 """
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Multi-line comments are typically implemented using docstrings.
    * - Print
      - .. code-block:: python
 
            print("Hello, World!")
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The print() function adds a newline by default.
    * - Import
      - .. code-block:: python
 
            import math
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python import; can also use 'from ... import ...'.
    * - SwitchCase
      - .. code-block:: python
@@ -151,163 +79,99 @@ Python Pivot View
                    return 2
                case _:
                    return 0
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Introduced in Python 3.10 as structural pattern matching.
    * - Constant
      - .. code-block:: python
 
            MAX = 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Python does not have true constants; uppercase naming is a convention to indicate immutability.
    * - Addition
      - .. code-block:: python
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Subtraction
      - .. code-block:: python
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Multiplication
      - .. code-block:: python
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Division
      - .. code-block:: python
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Remainder
      - .. code-block:: python
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Floor
      - .. code-block:: python
 
            math.floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Rounding
      - .. code-block:: python
 
            round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Increment
      - .. code-block:: python
 
            a += 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - Decrement
      - .. code-block:: python
 
            a -= 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - LeftShift
      - .. code-block:: python
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
    * - RightShift
      - .. code-block:: python
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Python arithmetic operator.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: python
 
            a & b
+     - Standard bitwise operators.
+   * - BitOr
      - .. code-block:: python
 
            a | b
+     - Standard bitwise operators.
+   * - BitXor
      - .. code-block:: python
 
            a ^ b
+     - Standard bitwise operators.
+   * - BitNot
      - .. code-block:: python
 
            ~a
-     - .. code-block:: python
-
-           a << b
-     - .. code-block:: python
-
-           a >> b
      - Standard bitwise operators.
+   * - Float4VectorMultiplication
+     - .. code-block:: python
+
+           c = [ai * bi for ai, bi in zip(a, b)]
+     - Uses list comprehension with zip; NumPy is preferred for performance.
+   * - Float4VectorDotProduct
+     - .. code-block:: python
+
+           dot = sum(ai * bi for ai, bi in zip(a, b))
+     - Uses a generator expression with zip and sum; NumPy's np.dot is standard for performance.
+   * - Float4VectorCrossProduct
+     - .. code-block:: python
+
+           c = [a[1]*b[2] - a[2]*b[1], a[2]*b[0] - a[0]*b[2], a[0]*b[1] - a[1]*b[0], 0.0]
+     - Uses list indexing; NumPy's np.cross is typically used for 3D vectors.

--- a/docs/riscv_pivot.rst
+++ b/docs/riscv_pivot.rst
@@ -7,23 +7,11 @@ RISC-V Assembler Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: asm
 
            x:  .word 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Defined in the .data section.
    * - IfElse
      - .. code-block:: asm
@@ -34,12 +22,6 @@ RISC-V Assembler Pivot View
            .else:
                li a0, 0
            .end:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses branch instructions like blez (branch if less than or equal to zero).
    * - Loop
      - .. code-block:: asm
@@ -49,12 +31,6 @@ RISC-V Assembler Pivot View
                addi t0, t0, -1
                j .loop
            .end:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses conditional branches and jumps to implement loops.
    * - FunctionDefinition
      - .. code-block:: asm
@@ -62,12 +38,6 @@ RISC-V Assembler Pivot View
            add:
                add a0, a0, a1
                ret
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions follow the RISC-V calling convention; a0-a7 are argument registers.
    * - ProcedureDefinition
      - .. code-block:: asm
@@ -79,87 +49,39 @@ RISC-V Assembler Pivot View
                ld ra, 8(sp)
                addi sp, sp, 16
                ret
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Follows standard calling convention; must save/restore return address (ra) if calling other functions.
    * - TryCatch
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - No native try-catch; relies on return codes or trap handlers for errors.
    * - Raise
      - .. code-block:: asm
 
                ebreak
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The ebreak instruction triggers a debug trap; ecall can be used for system calls.
    * - Thread
      - .. code-block:: asm
 
                li a7, 220 # clone syscall
                ecall
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Thread creation typically involves invoking OS system calls (e.g., clone in Linux).
    * - SendMessage
      - .. code-block:: asm
 
                li a7, 139 # rt_sigqueueinfo
                ecall
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Inter-process/thread communication is managed by the OS.
    * - ReceiveMessage
      - .. code-block:: asm
 
                li a7, 128 # rt_sigtimedwait
                ecall
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Receiving signals or messages involves OS system calls.
    * - SingleLineComment
      - .. code-block:: asm
 
            # comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - RISC-V assembly typically uses the hash character for single-line comments.
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - RISC-V assembly does not have a native multi-line comment syntax.
    * - Print
@@ -167,23 +89,11 @@ RISC-V Assembler Pivot View
 
                la a0, hello_msg
                call printf
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Typically uses the C library printf or writes to stdout via system calls.
    * - Import
      - .. code-block:: asm
 
            .include "macros.s"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the .include directive to include external source files.
    * - SwitchCase
      - .. code-block:: asm
@@ -193,159 +103,96 @@ RISC-V Assembler Pivot View
                li t1, 2
                beq t0, t1, .case2
                j .default
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Typically implemented using comparison and branch instructions.
    * - Constant
      - .. code-block:: asm
 
            .equiv MAX, 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the .equiv or .set directive to define constants.
    * - Addition
      - .. code-block:: asm
 
            add t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - Subtraction
      - .. code-block:: asm
 
            sub t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - Multiplication
      - .. code-block:: asm
 
            mul t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard RISC-V M-extension instructions.
    * - Division
      - .. code-block:: asm
 
            div t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard RISC-V M-extension instructions.
    * - Remainder
      - .. code-block:: asm
 
            rem t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard RISC-V M-extension instructions.
    * - Floor
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - Rounding
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - Increment
      - .. code-block:: asm
 
            addi t0, t0, 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - Decrement
      - .. code-block:: asm
 
            addi t0, t0, -1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - LeftShift
      - .. code-block:: asm
 
            sll t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
+     - Standard RISC-V instructions.
    * - RightShift
      - .. code-block:: asm
 
            srl t0, t1, t2
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - Standard RISC-V M-extension instructions.
-   * - Bitwise
-     - N/A
+     - Standard RISC-V instructions.
+   * - BitAnd
      - .. code-block:: asm
 
            and t0, t1, t2
+     - Core bitwise logical and shift instructions.
+   * - BitOr
      - .. code-block:: asm
 
            or t0, t1, t2
+     - Core bitwise logical and shift instructions.
+   * - BitXor
      - .. code-block:: asm
 
            xor t0, t1, t2
+     - Core bitwise logical and shift instructions.
+   * - BitNot
      - .. code-block:: asm
 
            not t0, t1
-     - .. code-block:: asm
-
-           sll t0, t1, t2
-     - .. code-block:: asm
-
-           srl t0, t1, t2
      - Core bitwise logical and shift instructions.
+   * - Float4VectorMultiplication
+     - .. code-block:: asm
+
+           vsetvli t0, x0, e32, m1
+           vfmul.vv v1, v2, v3
+     - Uses the RISC-V Vector extension (RVV) for element-wise float multiplication.
+   * - Float4VectorDotProduct
+     - .. code-block:: asm
+
+           vsetvli t0, x0, e32, m1
+           vfmul.vv v1, v2, v3
+           vfredusum.vs v4, v1, v5
+     - Uses vfmul.vv for multiplication and vfredusum.vs for a horizontal sum.
+   * - Float4VectorCrossProduct
+     - N/A
+     - RISC-V Vector extension does not have a dedicated cross product instruction; requires multiple operations.

--- a/docs/rust_pivot.rst
+++ b/docs/rust_pivot.rst
@@ -7,23 +7,11 @@ Rust Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: rust
 
            let x: i32 = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Immutable by default; supports type inference.
    * - IfElse
      - .. code-block:: rust
@@ -33,12 +21,6 @@ Rust Pivot View
            } else {
                0
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Rust if-else is an expression; parentheses around condition are not required.
    * - Loop
      - .. code-block:: rust
@@ -46,12 +28,6 @@ Rust Pivot View
            while x > 0 {
                x -= 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Condition does not require parentheses.
    * - FunctionDefinition
      - .. code-block:: rust
@@ -59,12 +35,6 @@ Rust Pivot View
            fn add(a: i32, b: i32) -> i32 {
                a + b
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'fn' keyword; return type preceded by '->'; last expression is returned implicitly.
    * - ProcedureDefinition
      - .. code-block:: rust
@@ -72,12 +42,6 @@ Rust Pivot View
            fn log_message(msg: &str) {
                println!("{}", msg);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions without a return type implicitly return the unit type ().
    * - TryCatch
      - .. code-block:: rust
@@ -86,101 +50,47 @@ Rust Pivot View
                Ok(v) => v,
                Err(e) => handle(e)
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Rust uses Result type and pattern matching instead of traditional try-catch.
    * - Raise
      - .. code-block:: rust
 
            panic!("Error");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'panic!' for unrecoverable errors.
    * - Thread
      - .. code-block:: rust
 
            thread::spawn(|| { do_work(); });
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Spawns a native OS thread. Closures are used for the thread body.
    * - SendMessage
      - .. code-block:: rust
 
            tx.send(42).unwrap();
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Using a channel sender. Result must be handled.
    * - ReceiveMessage
      - .. code-block:: rust
 
            let msg = rx.recv().unwrap(); handle(msg);
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Using a channel receiver; blocks until a message is available.
    * - SingleLineComment
      - .. code-block:: rust
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard Rust single-line comment.
    * - MultiLineComment
      - .. code-block:: rust
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Supports nested multi-line comments.
    * - Print
      - .. code-block:: rust
 
            println!("Hello, World!");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses a macro for formatted output to standard output with a newline.
    * - Import
      - .. code-block:: rust
 
            use std::collections::HashMap;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Brings a path into scope using the 'use' keyword.
    * - SwitchCase
      - .. code-block:: rust
@@ -190,163 +100,102 @@ Rust Pivot View
                2 => 2,
                _ => 0,
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Rust uses 'match' for pattern matching, which is exhaustive.
    * - Constant
      - .. code-block:: rust
 
            const MAX: i32 = 100;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Constants are always immutable and must have their types explicitly declared.
    * - Addition
      - .. code-block:: rust
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Subtraction
      - .. code-block:: rust
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Multiplication
      - .. code-block:: rust
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Division
      - .. code-block:: rust
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Remainder
      - .. code-block:: rust
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Floor
      - .. code-block:: rust
 
            a.floor()
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Rounding
      - .. code-block:: rust
 
            a.round()
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Increment
      - .. code-block:: rust
 
            a += 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - Decrement
      - .. code-block:: rust
 
            a -= 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - LeftShift
      - .. code-block:: rust
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
    * - RightShift
      - .. code-block:: rust
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operators for primitive types; floor and round are methods on float types.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: rust
 
            a & b
+     - Bitwise NOT uses the ! operator.
+   * - BitOr
      - .. code-block:: rust
 
            a | b
+     - Bitwise NOT uses the ! operator.
+   * - BitXor
      - .. code-block:: rust
 
            a ^ b
+     - Bitwise NOT uses the ! operator.
+   * - BitNot
      - .. code-block:: rust
 
            !a
-     - .. code-block:: rust
-
-           a << b
-     - .. code-block:: rust
-
-           a >> b
      - Bitwise NOT uses the ! operator.
+   * - Float4VectorMultiplication
+     - .. code-block:: rust
+
+           for i in 0..4 { c[i] = a[i] * b[i]; }
+     - Usually implemented with loops or iterator zipping; crates like nalgebra or glam provide dedicated types.
+   * - Float4VectorDotProduct
+     - .. code-block:: rust
+
+           let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
+     - Functional approach using iterators, zip, map, and sum.
+   * - Float4VectorCrossProduct
+     - .. code-block:: rust
+
+           c[0] = a[1]*b[2] - a[2]*b[1];
+           c[1] = a[2]*b[0] - a[0]*b[2];
+           c[2] = a[0]*b[1] - a[1]*b[0];
+           c[3] = 0.0;
+     - Direct implementation; libraries like glam provide a cross() method.

--- a/docs/sql_pivot.rst
+++ b/docs/sql_pivot.rst
@@ -7,19 +7,11 @@ SQL Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
      - Notes
    * - VariableDeclaration
      - .. code-block:: sql
 
            DECLARE @x INT = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL syntax for variable declaration.
    * - IfElse
      - .. code-block:: sql
@@ -32,10 +24,6 @@ SQL Pivot View
            BEGIN
                RETURN 0
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses IF-ELSE with BEGIN-END blocks.
    * - Loop
      - .. code-block:: sql
@@ -44,10 +32,6 @@ SQL Pivot View
            BEGIN
                SET @x = @x - 1
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard WHILE loop in T-SQL.
    * - FunctionDefinition
      - .. code-block:: sql
@@ -57,10 +41,6 @@ SQL Pivot View
            BEGIN
                RETURN @a + @b
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL syntax for Scalar-Valued Functions.
    * - ProcedureDefinition
      - .. code-block:: sql
@@ -70,10 +50,6 @@ SQL Pivot View
            BEGIN
                PRINT @msg;
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL uses CREATE PROCEDURE for blocks that perform actions.
    * - TryCatch
      - .. code-block:: sql
@@ -84,53 +60,29 @@ SQL Pivot View
            BEGIN CATCH
                EXEC handle_error;
            END CATCH
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL supports BEGIN TRY...END TRY and BEGIN CATCH...END CATCH blocks.
    * - Raise
      - .. code-block:: sql
 
            THROW 50000, 'Error', 1;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The THROW statement raises an exception and transfers execution to a CATCH block.
    * - SingleLineComment
      - .. code-block:: sql
 
            -- comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL single-line comment.
    * - MultiLineComment
      - .. code-block:: sql
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL multi-line comment.
    * - Print
      - .. code-block:: sql
 
            PRINT 'Hello, World!';
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL PRINT statement outputs a message to the client.
    * - Import
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Standard SQL does not have a native 'import' keyword for code; database objects are globally accessible or schema-qualified.
    * - SwitchCase
@@ -141,127 +93,95 @@ SQL Pivot View
                WHEN 2 THEN 'two'
                ELSE 'none'
            END
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The CASE expression is used for conditional logic in SQL.
    * - Constant
      - .. code-block:: sql
 
            DECLARE @MAX INT = 100;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - T-SQL variables are not strictly constant, but can be treated as such within a batch or procedure.
    * - Addition
      - .. code-block:: sql
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Subtraction
      - .. code-block:: sql
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Multiplication
      - .. code-block:: sql
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Division
      - .. code-block:: sql
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Remainder
      - .. code-block:: sql
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Floor
      - .. code-block:: sql
 
            FLOOR(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Rounding
      - .. code-block:: sql
 
            ROUND(a, 0)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Increment
      - .. code-block:: sql
 
            a + 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - Decrement
      - .. code-block:: sql
 
            a - 1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
    * - LeftShift
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Standard SQL arithmetic functions.
    * - RightShift
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard SQL arithmetic functions.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: sql
 
            a & b
+     - Bitwise support varies by SQL dialect; T-SQL supports &, |, ^, ~.
+   * - BitOr
      - .. code-block:: sql
 
            a | b
+     - Bitwise support varies by SQL dialect; T-SQL supports &, |, ^, ~.
+   * - BitXor
      - .. code-block:: sql
 
            a ^ b
+     - Bitwise support varies by SQL dialect; T-SQL supports &, |, ^, ~.
+   * - BitNot
      - .. code-block:: sql
 
            ~a
      - Bitwise support varies by SQL dialect; T-SQL supports &, |, ^, ~.
+   * - Float4VectorMultiplication
+     - .. code-block:: sql
+
+           SELECT a1*b1, a2*b2, a3*b3, a4*b4
+     - SQL typically operates on columns; vector operations are dialect-specific.
+   * - Float4VectorDotProduct
+     - .. code-block:: sql
+
+           SELECT a1*b1 + a2*b2 + a3*b3 + a4*b4
+     - Calculated by manually summing component-wise products.
+   * - Float4VectorCrossProduct
+     - .. code-block:: sql
+
+           SELECT a2*b3 - a3*b2, a3*b1 - a1*b3, a1*b2 - a2*b1, 0.0
+     - Computed using column-wise arithmetic.

--- a/docs/tcl_pivot.rst
+++ b/docs/tcl_pivot.rst
@@ -7,23 +7,11 @@ Tcl Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: tcl
 
            set x 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Variables are untyped strings; set is used for assignment.
    * - IfElse
      - .. code-block:: tcl
@@ -33,12 +21,6 @@ Tcl Pivot View
            } else {
                return 0
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses braces for the condition and branches.
    * - Loop
      - .. code-block:: tcl
@@ -46,12 +28,6 @@ Tcl Pivot View
            while {$x > 0} {
                set x [expr {$x - 1}]
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard while loop; expr is used for mathematical evaluation.
    * - FunctionDefinition
      - .. code-block:: tcl
@@ -59,12 +35,6 @@ Tcl Pivot View
            proc add {a b} {
                return [expr {$a + $b}]
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures can return values using the return command.
    * - ProcedureDefinition
      - .. code-block:: tcl
@@ -72,12 +42,6 @@ Tcl Pivot View
            proc logMessage {msg} {
                puts $msg
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'proc' to define a command.
    * - TryCatch
      - .. code-block:: tcl
@@ -87,98 +51,44 @@ Tcl Pivot View
            } on error {e} {
                handle $e
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The try command handles errors and exceptions (Tcl 8.6+).
    * - Raise
      - .. code-block:: tcl
 
            error "Error"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Signals an error condition.
    * - Thread
      - .. code-block:: tcl
 
            thread::create { do_work }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Requires the Thread package.
    * - SendMessage
      - .. code-block:: tcl
 
            thread::send $id $msg
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Sends a message to a thread.
    * - ReceiveMessage
      - .. code-block:: tcl
 
            vwait msg; handle $msg
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - vwait blocks until a variable is written.
    * - SingleLineComment
      - .. code-block:: tcl
 
            # comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Hashes start comments; must be at the beginning of a command.
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Tcl has no native multi-line comment syntax.
    * - Print
      - .. code-block:: tcl
 
            puts "Hello, World!"
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Outputs a string to stdout followed by a newline.
    * - Import
      - .. code-block:: tcl
 
            package require Tcl
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Loads a package into the interpreter.
    * - SwitchCase
      - .. code-block:: tcl
@@ -194,163 +104,102 @@ Tcl Pivot View
                    return 0
                }
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The switch command provides multi-way branching.
    * - Constant
      - .. code-block:: tcl
 
            set MAX 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Tcl does not have true constants; naming conventions are used.
    * - Addition
      - .. code-block:: tcl
 
            [expr {$a + $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Subtraction
      - .. code-block:: tcl
 
            [expr {$a - $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Multiplication
      - .. code-block:: tcl
 
            [expr {$a * $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Division
      - .. code-block:: tcl
 
            [expr {$a / $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Remainder
      - .. code-block:: tcl
 
            [expr {$a % $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Floor
      - .. code-block:: tcl
 
            [expr {floor($a)}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Rounding
      - .. code-block:: tcl
 
            [expr {round($a)}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - Increment
      - .. code-block:: tcl
 
            incr a
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The incr command increments an integer variable.
    * - Decrement
      - .. code-block:: tcl
 
            incr a -1
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - The incr command can decrement if a negative value is provided.
    * - LeftShift
      - .. code-block:: tcl
 
            [expr {$a << $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
    * - RightShift
      - .. code-block:: tcl
 
            [expr {$a >> $b}]
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Math operations require the expr command.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: tcl
 
            [expr {$a & $b}]
+     - Math operations require the expr command.
+   * - BitOr
      - .. code-block:: tcl
 
            [expr {$a | $b}]
+     - Math operations require the expr command.
+   * - BitXor
      - .. code-block:: tcl
 
            [expr {$a ^ $b}]
+     - Math operations require the expr command.
+   * - BitNot
      - .. code-block:: tcl
 
            [expr {~$a}]
-     - .. code-block:: tcl
-
-           [expr {$a << $b}]
-     - .. code-block:: tcl
-
-           [expr {$a >> $b}]
      - Math operations require the expr command.
+   * - Float4VectorMultiplication
+     - .. code-block:: tcl
+
+           foreach ai $a bi $b { lappend c [expr {$ai * $bi}] }
+     - Uses a multi-variable foreach loop to zip and multiply.
+   * - Float4VectorDotProduct
+     - .. code-block:: tcl
+
+           set dot 0
+           foreach ai $a bi $b { set dot [expr {$dot + ($ai * $bi)}] }
+     - Uses a multi-variable foreach loop to multiply and accumulate using expr.
+   * - Float4VectorCrossProduct
+     - .. code-block:: tcl
+
+           set c [list [expr {[lindex $a 1]*[lindex $b 2] - [lindex $a 2]*[lindex $b 1]}] \
+                       [expr {[lindex $a 2]*[lindex $b 0] - [lindex $a 0]*[lindex $b 2]}] \
+                       [expr {[lindex $a 0]*[lindex $b 1] - [lindex $a 1]*[lindex $b 0]}] 0.0]
+     - Uses expr and lindex for calculation.

--- a/docs/typescript_pivot.rst
+++ b/docs/typescript_pivot.rst
@@ -7,23 +7,11 @@ TypeScript Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: typescript
 
            let x: number = 42;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Supports static typing on top of JavaScript.
    * - IfElse
      - .. code-block:: typescript
@@ -33,12 +21,6 @@ TypeScript Pivot View
            } else {
                return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-style if-else statement.
    * - Loop
      - .. code-block:: typescript
@@ -46,12 +28,6 @@ TypeScript Pivot View
            while (x > 0) {
                x = x - 1;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard while loop.
    * - FunctionDefinition
      - .. code-block:: typescript
@@ -59,12 +35,6 @@ TypeScript Pivot View
            function add(a: number, b: number): number {
                return a + b;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions support typed parameters and return values.
    * - ProcedureDefinition
      - .. code-block:: typescript
@@ -72,12 +42,6 @@ TypeScript Pivot View
            function logMessage(msg: string): void {
                console.log(msg);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Procedures use the 'void' return type.
    * - TryCatch
      - .. code-block:: typescript
@@ -87,101 +51,47 @@ TypeScript Pivot View
            } catch (e) {
                handle(e);
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript exception handling.
    * - Raise
      - .. code-block:: typescript
 
            throw new Error("Error");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'throw' to raise an error.
    * - Thread
      - .. code-block:: typescript
 
            new Worker('worker.js');
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Concurrency is typically handled via Web Workers or asynchronous programming (Promises/async-await).
    * - SendMessage
      - .. code-block:: typescript
 
            worker.postMessage(42);
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Communicates with a Web Worker.
    * - ReceiveMessage
      - .. code-block:: typescript
 
            worker.onmessage = (e) => { handle(e.data); };
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Handles messages from a Web Worker.
    * - SingleLineComment
      - .. code-block:: typescript
 
            // comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard single-line comment.
    * - MultiLineComment
      - .. code-block:: typescript
 
            /* line 1
               line 2 */
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard block comment.
    * - Print
      - .. code-block:: typescript
 
            console.log("Hello, World!");
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Outputs to the console.
    * - Import
      - .. code-block:: typescript
 
            import { add } from './math';
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - ESM import syntax.
    * - SwitchCase
      - .. code-block:: typescript
@@ -194,163 +104,104 @@ TypeScript Pivot View
                default:
                    return 0;
            }
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard C-style switch statement.
    * - Constant
      - .. code-block:: typescript
 
            const MAX: number = 100;
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses 'const' for immutable declarations.
    * - Addition
      - .. code-block:: typescript
 
            a + b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Subtraction
      - .. code-block:: typescript
 
            a - b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Multiplication
      - .. code-block:: typescript
 
            a * b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Division
      - .. code-block:: typescript
 
            a / b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Remainder
      - .. code-block:: typescript
 
            a % b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Floor
      - .. code-block:: typescript
 
            Math.floor(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Rounding
      - .. code-block:: typescript
 
            Math.round(a)
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Increment
      - .. code-block:: typescript
 
            a++
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - Decrement
      - .. code-block:: typescript
 
            a--
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - LeftShift
      - .. code-block:: typescript
 
            a << b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
    * - RightShift
      - .. code-block:: typescript
 
            a >> b
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Standard JavaScript operators.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: typescript
 
            a & b
+     - Standard bitwise operators.
+   * - BitOr
      - .. code-block:: typescript
 
            a | b
+     - Standard bitwise operators.
+   * - BitXor
      - .. code-block:: typescript
 
            a ^ b
+     - Standard bitwise operators.
+   * - BitNot
      - .. code-block:: typescript
 
            ~a
-     - .. code-block:: typescript
-
-           a << b
-     - .. code-block:: typescript
-
-           a >> b
      - Standard bitwise operators.
+   * - Float4VectorMultiplication
+     - .. code-block:: typescript
+
+           const c = a.map((v, i) => v * b[i]);
+     - Uses the Array.map method with the index parameter.
+   * - Float4VectorDotProduct
+     - .. code-block:: typescript
+
+           const dot = a.reduce((acc, v, i) => acc + v * b[i], 0);
+     - Uses Array.reduce to accumulate the product of elements.
+   * - Float4VectorCrossProduct
+     - .. code-block:: typescript
+
+           const c = [
+               a[1]*b[2] - a[2]*b[1],
+               a[2]*b[0] - a[0]*b[2],
+               a[0]*b[1] - a[1]*b[0],
+               0
+           ];
+     - Uses array indexing to compute the components.

--- a/docs/x86_pivot.rst
+++ b/docs/x86_pivot.rst
@@ -7,23 +7,11 @@ x86 Assembler Pivot View
 
    * - Pattern
      - Syntax
-     - Bit and
-     - Bit or
-     - Bit xor
-     - Bit not
-     - Bit lshift
-     - Bit rshift
      - Notes
    * - VariableDeclaration
      - .. code-block:: nasm
 
            x   dd 42
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Defined in the .data section (Intel syntax).
    * - IfElse
      - .. code-block:: nasm
@@ -35,12 +23,6 @@ x86 Assembler Pivot View
            .else:
                mov eax, 0
            .end:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented using comparison and jump instructions (Intel syntax).
    * - Loop
      - .. code-block:: nasm
@@ -51,12 +33,6 @@ x86 Assembler Pivot View
                dec ecx
                jmp .loop
            .end:
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented using labels and conditional jumps.
    * - FunctionDefinition
      - .. code-block:: nasm
@@ -64,12 +40,6 @@ x86 Assembler Pivot View
            add_func:
                add eax, ebx
                ret
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Functions are labels; parameters usually passed via registers or stack.
    * - ProcedureDefinition
      - .. code-block:: nasm
@@ -79,44 +49,20 @@ x86 Assembler Pivot View
                call printf
                add esp, 4
                ret
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented as a label followed by code and a ret instruction.
    * - TryCatch
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - No high-level try-catch; requires OS-specific mechanisms like SEH.
    * - Raise
      - .. code-block:: nasm
 
                int 3
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Software interrupts (like int 3) can be used to signal errors or breakpoints.
    * - Thread
      - .. code-block:: nasm
 
                push offset do_work
                call CreateThread
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Spawning threads requires calling OS-specific APIs (e.g., Win32 CreateThread).
    * - SendMessage
      - .. code-block:: nasm
@@ -124,42 +70,18 @@ x86 Assembler Pivot View
                push msg
                push thread_id
                call PostThreadMessage
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Message passing is done via OS APIs.
    * - ReceiveMessage
      - .. code-block:: nasm
 
                call GetMessage
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Message retrieval via OS APIs.
    * - SingleLineComment
      - .. code-block:: nasm
 
            ; comment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Most assemblers use semicolon for single-line comments (Intel syntax).
    * - MultiLineComment
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Most assemblers do not have a native multi-line comment syntax.
    * - Print
@@ -167,23 +89,11 @@ x86 Assembler Pivot View
 
            push offset hello_msg
            call printf
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Printing in assembler usually involves calling C library functions or OS-specific system calls.
    * - Import
      - .. code-block:: nasm
 
            include 'macros.inc'
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Includes another assembly file; syntax varies by assembler (e.g., FASM uses 'include').
    * - SwitchCase
      - .. code-block:: nasm
@@ -199,157 +109,101 @@ x86 Assembler Pivot View
                ; ...
            .default:
                ; ...
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Implemented using a series of comparison and jump instructions.
    * - Constant
      - .. code-block:: nasm
 
            MAX equ 100
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Uses the EQU directive to define a symbolic constant (Intel syntax).
    * - Addition
      - .. code-block:: nasm
 
            add eax, ebx
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - Subtraction
      - .. code-block:: nasm
 
            sub eax, ebx
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - Multiplication
      - .. code-block:: nasm
 
            imul eax, ebx
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - Division
      - .. code-block:: nasm
 
            idiv ebx
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - Remainder
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Operates on registers or memory.
    * - Floor
      - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - Rounding
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - N/A
      - Operates on registers or memory.
    * - Increment
      - .. code-block:: nasm
 
            inc eax
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - Decrement
      - .. code-block:: nasm
 
            dec eax
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - LeftShift
      - .. code-block:: nasm
 
            shl eax, cl
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
    * - RightShift
      - .. code-block:: nasm
 
            shr eax, cl
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
-     - N/A
      - Operates on registers or memory.
-   * - Bitwise
-     - N/A
+   * - BitAnd
      - .. code-block:: nasm
 
            and eax, ebx
+     - Bitwise instructions for general-purpose registers.
+   * - BitOr
      - .. code-block:: nasm
 
            or eax, ebx
+     - Bitwise instructions for general-purpose registers.
+   * - BitXor
      - .. code-block:: nasm
 
            xor eax, ebx
+     - Bitwise instructions for general-purpose registers.
+   * - BitNot
      - .. code-block:: nasm
 
            not eax
-     - .. code-block:: nasm
-
-           shl eax, cl
-     - .. code-block:: nasm
-
-           shr eax, cl
      - Bitwise instructions for general-purpose registers.
+   * - Float4VectorMultiplication
+     - .. code-block:: nasm
+
+           mulps xmm0, xmm1
+     - SSE instruction for packed single-precision floating-point multiplication (4 floats).
+   * - Float4VectorDotProduct
+     - .. code-block:: nasm
+
+           dpps xmm0, xmm1, 0xF1
+     - SSE4.1 instruction for Dot Product of Packed Singles. 0xF1 mask controls input/output lanes.
+   * - Float4VectorCrossProduct
+     - .. code-block:: nasm
+
+           movaps xmm2, xmm0
+           shufps xmm0, xmm0, 0xC9 ; y z x w
+           shufps xmm2, xmm2, 0xD2 ; z x y w
+           movaps xmm3, xmm1
+           shufps xmm1, xmm1, 0xD2 ; z x y w
+           shufps xmm3, xmm3, 0xC9 ; y z x w
+           mulps xmm0, xmm1
+           mulps xmm2, xmm3
+           subps xmm0, xmm2
+     - A common SSE sequence for 3D cross product using shuffles and multiplications.

--- a/docs/xquery_pivot.rst
+++ b/docs/xquery_pivot.rst
@@ -141,6 +141,30 @@ XQuery Pivot View
    * - RightShift
      - N/A
      - Uses 'div' for division and 'idiv' for integer division.
-   * - Bitwise
+   * - BitAnd
      - N/A
      - Standard XQuery does not have native bitwise operators.
+   * - BitOr
+     - N/A
+     - Standard XQuery does not have native bitwise operators.
+   * - BitXor
+     - N/A
+     - Standard XQuery does not have native bitwise operators.
+   * - BitNot
+     - N/A
+     - Standard XQuery does not have native bitwise operators.
+   * - Float4VectorMultiplication
+     - .. code-block:: xquery
+
+           for $i in 1 to 4 return $a[$i] * $b[$i]
+     - Uses a for expression to iterate over indices.
+   * - Float4VectorDotProduct
+     - .. code-block:: xquery
+
+           sum(for $i in 1 to 4 return $a[$i] * $b[$i])
+     - Uses the built-in sum() function over a sequence of products.
+   * - Float4VectorCrossProduct
+     - .. code-block:: xquery
+
+           ($a[2]*$b[3] - $a[3]*$b[2], $a[3]*$b[1] - $a[1]*$b[3], $a[1]*$b[2] - $a[2]*$b[1], 0.0)
+     - Uses sequence indexing (1-indexed).

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -2036,27 +2036,27 @@ pattern BitNot {
 
 instance CAddition of Addition {
     syntax = "a + b"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CSubtraction of Subtraction {
     syntax = "a - b"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CMultiplication of Multiplication {
     syntax = "a * b"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CDivision of Division {
     syntax = "a / b"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CRemainder of Remainder {
     syntax = "a % b"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CFloor of Floor {
@@ -2071,12 +2071,12 @@ instance CRounding of Rounding {
 
 instance CIncrement of Increment {
     syntax = "a++"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CDecrement of Decrement {
     syntax = "a--"
-    notes = "Standard C operators; floor and round require math.h."
+    notes = "Standard C operators."
 }
 
 instance CLeftShift of LeftShift {
@@ -3161,12 +3161,12 @@ instance X86BitNot of BitNot {
 
 instance RiscvAddition of Addition {
     syntax = "add t0, t1, t2"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvSubtraction of Subtraction {
     syntax = "sub t0, t1, t2"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvMultiplication of Multiplication {
@@ -3186,32 +3186,32 @@ instance RiscvRemainder of Remainder {
 
 instance RiscvFloor of Floor {
     syntax = "N/A"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvRounding of Rounding {
     syntax = "N/A"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvIncrement of Increment {
     syntax = "addi t0, t0, 1"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvDecrement of Decrement {
     syntax = "addi t0, t0, -1"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvLeftShift of LeftShift {
     syntax = "sll t0, t1, t2"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvRightShift of RightShift {
     syntax = "srl t0, t1, t2"
-    notes = "Standard RISC-V M-extension instructions."
+    notes = "Standard RISC-V instructions."
 }
 
 instance RiscvBitAnd of BitAnd {
@@ -3685,57 +3685,57 @@ instance ArmAarch64Constant of Constant {
 
 instance ArmAarch64Addition of Addition {
     syntax = "add x0, x1, x2"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Subtraction of Subtraction {
     syntax = "sub x0, x1, x2"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Multiplication of Multiplication {
     syntax = "mul x0, x1, x2"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Division of Division {
     syntax = "sdiv x0, x1, x2"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Remainder of Remainder {
     syntax = "N/A"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Modulo is typically calculated via sdiv and msub."
 }
 
 instance ArmAarch64Floor of Floor {
     syntax = "N/A"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Rounding of Rounding {
     syntax = "N/A"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Increment of Increment {
     syntax = "add x0, x0, #1"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64Decrement of Decrement {
     syntax = "sub x0, x0, #1"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64LeftShift of LeftShift {
     syntax = "lsl x0, x1, x2"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64RightShift of RightShift {
     syntax = "lsr x0, x1, x2"
-    notes = "Standard A64 instructions; modulo is typically calculated via sdiv and msub."
+    notes = "Standard A64 instructions."
 }
 
 instance ArmAarch64BitAnd of BitAnd {


### PR DESCRIPTION
This PR updates all 24 programming language pivot pages in the documentation. The update includes a structural refactoring of the comparison tables to a more readable 3-column format and the addition of new patterns, including bitwise and floating-point vector operations. Key inaccuracies in the underlying pattern definitions (specifically regarding arithmetic instructions for C, ARM, and RISC-V) have also been corrected to ensure technical precision.

Fixes #253

---
*PR created automatically by Jules for task [17313430351262989923](https://jules.google.com/task/17313430351262989923) started by @chatelao*