### PR TITLE
Add C++ Support

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,17 +13,17 @@ build:
       - echo "" >> docs/matrices.rst
       - echo "Programming Languages" >> docs/matrices.rst
       - echo "---------------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --pivot-matrix >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --pivot-matrix >> docs/matrices.rst
       - echo "" >> docs/matrices.rst
       - echo "Data Formats" >> docs/matrices.rst
       - echo "------------" >> docs/matrices.rst
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
       # Generate Downloadable Matrices for Sphinx :download: role
       # CSV
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --csv > docs/programming_matrix.csv
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --csv > docs/programming_matrix.csv
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
       # Excel
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --excel -o docs/programming_matrix.xlsx
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --excel -o docs/programming_matrix.xlsx
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
 python:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,7 @@ This section compares languages based on common programming patterns.
 **Languages:**
 - SQL
 - C
+- C++
 - XQuery
 - Java
 - Rust

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -12,6 +12,7 @@ The transpiler must maintain a mapping between the internal instance names (e.g.
 |---------------|----------------|
 | SQL           | `sql`          |
 | C             | `c`            |
+| Cpp           | `cpp`          |
 | XQuery        | `xquery`       |
 | Java          | `java`         |
 | Rust          | `rust`         |

--- a/docs/cpp_pivot.rst
+++ b/docs/cpp_pivot.rst
@@ -1,0 +1,230 @@
+Cpp Pivot View
+==============
+
+.. list-table:: Cpp Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: cpp
+
+           int x = 42;
+     - Static typing, similar to C.
+   * - Equal
+     - .. code-block:: cpp
+
+           a == b
+     - Standard equality operator.
+   * - NotEqual
+     - .. code-block:: cpp
+
+           a != b
+     - Standard inequality operator.
+   * - GreaterThan
+     - .. code-block:: cpp
+
+           a > b
+     - Standard greater than operator.
+   * - ProcedureDefinition
+     - .. code-block:: cpp
+
+           void logMessage(std::string msg) {
+               std::cout << msg << std::endl;
+           }
+     - Procedures use the 'void' return type.
+   * - FunctionDefinition
+     - .. code-block:: cpp
+
+           int add(int a, int b) {
+               return a + b;
+           }
+     - Standard C-style function definition.
+   * - IfElse
+     - .. code-block:: cpp
+
+           if (x > 0) {
+               return 1;
+           } else {
+               return 0;
+           }
+     - Standard C-style if-else statement.
+   * - SwitchCase
+     - .. code-block:: cpp
+
+           switch (x) {
+               case 1:
+                   return 1;
+               case 2:
+                   return 2;
+               default:
+                   return 0;
+           }
+     - Standard C-style switch statement.
+   * - Loop
+     - .. code-block:: cpp
+
+           while (x > 0) {
+               x = x - 1;
+           }
+     - Standard C-style while loop.
+   * - ForLoop
+     - .. code-block:: cpp
+
+           for (int i = 0; i < 10; i++) {
+               // body
+           }
+     - Standard C-style for loop.
+   * - Addition
+     - .. code-block:: cpp
+
+           a + b
+     - Standard arithmetic operator.
+   * - Subtraction
+     - .. code-block:: cpp
+
+           a - b
+     - Standard arithmetic operator.
+   * - Multiplication
+     - .. code-block:: cpp
+
+           a * b
+     - Standard arithmetic operator.
+   * - Division
+     - .. code-block:: cpp
+
+           a / b
+     - Standard arithmetic operator.
+   * - Remainder
+     - .. code-block:: cpp
+
+           a % b
+     - Standard arithmetic operator.
+   * - Floor
+     - .. code-block:: cpp
+
+           std::floor(a)
+     - Requires <cmath>.
+   * - Rounding
+     - .. code-block:: cpp
+
+           std::round(a)
+     - Requires <cmath>.
+   * - Increment
+     - .. code-block:: cpp
+
+           a++
+     - Standard increment operator.
+   * - Decrement
+     - .. code-block:: cpp
+
+           a--
+     - Standard decrement operator.
+   * - LeftShift
+     - .. code-block:: cpp
+
+           a << b
+     - Standard bitwise shift operator.
+   * - RightShift
+     - .. code-block:: cpp
+
+           a >> b
+     - Standard bitwise shift operator.
+   * - BitAnd
+     - .. code-block:: cpp
+
+           a & b
+     - Standard bitwise operator.
+   * - BitOr
+     - .. code-block:: cpp
+
+           a | b
+     - Standard bitwise operator.
+   * - BitXor
+     - .. code-block:: cpp
+
+           a ^ b
+     - Standard bitwise operator.
+   * - BitNot
+     - .. code-block:: cpp
+
+           ~a
+     - Standard bitwise operator.
+   * - TryCatch
+     - .. code-block:: cpp
+
+           try {
+               do_something();
+           } catch (const std::exception& e) {
+               handle(e);
+           }
+     - Standard C++ exception handling using try-catch blocks.
+   * - Raise
+     - .. code-block:: cpp
+
+           throw std::runtime_error("Error");
+     - Uses 'throw' to raise an exception.
+   * - Thread
+     - .. code-block:: cpp
+
+           std::thread t(do_work);
+           t.join();
+     - Uses std::thread (C++11 and later).
+   * - SendMessage
+     - .. code-block:: cpp
+
+           queue.push(42);
+     - Communication is typically handled via shared data structures and synchronization primitives.
+   * - ReceiveMessage
+     - .. code-block:: cpp
+
+           int msg = queue.front();
+           queue.pop();
+           handle(msg);
+     - Typically involves pulling from a thread-safe queue.
+   * - SingleLineComment
+     - .. code-block:: cpp
+
+           // comment
+     - Standard C++ single-line comment.
+   * - MultiLineComment
+     - .. code-block:: cpp
+
+           /* line 1
+              line 2 */
+     - Standard C++ multi-line comment.
+   * - Print
+     - .. code-block:: cpp
+
+           std::cout << "Hello, World!" << std::endl;
+     - Uses std::cout for standard output; requires <iostream>.
+   * - Import
+     - .. code-block:: cpp
+
+           #include <iostream>
+     - Standard way to include headers.
+   * - Constant
+     - .. code-block:: cpp
+
+           const int MAX = 100;
+     - The 'const' keyword defines an immutable value.
+   * - Float4VectorMultiplication
+     - .. code-block:: cpp
+
+           for (int i = 0; i < 4; i++) c[i] = a[i] * b[i];
+     - Standard C++ requires a loop or explicit component-wise multiplication for arrays.
+   * - Float4VectorDotProduct
+     - .. code-block:: cpp
+
+           float dot = 0; for (int i = 0; i < 4; i++) dot += a[i] * b[i];
+     - Calculated by accumulating component-wise products in a loop.
+   * - Float4VectorCrossProduct
+     - .. code-block:: cpp
+
+           c[0] = a[1]*b[2] - a[2]*b[1];
+           c[1] = a[2]*b[0] - a[0]*b[2];
+           c[2] = a[0]*b[1] - a[1]*b[0];
+           c[3] = 0.0f;
+     - Manual implementation for the first three components.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Downloads
 
    sql_pivot
    c_pivot
+   cpp_pivot
    xquery_pivot
    java_pivot
    rust_pivot

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -6497,3 +6497,225 @@ instance KotlinFloat4VectorCrossProduct of Float4VectorCrossProduct {
     syntax = "val c = floatArrayOf(\n    a[1]*b[2] - a[2]*b[1],\n    a[2]*b[0] - a[0]*b[2],\n    a[0]*b[1] - a[1]*b[0],\n    0.0f\n)"
     notes = "Manual calculation for 3D cross product."
 }
+
+instance CppVar of VariableDeclaration {
+    name = "x"
+    type = "int"
+    initial_value = 42
+    syntax = "int x = 42;"
+    notes = "Static typing, similar to C."
+}
+
+instance CppEqual of Equal {
+    syntax = "a == b"
+    notes = "Standard equality operator."
+}
+
+instance CppNotEqual of NotEqual {
+    syntax = "a != b"
+    notes = "Standard inequality operator."
+}
+
+instance CppGreaterThan of GreaterThan {
+    syntax = "a > b"
+    notes = "Standard greater than operator."
+}
+
+instance CppProcedure of ProcedureDefinition {
+    name = "logMessage"
+    parameters = ["std::string msg"]
+    body = { raw "std::cout << msg << std::endl;" }
+    syntax = "void logMessage(std::string msg) {\n    std::cout << msg << std::endl;\n}"
+    notes = "Procedures use the 'void' return type."
+}
+
+instance CppFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["int a", "int b"]
+    return_type = "int"
+    body = { raw "return a + b;" }
+    syntax = "int add(int a, int b) {\n    return a + b;\n}"
+    notes = "Standard C-style function definition."
+}
+
+instance CppIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) {\n    return 1;\n} else {\n    return 0;\n}"
+    notes = "Standard C-style if-else statement."
+}
+
+instance CppSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "switch (x) {\n    case 1:\n        return 1;\n    case 2:\n        return 2;\n    default:\n        return 0;\n}"
+    notes = "Standard C-style switch statement."
+}
+
+instance CppLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x = x - 1;" }
+    syntax = "while (x > 0) {\n    x = x - 1;\n}"
+    notes = "Standard C-style while loop."
+}
+
+instance CppForLoop of ForLoop {
+    syntax = "for (int i = 0; i < 10; i++) {\n    // body\n}"
+    notes = "Standard C-style for loop."
+}
+
+instance CppAddition of Addition {
+    syntax = "a + b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CppSubtraction of Subtraction {
+    syntax = "a - b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CppMultiplication of Multiplication {
+    syntax = "a * b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CppDivision of Division {
+    syntax = "a / b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CppRemainder of Remainder {
+    syntax = "a % b"
+    notes = "Standard arithmetic operator."
+}
+
+instance CppFloor of Floor {
+    syntax = "std::floor(a)"
+    notes = "Requires <cmath>."
+}
+
+instance CppRounding of Rounding {
+    syntax = "std::round(a)"
+    notes = "Requires <cmath>."
+}
+
+instance CppIncrement of Increment {
+    syntax = "a++"
+    notes = "Standard increment operator."
+}
+
+instance CppDecrement of Decrement {
+    syntax = "a--"
+    notes = "Standard decrement operator."
+}
+
+instance CppLeftShift of LeftShift {
+    syntax = "a << b"
+    notes = "Standard bitwise shift operator."
+}
+
+instance CppRightShift of RightShift {
+    syntax = "a >> b"
+    notes = "Standard bitwise shift operator."
+}
+
+instance CppBitAnd of BitAnd {
+    syntax = "a & b"
+    notes = "Standard bitwise operator."
+}
+
+instance CppBitOr of BitOr {
+    syntax = "a | b"
+    notes = "Standard bitwise operator."
+}
+
+instance CppBitXor of BitXor {
+    syntax = "a ^ b"
+    notes = "Standard bitwise operator."
+}
+
+instance CppBitNot of BitNot {
+    syntax = "~a"
+    notes = "Standard bitwise operator."
+}
+
+instance CppTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "std::exception"
+    error_variable = "e"
+    catch_body = { call handle(e) }
+    syntax = "try {\n    do_something();\n} catch (const std::exception& e) {\n    handle(e);\n}"
+    notes = "Standard C++ exception handling using try-catch blocks."
+}
+
+instance CppRaise of Raise {
+    exception_type = "std::runtime_error"
+    message = "Error"
+    syntax = "throw std::runtime_error(\"Error\");"
+    notes = "Uses 'throw' to raise an exception."
+}
+
+instance CppThread of Thread {
+    body = { call do_work() }
+    syntax = "std::thread t(do_work);\nt.join();"
+    notes = "Uses std::thread (C++11 and later)."
+}
+
+instance CppSendMessage of SendMessage {
+    recipient = "queue"
+    message = "42"
+    syntax = "queue.push(42);"
+    notes = "Communication is typically handled via shared data structures and synchronization primitives."
+}
+
+instance CppReceiveMessage of ReceiveMessage {
+    match_pattern = "msg"
+    body = { call handle(msg) }
+    syntax = "int msg = queue.front();\nqueue.pop();\nhandle(msg);"
+    notes = "Typically involves pulling from a thread-safe queue."
+}
+
+instance CppSingleLineComment of SingleLineComment {
+    syntax = "// comment"
+    notes = "Standard C++ single-line comment."
+}
+
+instance CppMultiLineComment of MultiLineComment {
+    syntax = "/* line 1\n   line 2 */"
+    notes = "Standard C++ multi-line comment."
+}
+
+instance CppPrint of Print {
+    value = "Hello, World!"
+    syntax = "std::cout << \"Hello, World!\" << std::endl;"
+    notes = "Uses std::cout for standard output; requires <iostream>."
+}
+
+instance CppImport of Import {
+    module_name = "iostream"
+    syntax = "#include <iostream>"
+    notes = "Standard way to include headers."
+}
+
+instance CppConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "const int MAX = 100;"
+    notes = "The 'const' keyword defines an immutable value."
+}
+
+instance CppFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "for (int i = 0; i < 4; i++) c[i] = a[i] * b[i];"
+    notes = "Standard C++ requires a loop or explicit component-wise multiplication for arrays."
+}
+
+instance CppFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "float dot = 0; for (int i = 0; i < 4; i++) dot += a[i] * b[i];"
+    notes = "Calculated by accumulating component-wise products in a loop."
+}
+
+instance CppFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "c[0] = a[1]*b[2] - a[2]*b[1];\nc[1] = a[2]*b[0] - a[0]*b[2];\nc[2] = a[0]*b[1] - a[1]*b[0];\nc[3] = 0.0f;"
+    notes = "Manual implementation for the first three components."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -58,7 +58,7 @@ def format_value(value) -> str:
 class CodeGenerator:
     # Centralized lists of supported languages and formats
     PROGRAMMING_LANGUAGES = [
-        "SQL", "C", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
+        "SQL", "C", "Cpp", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin"
@@ -71,6 +71,7 @@ class CodeGenerator:
     LEXER_MAP = {
         "SQL": "sql",
         "C": "c",
+        "Cpp": "cpp",
         "XQuery": "xquery",
         "Java": "java",
         "Rust": "rust",


### PR DESCRIPTION
This change adds full support for C++ as a comparison language. It includes implementation of 38 programming patterns, updates to the documentation index, design, and syntax specifications, and integration into the ReadTheDocs matrix generation workflow.

Fixes #273

---
*PR created automatically by Jules for task [12076213845888508622](https://jules.google.com/task/12076213845888508622) started by @chatelao*