### PR TITLE
Add COBOL and Fortran support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,6 +32,8 @@ This section compares languages based on common programming patterns.
 - Haskell
 - TypeScript
 - Tcl
+- COBOL
+- Fortran
 
 **Patterns to be compared:**
 - Variable declaration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,3 +174,5 @@
 - [x] Generate Pivot Chapter for Haskell
 - [x] Generate Pivot Chapter for TypeScript
 - [x] Generate Pivot Chapter for Tcl
+- [x] Generate Pivot Chapter for COBOL
+- [x] Generate Pivot Chapter for Fortran

--- a/docs/cobol_pivot.rst
+++ b/docs/cobol_pivot.rst
@@ -1,0 +1,195 @@
+COBOL Pivot View
+================
+
+.. list-table:: COBOL Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: cobol
+
+           01 X PIC 9(4) VALUE 42.
+     - Variables are defined in the DATA DIVISION; PIC (picture) clause specifies the data type and size.
+   * - IfElse
+     - .. code-block:: cobol
+
+           IF X > 0 THEN
+               MOVE 1 TO RESULT
+           ELSE
+               MOVE 0 TO RESULT
+           END-IF.
+     - Uses IF-THEN-ELSE-END-IF structure; periods are used to terminate sentences.
+   * - Loop
+     - .. code-block:: cobol
+
+           PERFORM UNTIL X <= 0
+               SUBTRACT 1 FROM X
+           END-PERFORM.
+     - The PERFORM UNTIL construct is used for conditional looping.
+   * - ForLoop
+     - .. code-block:: cobol
+
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > 10
+               *> body
+           END-PERFORM.
+     - PERFORM VARYING is the COBOL equivalent of a for loop.
+   * - FunctionDefinition
+     - .. code-block:: cobol
+
+           FUNCTION-ID. ADD-FUNC.
+           ...
+           COMPUTE RESULT = A + B
+           ...
+           END FUNCTION ADD-FUNC.
+     - User-defined functions were introduced in modern COBOL (COBOL 2002).
+   * - ProcedureDefinition
+     - .. code-block:: cobol
+
+           IDENTIFICATION DIVISION.
+           PROGRAM-ID. LOG-MSG.
+           ...
+           DISPLAY MSG.
+           EXIT PROGRAM.
+     - Procedures are typically implemented as separate programs or paragraphs.
+   * - TryCatch
+     - .. code-block:: cobol
+
+           ADD A TO B ON SIZE ERROR
+               DISPLAY 'Arithmetic Overflow'
+           END-ADD.
+     - COBOL uses imperative 'ON ERROR' clauses for specific operations.
+   * - Raise
+     - N/A
+     - No standard mechanism to 'throw' exceptions; execution is managed via status codes.
+   * - Thread
+     - N/A
+     - Standard COBOL does not support multi-threading.
+   * - SendMessage
+     - N/A
+     - Message passing is not a native COBOL feature.
+   * - ReceiveMessage
+     - N/A
+     - Not supported natively.
+   * - SingleLineComment
+     - .. code-block:: cobol
+
+           *> comment
+     - *> is used for inline comments in free-format COBOL.
+   * - MultiLineComment
+     - N/A
+     - No native multi-line comment syntax; multiple * or *> must be used.
+   * - Print
+     - .. code-block:: cobol
+
+           DISPLAY "Hello World".
+     - DISPLAY outputs data to the system console or standard output.
+   * - Import
+     - .. code-block:: cobol
+
+           COPY DEFS.
+     - The COPY statement includes text from a library at compile time.
+   * - SwitchCase
+     - .. code-block:: cobol
+
+           EVALUATE X
+               WHEN 1
+                   DISPLAY 'One'
+               WHEN 2
+                   DISPLAY 'Two'
+               WHEN OTHER
+                   DISPLAY 'Other'
+           END-EVALUATE.
+     - The EVALUATE statement is used for multi-way branching.
+   * - Constant
+     - .. code-block:: cobol
+
+           01 MAX-VAL PIC 9(3) VALUE 100 CONSTANT.
+     - The CONSTANT keyword defines a symbolic constant (COBOL 2002).
+   * - Addition
+     - .. code-block:: cobol
+
+           ADD A TO B.
+     - Adds the value of A to B and stores it in B.
+   * - Subtraction
+     - .. code-block:: cobol
+
+           SUBTRACT A FROM B.
+     - Subtracts A from B and stores it in B.
+   * - Multiplication
+     - .. code-block:: cobol
+
+           MULTIPLY A BY B.
+     - Multiplies A and B and stores the result in B.
+   * - Division
+     - .. code-block:: cobol
+
+           DIVIDE A BY B GIVING C.
+     - Divides A by B and stores the quotient in C.
+   * - Remainder
+     - .. code-block:: cobol
+
+           DIVIDE A BY B GIVING Q REMAINDER R.
+     - Calculates both the quotient and the remainder.
+   * - Floor
+     - .. code-block:: cobol
+
+           FUNCTION INTEGER(A)
+     - The INTEGER intrinsic function returns the greatest integer <= A.
+   * - Rounding
+     - .. code-block:: cobol
+
+           ADD A TO B ROUNDED.
+     - The ROUNDED phrase specifies that any fractional part should be rounded.
+   * - Increment
+     - .. code-block:: cobol
+
+           ADD 1 TO A.
+     - Increments the value of A by 1.
+   * - Decrement
+     - .. code-block:: cobol
+
+           SUBTRACT 1 FROM A.
+     - Decrements the value of A by 1.
+   * - LeftShift
+     - N/A
+     - COBOL does not have native bitwise shift operators.
+   * - RightShift
+     - N/A
+     - COBOL does not have native bitwise shift operators.
+   * - BitAnd
+     - N/A
+     - Not natively supported in standard COBOL.
+   * - BitOr
+     - N/A
+     - Not natively supported in standard COBOL.
+   * - BitXor
+     - N/A
+     - Not natively supported in standard COBOL.
+   * - BitNot
+     - N/A
+     - Not natively supported in standard COBOL.
+   * - Float4VectorMultiplication
+     - .. code-block:: cobol
+
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > 4
+               COMPUTE C(I) = A(I) * B(I)
+           END-PERFORM.
+     - Requires a loop over the array elements.
+   * - Float4VectorDotProduct
+     - .. code-block:: cobol
+
+           MOVE 0 TO DOT-PRODUCT.
+           PERFORM VARYING I FROM 1 BY 1 UNTIL I > 4
+               COMPUTE DOT-PRODUCT = DOT-PRODUCT + (A(I) * B(I))
+           END-PERFORM.
+     - Calculated by accumulating products in a loop.
+   * - Float4VectorCrossProduct
+     - .. code-block:: cobol
+
+           COMPUTE C(1) = A(2) * B(3) - A(3) * B(2).
+           COMPUTE C(2) = A(3) * B(1) - A(1) * B(3).
+           COMPUTE C(3) = A(1) * B(2) - A(2) * B(1).
+     - Calculated component-wise using COMPUTE.

