### PR TITLE
Split monolithic data patterns and add Date pattern

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -75,8 +75,12 @@ This section compares data structures and serialization formats.
 - TOML
 
 **Patterns to be compared:**
-- Basic data types (Strings, Numbers, Booleans)
-- Nested structures (Objects/Maps, Arrays/Lists)
+- Strings
+- Numbers
+- Booleans
+- Dates
+- Collections (Arrays/Lists)
+- Mappings (Objects/Maps)
 - Metadata/Attributes
 - Single-line comments
 - Multi-line comments

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,13 +75,9 @@
     - [x] 8.6 Single-line and Multi-line comments <!-- 2026-05-12, issue #8.6 -->
     - [x] 8.7 Print (Hello World) <!-- 2026-05-24, issue #8.7 -->
 - [x] Populate Data Format patterns <!-- 2026-05-11, issue #9 -->
-    - [x] 9.1 Basic data types (Strings, Numbers, Booleans) <!-- 2026-05-08, issue #9.1 -->
-        - [x] 9.1.1 Define `BasicTypes` pattern <!-- 2026-05-08, issue #9.1.1 -->
-        - [x] 9.1.2 Implement instances (JSON, XML, YAML, TOML) <!-- 2026-05-08, issue #9.1.2 -->
-            - [x] 9.1.2.1 JSON <!-- 2026-05-08, issue #9.1.2.1 -->
-            - [x] 9.1.2.2 XML <!-- 2026-05-08, issue #9.1.2.2 -->
-            - [x] 9.1.2.3 YAML <!-- 2026-05-08, issue #9.1.2.3 -->
-            - [x] 9.1.2.4 TOML <!-- 2026-05-08, issue #9.1.2.4 -->
+    - [x] 9.1 Atomic data types (Strings, Numbers, Booleans, Dates) <!-- 2026-05-08, issue #9.1 -->
+        - [x] 9.1.1 Define individual patterns <!-- 2026-05-08, issue #9.1.1 -->
+        - [x] 9.1.2 Implement instances (JSON, XML, YAML, TOML, CSV, Fixlength) <!-- 2026-05-08, issue #9.1.2 -->
     - [x] 9.2 Nested structures (Objects/Maps, Arrays/Lists) <!-- 2026-05-04, issue #9.2 -->
         - [x] 9.2.1 Define `Collection` and `Mapping` patterns <!-- 2026-05-04, issue #9.2.1 -->
         - [x] 9.2.2 Implement instances across formats <!-- 2026-05-04, issue #9.2.2 -->

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -35,13 +35,13 @@ This page provides an overview of the implementation status for all patterns acr
 
 ## Data Formats
 
-| Format | Basic | Coll | Map | Meta | S-Comm | M-Comm | Schema |
-|--------|:-----:|:----:|:---:|:----:|:------:|:------:|:------:|
-| JSON | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| XML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| YAML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| TOML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| CSV | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Fixlength | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Format | Str | Num | Bool | Date | Coll | Map | Meta | S-Comm | M-Comm | Schema |
+|--------|:---:|:---:|:----:|:----:|:----:|:---:|:----:|:------:|:------:|:------:|
+| JSON | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| XML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| YAML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| TOML | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| CSV | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Fixlength | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 *Legend: ✅ = Implemented, ❌ = Not yet implemented.*

