### PR TITLE
Add GitHub backlink to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,14 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
+html_context = {
+    "display_github": True,
+    "github_user": "chatelao",
+    "github_repo": "bible-of-babylon",
+    "github_version": "main",
+    "conf_py_path": "/docs/",
+}
+
 source_suffix = {
     '.rst': 'restructuredtext',
     '.md': 'markdown',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,11 @@
 Welcome to the Bible of Babylon Documentation
 =============================================
 
+Project Links
+=============
+
+- **GitHub Repository:** `https://github.com/chatelao/bible-of-babylon <https://github.com/chatelao/bible-of-babylon>`_
+
 Downloads
 =========
 


### PR DESCRIPTION
This change adds a backlink to the project's GitHub repository from the documentation hosted on Read the Docs. It enables the "Edit on GitHub" feature in the Sphinx theme and adds a prominent link on the main index page.

Fixes #271

---
*PR created automatically by Jules for task [11446481152986084179](https://jules.google.com/task/11446481152986084179) started by @chatelao*