--- a/docs/fortran_pivot.rst
+++ b/docs/fortran_pivot.rst
@@ -1,0 +1,203 @@
+Fortran Pivot View
+==================
+
+.. list-table:: Fortran Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: fortran
+
+           integer :: x = 42
+     - Static typing; :: is used to separate attributes from the variable name.
+   * - IfElse
+     - .. code-block:: fortran
+
+           if (x > 0) then
+               res = 1
+           else
+               res = 0
+           end if
+     - Standard block if-then-else-end if.
+   * - Loop
+     - .. code-block:: fortran
+
+           do while (x > 0)
+               x = x - 1
+           end do
+     - Standard do while loop.
+   * - ForLoop
+     - .. code-block:: fortran
+
+           do i = 1, 10
+               ! body
+           end do
+     - The do loop is used for iteration over ranges.
+   * - FunctionDefinition
+     - .. code-block:: fortran
+
+           function add(a, b) result(res)
+               integer, intent(in) :: a, b
+               integer :: res
+               res = a + b
+           end function add
+     - Functions return a value; 'intent(in)' specifies that parameters are read-only.
+   * - ProcedureDefinition
+     - .. code-block:: fortran
+
+           subroutine log_msg(msg)
+               character(len=*), intent(in) :: msg
+               print *, msg
+           end subroutine log_msg
+     - Subroutines are used for procedures that do not return a value.
+   * - TryCatch
+     - N/A
+     - Fortran does not have high-level try-catch blocks; uses iostat for I/O errors.
+   * - Raise
+     - .. code-block:: fortran
+
+           error stop "Error"
+     - The 'error stop' statement terminates execution with an error message (Fortran 2008+).
+   * - Thread
+     - N/A
+     - Fortran uses Coarrays or OpenMP/MPI for parallelism, but not a simple 'thread spawn' primitive.
+   * - SendMessage
+     - .. code-block:: fortran
+
+           target_var[image] = data
+     - Coarrays use distributed memory and assignment to 'images' for communication.
+   * - ReceiveMessage
+     - .. code-block:: fortran
+
+           sync images(*)
+     - Synchronization is used to ensure data consistency in Coarrays.
+   * - SingleLineComment
+     - .. code-block:: fortran
+
+           ! comment
+     - Exclamation mark starts a comment to the end of the line.
+   * - MultiLineComment
+     - N/A
+     - Fortran does not support multi-line comments natively.
+   * - Print
+     - .. code-block:: fortran
+
+           print *, "Hello World"
+     - The print statement with * (default format) outputs to stdout.
+   * - Import
+     - .. code-block:: fortran
+
+           use math_mod
+     - The 'use' statement imports a module's public variables and procedures.
+   * - SwitchCase
+     - .. code-block:: fortran
+
+           select case (x)
+           case (1)
+               res = 1
+           case (2)
+               res = 2
+           case default
+               res = 0
+           end select
+     - The select case construct is used for branching based on values.
+   * - Constant
+     - .. code-block:: fortran
+
+           integer, parameter :: MAX = 100
+     - The 'parameter' attribute makes the variable a named constant.
+   * - Addition
+     - .. code-block:: fortran
+
+           a + b
+     - Standard arithmetic operator.
+   * - Subtraction
+     - .. code-block:: fortran
+
+           a - b
+     - Standard arithmetic operator.
+   * - Multiplication
+     - .. code-block:: fortran
+
+           a * b
+     - Standard arithmetic operator.
+   * - Division
+     - .. code-block:: fortran
+
+           a / b
+     - Standard arithmetic operator.
+   * - Remainder
+     - .. code-block:: fortran
+
+           mod(a, b)
+     - Built-in function for remainder.
+   * - Floor
+     - .. code-block:: fortran
+
+           floor(a)
+     - Built-in function for the floor of a real number.
+   * - Rounding
+     - .. code-block:: fortran
+
+           nint(a)
+     - Built-in function for the nearest integer.
+   * - Increment
+     - .. code-block:: fortran
+
+           a = a + 1
+     - No native increment operator; uses assignment.
+   * - Decrement
+     - .. code-block:: fortran
+
+           a = a - 1
+     - No native decrement operator; uses assignment.
+   * - LeftShift
+     - .. code-block:: fortran
+
+           ishft(a, b)
+     - The ishft function performs a logical shift.
+   * - RightShift
+     - .. code-block:: fortran
+
+           ishft(a, -b)
+     - Negative shift counts in ishft perform a right shift.
+   * - BitAnd
+     - .. code-block:: fortran
+
+           iand(a, b)
+     - Built-in function for bitwise AND.
+   * - BitOr
+     - .. code-block:: fortran
+
+           ior(a, b)
+     - Built-in function for bitwise OR.
+   * - BitXor
+     - .. code-block:: fortran
+
+           ieor(a, b)
+     - Built-in function for bitwise XOR.
+   * - BitNot
+     - .. code-block:: fortran
+
+           not(a)
+     - Built-in function for bitwise NOT.
+   * - Float4VectorMultiplication
+     - .. code-block:: fortran
+
+           c = a * b
+     - Fortran supports element-wise operations on arrays natively.
+   * - Float4VectorDotProduct
+     - .. code-block:: fortran
+
+           res = dot_product(a, b)
+     - The dot_product intrinsic function calculates the dot product of two vectors.
+   * - Float4VectorCrossProduct
+     - .. code-block:: fortran
+
+           c = [a(2)*b(3) - a(3)*b(2), &
+                a(3)*b(1) - a(1)*b(3), &
+                a(1)*b(2) - a(2)*b(1), 0.0]
+     - Calculated component-wise using an array constructor.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,8 @@ Downloads
    haskell_pivot
    typescript_pivot
    tcl_pivot