--- a/patterns/data_formats.patterns
+++ b/patterns/data_formats.patterns
@@ -1,50 +1,144 @@
-pattern BasicTypes {
-    meta description: "Representation of fundamental data types: Strings, Numbers, and Booleans."
-    parameter string_val: String
-    parameter number_val: String
-    parameter boolean_val: String
+pattern String {
+    meta description: "Representation of text data."
+    parameter syntax: String
     parameter notes: String
 }
 
-instance JsonBasic of BasicTypes {
-    string_val = "\"Hello\""
-    number_val = "42 or 3.14"
-    boolean_val = "true / false"
-    notes = "Standard JSON types; strings must be double-quoted."
+pattern Number {
+    meta description: "Representation of numeric data (integers or floating-point)."
+    parameter syntax: String
+    parameter notes: String
 }
 
-instance XmlBasic of BasicTypes {
-    string_val = "<tag>Hello</tag>"
-    number_val = "<tag>42</tag>"
-    boolean_val = "<tag>true</tag>"
-    notes = "XML is text-based; types are typically inferred or defined by a schema (XSD)."
+pattern Boolean {
+    meta description: "Representation of truth values (true or false)."
+    parameter syntax: String
+    parameter notes: String
 }
 
-instance YamlBasic of BasicTypes {
-    string_val = "Hello or 'Hello' or \"Hello\""
-    number_val = "42 or 3.14"
-    boolean_val = "true / false (or yes/no, on/off in YAML 1.1)"
-    notes = "YAML supports plain, single-quoted, and double-quoted strings."
+pattern Date {
+    meta description: "Representation of date and time information."
+    parameter syntax: String
+    parameter notes: String
 }
 
-instance TomlBasic of BasicTypes {
-    string_val = "\"Hello\""
-    number_val = "42 or 3.14"
-    boolean_val = "true / false"
-    notes = "TOML is strictly typed; strings must be double-quoted."
+instance JsonString of String {
+    syntax = "\"Hello\""
+    notes = "JSON strings must be enclosed in double quotes."
 }
 
-instance CsvBasic of BasicTypes {
-    string_val = "Hello or \"Hello\""
-    number_val = "42 or 3.14"
-    boolean_val = "true / false"
+instance JsonNumber of Number {
+    syntax = "42 or 3.14"
+    notes = "Supports integers and floating-point numbers."
+}
+
+instance JsonBoolean of Boolean {
+    syntax = "true / false"
+    notes = "Standard boolean literals."
+}
+
+instance JsonDate of Date {
+    syntax = "\"2026-05-24\""
+    notes = "JSON does not have a native date type; ISO 8601 strings are commonly used."
+}
+
+instance XmlString of String {
+    syntax = "<tag>Hello</tag>"
+    notes = "XML values are text-based."
+}
+
+instance XmlNumber of Number {
+    syntax = "<tag>42</tag>"
+    notes = "Numeric values are represented as text."
+}
+
+instance XmlBoolean of Boolean {
+    syntax = "<tag>true</tag>"
+    notes = "Boolean values are typically 'true' or 'false'."
+}
+
+instance XmlDate of Date {
+    syntax = "<tag>2026-05-24</tag>"
+    notes = "ISO 8601 is the standard format for dates in XML (XSD date type)."
+}
+
+instance YamlString of String {
+    syntax = "Hello or 'Hello' or \"Hello\""
+    notes = "Supports plain, single-quoted, and double-quoted strings."
+}
+
+instance YamlNumber of Number {
+    syntax = "42 or 3.14"
+    notes = "Standard numeric representations."
+}
+
+instance YamlBoolean of Boolean {
+    syntax = "true / false"
+    notes = "YAML 1.2 uses true/false; YAML 1.1 also supported yes/no, on/off."
+}
+
+instance YamlDate of Date {
+    syntax = "2026-05-24"
+    notes = "YAML has native support for ISO 8601 dates (timestamp type)."
+}
+
+instance TomlString of String {
+    syntax = "\"Hello\""
+    notes = "TOML strings must be double-quoted."
+}
+
+instance TomlNumber of Number {
+    syntax = "42 or 3.14"
+    notes = "Strictly typed numeric values."
+}
+
+instance TomlBoolean of Boolean {
+    syntax = "true / false"
+    notes = "Standard boolean literals."
+}
+
+instance TomlDate of Date {
+    syntax = "2026-05-24"
+    notes = "TOML has native support for RFC 3339 dates and times."
+}
+
+instance CsvString of String {
+    syntax = "Hello or \"Hello\""
     notes = "CSV values are typically plain text; quoting is used for values containing delimiters or newlines."
 }
 
-instance FixlengthBasic of BasicTypes {
-    string_val = "Fixed width string (e.g., 'Hello     ')"
-    number_val = "Fixed width number (e.g., '00042')"
-    boolean_val = "Fixed width indicator (e.g., 'Y' / 'N')"
+instance CsvNumber of Number {
+    syntax = "42 or 3.14"
+    notes = "Numeric values are typically plain text."
+}
+
+instance CsvBoolean of Boolean {
+    syntax = "true / false"
+    notes = "Represented as text literals."
+}
+
+instance CsvDate of Date {
+    syntax = "2026-05-24"
+    notes = "Usually represented as ISO 8601 strings."
+}
+
+instance FixlengthString of String {
+    syntax = "Fixed width string (e.g., 'Hello     ')"
+    notes = "Data is defined by fixed positions and lengths rather than delimiters."
+}
+
+instance FixlengthNumber of Number {
+    syntax = "Fixed width number (e.g., '00042')"
+    notes = "Data is defined by fixed positions and lengths rather than delimiters."
+}
+
+instance FixlengthBoolean of Boolean {
+    syntax = "Fixed width indicator (e.g., 'Y' / 'N')"
+    notes = "Data is defined by fixed positions and lengths rather than delimiters."
+}
+
+instance FixlengthDate of Date {
+    syntax = "Fixed width date (e.g., '20260524')"
     notes = "Data is defined by fixed positions and lengths rather than delimiters."
 }
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -190,9 +190,7 @@ class CodeGenerator:
         return template.render(pattern=pattern)
 
     def render_instance_table(self, pattern: Pattern, instances: List[Instance]) -> str:
-        syntax_params = {
-            "syntax", "string_val", "number_val", "boolean_val"
-        }
+        syntax_params = {"syntax"}
 
         display_parameters = [p for p in pattern.parameters if p.name in syntax_params]
         notes_param = next((p for p in pattern.parameters if p.name == "notes"), None)
@@ -233,10 +231,7 @@ class CodeGenerator:
 
     def render_pivot_table(self, program: Program, language: str) -> str:
         # Candidate parameters for columns in pivot table
-        candidates = [
-            "syntax", "string_val", "number_val", "boolean_val",
-            "notes"
-        ]
+        candidates = ["syntax", "notes"]
 
         normalized_lang = self._normalize(language)
         pivot_data = []
@@ -335,9 +330,8 @@ class CodeGenerator:
 
                     if instance:
                         syntax = "N/A"
-                        priority_params = [
-                            "syntax", "string_val", "number_val", "boolean_val"
-                        ]
+                        priority_params = ["syntax"]
+                        priority_params = ["syntax"]
                         for param in priority_params:
                             val = next((a.value for a in instance.assignments if a.name == param), None)
                             if val and val != "N/A":
@@ -370,9 +364,7 @@ class CodeGenerator:
 
                     if instance:
                         syntax = "N/A"
-                        priority_params = [
-                            "syntax", "string_val", "number_val", "boolean_val"
-                        ]
+                        priority_params = ["syntax"]
                         for param in priority_params:
                             val = next((a.value for a in instance.assignments if a.name == param), None)
                             if val and val != "N/A":


### PR DESCRIPTION
This change refactors the data format patterns by splitting the monolithic `BasicTypes` pattern into individual, atomic patterns: `String`, `Number`, `Boolean`, and a new `Date` pattern. This alignment follows the project's established design for programming patterns (e.g., arithmetic and bitwise operations).

Key modifications:
- `patterns/data_formats.patterns`: Replaced `BasicTypes` with `String`, `Number`, `Boolean`, and `Date`. Updated all 24 format instances.
- `src/generator.py`: Removed support for specialized parameters (`string_val`, `number_val`, `boolean_val`) in favor of the standard `syntax` parameter.
- `DESIGN.md` & `ROADMAP.md`: Updated pattern lists and implementation status.
- `docs/coverage.md`: Expanded the Data Formats coverage table to include individual columns for the new atomic types.

Verified with `pytest` and manual documentation inspection.

Fixes #255

---
*PR created automatically by Jules for task [14449709606091765055](https://jules.google.com/task/14449709606091765055) started by @chatelao*