### PR TITLE
Create ENTROPY.md with pattern/language coverage reports

### DIFF
--- a/ENTROPY.md
+++ b/ENTROPY.md
@@ -1,0 +1,90 @@
+# Entropy Report
+
+## 15/7 Set
+
+**Entropy:** 0.660962
+**Coverage:** 82.86% (87/105)
+
+| Pattern | Bash | CSS | Lisp | PowerShell | SQL | Swift | XQuery |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| BitAnd | X | X | X | X | X | X | X |
+| Decrement | X | X | X | X | X | X | X |
+| ForLoop | X | X | X | X | X | X | X |
+| FunctionDefinition | X | X | X | X | X | X | X |
+| GreaterThan | X | X | X | X | X | X | X |
+| Import | X | X | X | X | X | X | X |
+| Multiplication | X | X | X | X | X | X | X |
+| NotEqual | X | X | X | X | X | X | X |
+| Print | X | X | X | X | X | X | X |
+| Raise | X | X | X | X | X | X | X |
+| ReceiveMessage |  |  |  |  |  | X |  |
+| Remainder | X | X | X | X | X | X | X |
+| Rounding | X | X | X | X | X | X | X |
+| SendMessage |  |  |  |  |  | X |  |
+| Thread |  |  |  |  |  | X |  |
+
+## 20/9 Set
+
+**Entropy:** 0.566510
+**Coverage:** 86.67% (156/180)
+
+| Pattern | Bash | CSS | Lisp | PHP | PowerShell | Python | Rust | SQL | XQuery |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| BitNot | X | X | X | X | X | X | X | X | X |
+| BitOr | X | X | X | X | X | X | X | X | X |
+| BitXor | X | X | X | X | X | X | X | X | X |
+| Constant | X | X | X | X | X | X | X | X | X |
+| Division | X | X | X | X | X | X | X | X | X |
+| Equal | X | X | X | X | X | X | X | X | X |
+| Float4VectorMultiplication | X | X | X | X | X | X | X | X | X |
+| Import | X | X | X | X | X | X | X | X | X |
+| Loop | X | X | X | X | X | X | X | X | X |
+| Print | X | X | X | X | X | X | X | X | X |
+| ProcedureDefinition | X | X | X | X | X | X | X | X | X |
+| Raise | X | X | X | X | X | X | X | X | X |
+| ReceiveMessage |  |  |  |  |  |  | X |  |  |
+| Remainder | X | X | X | X | X | X | X | X | X |
+| Rounding | X | X | X | X | X | X | X | X | X |
+| SendMessage |  |  |  |  |  |  | X |  |  |
+| SingleLineComment | X | X | X | X | X | X | X | X | X |
+| Thread |  |  |  |  |  |  | X |  |  |
+| TryCatch | X | X | X | X | X | X | X | X | X |
+| VariableDeclaration | X | X | X | X | X | X | X | X | X |
+
+## 30/12 Set
+
+**Entropy:** 0.384312
+**Coverage:** 92.50% (333/360)
+
+| Pattern | Bash | C | CSS | Cmd | Go | Kotlin | Lisp | PHP | PowerShell | Python | SQL | x86 Assembler |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| BitAnd | X | X | X | X | X | X | X | X | X | X | X | X |
+| BitNot | X | X | X | X | X | X | X | X | X | X | X | X |
+| BitOr | X | X | X | X | X | X | X | X | X | X | X | X |
+| BitXor | X | X | X | X | X | X | X | X | X | X | X | X |
+| Constant | X | X | X | X | X | X | X | X | X | X | X | X |
+| Decrement | X | X | X | X | X | X | X | X | X | X | X | X |
+| Division | X | X | X | X | X | X | X | X | X | X | X | X |
+| Equal | X | X | X | X | X | X | X | X | X | X | X | X |
+| Float4VectorCrossProduct | X | X | X | X | X | X | X | X | X | X | X | X |
+| Float4VectorDotProduct | X | X | X | X | X | X | X | X | X | X | X | X |
+| Floor | X | X | X | X | X | X | X | X | X | X | X | X |
+| FunctionDefinition | X | X | X | X | X | X | X | X | X | X | X | X |
+| GreaterThan | X | X | X | X | X | X | X | X | X | X | X | X |
+| IfElse | X | X | X | X | X | X | X | X | X | X | X | X |
+| Import | X | X | X | X | X | X | X | X | X | X | X | X |
+| Increment | X | X | X | X | X | X | X | X | X | X | X | X |
+| LeftShift | X | X | X | X | X | X | X | X | X | X | X | X |
+| Loop | X | X | X | X | X | X | X | X | X | X | X | X |
+| MultiLineComment | X | X | X | X | X | X | X | X | X | X | X | X |
+| Multiplication | X | X | X | X | X | X | X | X | X | X | X | X |
+| NotEqual | X | X | X | X | X | X | X | X | X | X | X | X |
+| Print | X | X | X | X | X | X | X | X | X | X | X | X |
+| ProcedureDefinition | X | X | X | X | X | X | X | X | X | X | X | X |
+| ReceiveMessage |  |  |  |  | X | X |  |  |  |  |  | X |
+| SendMessage |  |  |  |  | X | X |  |  |  |  |  | X |
+| Subtraction | X | X | X | X | X | X | X | X | X | X | X | X |
+| SwitchCase | X | X | X | X | X | X | X | X | X | X | X | X |
+| Thread |  |  |  |  | X | X |  |  |  |  |  | X |
+| TryCatch | X | X | X | X | X | X | X | X | X | X | X | X |
+| VariableDeclaration | X | X | X | X | X | X | X | X | X | X | X | X |


### PR DESCRIPTION
Created ENTROPY.md with 15/7, 20/9, and 30/12 pattern/language sets that maximize entropy. Each set is meaningful, ensuring no empty rows or columns in the coverage tables.

Fixes #278

---
*PR created automatically by Jules for task [8268886220990321591](https://jules.google.com/task/8268886220990321591) started by @chatelao*