+   cobol_pivot
+   fortran_pivot
 
 Indices and tables
 ==================

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -5009,3 +5009,417 @@ instance TclForLoop of ForLoop {
     syntax = "for {set i 0} {$i < 10} {incr i} {\n    # body\n}"
     notes = "Standard for loop; all arguments are Tcl scripts."
 }
+
+instance CobolVariableDeclaration of VariableDeclaration {
+    name = "X"
+    type = "PIC 9(4)"
+    initial_value = 42
+    syntax = "01 X PIC 9(4) VALUE 42."
+    notes = "Variables are defined in the DATA DIVISION; PIC (picture) clause specifies the data type and size."
+}
+
+instance FortranVariableDeclaration of VariableDeclaration {
+    name = "x"
+    type = "integer"
+    initial_value = 42
+    syntax = "integer :: x = 42"
+    notes = "Static typing; :: is used to separate attributes from the variable name."
+}
+
+instance CobolIfElse of IfElse {
+    condition = "X > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "IF X > 0 THEN\n    MOVE 1 TO RESULT\nELSE\n    MOVE 0 TO RESULT\nEND-IF."
+    notes = "Uses IF-THEN-ELSE-END-IF structure; periods are used to terminate sentences."
+}
+
+instance FortranIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) then\n    res = 1\nelse\n    res = 0\nend if"
+    notes = "Standard block if-then-else-end if."
+}
+
+instance CobolLoop of Loop {
+    condition = "X > 0"
+    body = { raw "SUBTRACT 1 FROM X" }
+    syntax = "PERFORM UNTIL X <= 0\n    SUBTRACT 1 FROM X\nEND-PERFORM."
+    notes = "The PERFORM UNTIL construct is used for conditional looping."
+}
+
+instance FortranLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x = x - 1" }
+    syntax = "do while (x > 0)\n    x = x - 1\nend do"
+    notes = "Standard do while loop."
+}
+
+instance CobolForLoop of ForLoop {
+    syntax = "PERFORM VARYING I FROM 1 BY 1 UNTIL I > 10\n    *> body\nEND-PERFORM."
+    notes = "PERFORM VARYING is the COBOL equivalent of a for loop."
+}
+
+instance FortranForLoop of ForLoop {
+    syntax = "do i = 1, 10\n    ! body\nend do"
+    notes = "The do loop is used for iteration over ranges."
+}
+
+instance CobolFunctionDefinition of FunctionDefinition {
+    name = "ADD-FUNC"
+    parameters = ["A", "B"]
+    return_type = "PIC 9(4)"
+    body = { raw "COMPUTE RESULT = A + B" }
+    syntax = "FUNCTION-ID. ADD-FUNC.\n... \nCOMPUTE RESULT = A + B\n... \nEND FUNCTION ADD-FUNC."
+    notes = "User-defined functions were introduced in modern COBOL (COBOL 2002)."
+}
+
+instance FortranFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["a", "b"]
+    return_type = "integer"
+    body = { raw "add = a + b" }
+    syntax = "function add(a, b) result(res)\n    integer, intent(in) :: a, b\n    integer :: res\n    res = a + b\nend function add"
+    notes = "Functions return a value; 'intent(in)' specifies that parameters are read-only."
+}
+
+instance CobolProcedure of ProcedureDefinition {
+    name = "LOG-MSG"
+    parameters = ["MSG"]
+    body = { raw "DISPLAY MSG" }
+    syntax = "IDENTIFICATION DIVISION.\nPROGRAM-ID. LOG-MSG.\n... \nDISPLAY MSG.\nEXIT PROGRAM."
+    notes = "Procedures are typically implemented as separate programs or paragraphs."
+}
+
+instance FortranProcedure of ProcedureDefinition {
+    name = "log_msg"
+    parameters = ["msg"]
+    body = { raw "print *, msg" }
+    syntax = "subroutine log_msg(msg)\n    character(len=*), intent(in) :: msg\n    print *, msg\nend subroutine log_msg"
+    notes = "Subroutines are used for procedures that do not return a value."
+}
+
+instance CobolTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "ON SIZE ERROR DISPLAY 'Error'" }
+    syntax = "ADD A TO B ON SIZE ERROR\n    DISPLAY 'Arithmetic Overflow'\nEND-ADD."
+    notes = "COBOL uses imperative 'ON ERROR' clauses for specific operations."
+}
+
+instance FortranTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "/* N/A */" }
+    syntax = "N/A"
+    notes = "Fortran does not have high-level try-catch blocks; uses iostat for I/O errors."
+}
+
+instance CobolRaise of Raise {
+    exception_type = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "No standard mechanism to 'throw' exceptions; execution is managed via status codes."
+}
+
+instance FortranRaise of Raise {
+    exception_type = "Error Stop"
+    message = "Error"
+    syntax = "error stop \"Error\""
+    notes = "The 'error stop' statement terminates execution with an error message (Fortran 2008+)."
+}
+
+instance CobolThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Standard COBOL does not support multi-threading."
+}
+
+instance FortranThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Fortran uses Coarrays or OpenMP/MPI for parallelism, but not a simple 'thread spawn' primitive."
+}
+
+instance CobolSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "Message passing is not a native COBOL feature."
+}
+
+instance FortranSendMessage of SendMessage {
+    recipient = "image"
+    message = "data"
+    syntax = "target_var[image] = data"
+    notes = "Coarrays use distributed memory and assignment to 'images' for communication."
+}
+
+instance CobolReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance FortranReceiveMessage of ReceiveMessage {
+    match_pattern = "data"
+    body = { raw "sync images(*)" }
+    syntax = "sync images(*)"
+    notes = "Synchronization is used to ensure data consistency in Coarrays."
+}
+
+instance CobolSingleLineComment of SingleLineComment {
+    syntax = "*> comment"
+    notes = "*> is used for inline comments in free-format COBOL."
+}
+
+instance FortranSingleLineComment of SingleLineComment {
+    syntax = "! comment"
+    notes = "Exclamation mark starts a comment to the end of the line."
+}
+
+instance CobolMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "No native multi-line comment syntax; multiple * or *> must be used."
+}
+
+instance FortranMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "Fortran does not support multi-line comments natively."
+}
+
+instance CobolPrint of Print {
+    value = "Hello World"
+    syntax = "DISPLAY \"Hello World\"."
+    notes = "DISPLAY outputs data to the system console or standard output."
+}
+
+instance FortranPrint of Print {
+    value = "Hello World"
+    syntax = "print *, \"Hello World\""
+    notes = "The print statement with * (default format) outputs to stdout."
+}
+
+instance CobolImport of Import {
+    module_name = "DEFS"
+    syntax = "COPY DEFS."
+    notes = "The COPY statement includes text from a library at compile time."
+}
+
+instance FortranImport of Import {
+    module_name = "math_mod"
+    syntax = "use math_mod"
+    notes = "The 'use' statement imports a module's public variables and procedures."
+}
+
+instance CobolSwitchCase of SwitchCase {
+    expression = "X"
+    syntax = "EVALUATE X\n    WHEN 1\n        DISPLAY 'One'\n    WHEN 2\n        DISPLAY 'Two'\n    WHEN OTHER\n        DISPLAY 'Other'\nEND-EVALUATE."
+    notes = "The EVALUATE statement is used for multi-way branching."
+}
+
+instance FortranSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "select case (x)\ncase (1)\n    res = 1\ncase (2)\n    res = 2\ncase default\n    res = 0\nend select"
+    notes = "The select case construct is used for branching based on values."
+}
+
+instance CobolConstant of Constant {
+    name = "MAX-VAL"
+    type = "PIC 9(3)"
+    value = "100"
+    syntax = "01 MAX-VAL PIC 9(3) VALUE 100 CONSTANT."
+    notes = "The CONSTANT keyword defines a symbolic constant (COBOL 2002)."
+}
+
+instance FortranConstant of Constant {
+    name = "MAX"
+    type = "integer"
+    value = "100"
+    syntax = "integer, parameter :: MAX = 100"
+    notes = "The 'parameter' attribute makes the variable a named constant."
+}
+
+instance CobolAddition of Addition {
+    syntax = "ADD A TO B."
+    notes = "Adds the value of A to B and stores it in B."
+}
+
+instance FortranAddition of Addition {
+    syntax = "a + b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CobolSubtraction of Subtraction {
+    syntax = "SUBTRACT A FROM B."
+    notes = "Subtracts A from B and stores it in B."
+}
+
+instance FortranSubtraction of Subtraction {
+    syntax = "a - b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CobolMultiplication of Multiplication {
+    syntax = "MULTIPLY A BY B."
+    notes = "Multiplies A and B and stores the result in B."
+}
+
+instance FortranMultiplication of Multiplication {
+    syntax = "a * b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CobolDivision of Division {
+    syntax = "DIVIDE A BY B GIVING C."
+    notes = "Divides A by B and stores the quotient in C."
+}
+
+instance FortranDivision of Division {
+    syntax = "a / b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CobolRemainder of Remainder {
+    syntax = "DIVIDE A BY B GIVING Q REMAINDER R."
+    notes = "Calculates both the quotient and the remainder."
+}
+
+instance FortranRemainder of Remainder {
+    syntax = "mod(a, b)"
+    notes = "Built-in function for remainder."
+}
+
+instance CobolFloor of Floor {
+    syntax = "FUNCTION INTEGER(A)"
+    notes = "The INTEGER intrinsic function returns the greatest integer <= A."
+}
+
+instance FortranFloor of Floor {
+    syntax = "floor(a)"
+    notes = "Built-in function for the floor of a real number."
+}
+
+instance CobolRounding of Rounding {
+    syntax = "ADD A TO B ROUNDED."
+    notes = "The ROUNDED phrase specifies that any fractional part should be rounded."
+}
+
+instance FortranRounding of Rounding {
+    syntax = "nint(a)"
+    notes = "Built-in function for the nearest integer."
+}
+
+instance CobolIncrement of Increment {
+    syntax = "ADD 1 TO A."
+    notes = "Increments the value of A by 1."
+}
+
+instance FortranIncrement of Increment {
+    syntax = "a = a + 1"
+    notes = "No native increment operator; uses assignment."
+}
+
+instance CobolDecrement of Decrement {
+    syntax = "SUBTRACT 1 FROM A."
+    notes = "Decrements the value of A by 1."
+}
+
+instance FortranDecrement of Decrement {
+    syntax = "a = a - 1"
+    notes = "No native decrement operator; uses assignment."
+}
+
+instance CobolLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = "COBOL does not have native bitwise shift operators."
+}
+
+instance FortranLeftShift of LeftShift {
+    syntax = "ishft(a, b)"
+    notes = "The ishft function performs a logical shift."
+}
+
+instance CobolRightShift of RightShift {
+    syntax = "N/A"
+    notes = "COBOL does not have native bitwise shift operators."
+}
+
+instance FortranRightShift of RightShift {
+    syntax = "ishft(a, -b)"
+    notes = "Negative shift counts in ishft perform a right shift."
+}
+
+instance CobolBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = "Not natively supported in standard COBOL."
+}
+
+instance FortranBitAnd of BitAnd {
+    syntax = "iand(a, b)"
+    notes = "Built-in function for bitwise AND."
+}
+
+instance CobolBitOr of BitOr {
+    syntax = "N/A"
+    notes = "Not natively supported in standard COBOL."
+}
+
+instance FortranBitOr of BitOr {
+    syntax = "ior(a, b)"
+    notes = "Built-in function for bitwise OR."
+}
+
+instance CobolBitXor of BitXor {
+    syntax = "N/A"
+    notes = "Not natively supported in standard COBOL."
+}
+
+instance FortranBitXor of BitXor {
+    syntax = "ieor(a, b)"
+    notes = "Built-in function for bitwise XOR."
+}
+
+instance CobolBitNot of BitNot {
+    syntax = "N/A"
+    notes = "Not natively supported in standard COBOL."
+}
+
+instance FortranBitNot of BitNot {
+    syntax = "not(a)"
+    notes = "Built-in function for bitwise NOT."
+}
+
+instance CobolFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "PERFORM VARYING I FROM 1 BY 1 UNTIL I > 4\n    COMPUTE C(I) = A(I) * B(I)\nEND-PERFORM."
+    notes = "Requires a loop over the array elements."
+}
+
+instance FortranFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "c = a * b"
+    notes = "Fortran supports element-wise operations on arrays natively."
+}
+
+instance CobolFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "MOVE 0 TO DOT-PRODUCT.\nPERFORM VARYING I FROM 1 BY 1 UNTIL I > 4\n    COMPUTE DOT-PRODUCT = DOT-PRODUCT + (A(I) * B(I))\nEND-PERFORM."
+    notes = "Calculated by accumulating products in a loop."
+}
+
+instance FortranFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "res = dot_product(a, b)"
+    notes = "The dot_product intrinsic function calculates the dot product of two vectors."
+}
+
+instance CobolFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "COMPUTE C(1) = A(2) * B(3) - A(3) * B(2).\nCOMPUTE C(2) = A(3) * B(1) - A(1) * B(3).\nCOMPUTE C(3) = A(1) * B(2) - A(2) * B(1)."
+    notes = "Calculated component-wise using COMPUTE."
+}
+
+instance FortranFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "c = [a(2)*b(3) - a(3)*b(2), &\n     a(3)*b(1) - a(1)*b(3), &\n     a(1)*b(2) - a(2)*b(1), 0.0]"
+    notes = "Calculated component-wise using an array constructor."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -61,7 +61,7 @@ class CodeGenerator:
         "SQL", "C", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
-        "Go", "Haskell", "TypeScript", "Tcl"
+        "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
@@ -97,6 +97,8 @@ class CodeGenerator:
         "Haskell": "haskell",
         "TypeScript": "typescript",
         "Tcl": "tcl",
+        "COBOL": "cobol",
+        "Fortran": "fortran",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",


### PR DESCRIPTION
This PR adds COBOL and Fortran to the Bible of Babylon comparative guide. It includes:
- 35 pattern implementations for COBOL (modern COBOL/free-format).
- 35 pattern implementations for Fortran (modern Fortran).
- Updated documentation and code generator configuration.
- Generated pivot chapters for both languages.

Fixes #258

---
*PR created automatically by Jules for task [410202054221061943](https://jules.google.com/task/410202054221061943) started by @chatelao*