### PR TITLE
Add GraphQL, SPARQL, and Overpass Turbo support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
           echo "" >> docs/matrices.rst
           echo "Programming Languages" >> docs/matrices.rst
           echo "---------------------" >> docs/matrices.rst
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin" --pivot-matrix >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --pivot-matrix >> docs/matrices.rst
           echo "" >> docs/matrices.rst
           echo "Data Formats" >> docs/matrices.rst
           echo "------------" >> docs/matrices.rst
@@ -46,10 +46,10 @@ jobs:
           # Sphinx expects these files to be in the source tree during build
           # By convention, we put them in docs/
           # CSV
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --csv > docs/programming_matrix.csv
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
           # Excel
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --excel -o docs/programming_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
       - name: Build Documentation

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -40,6 +40,9 @@ The transpiler maintains a mapping between internal instance names and Pygments-
 | C#            | `csharp`       |
 | Swift         | `swift`        |
 | Kotlin        | `kotlin`       |
+| GraphQL       | `graphql`      |
+| SPARQL        | `sparql`       |
+| Overpass Turbo| `text`         |
 | JSON          | `json`         |
 | XML           | `xml`          |
 | YAML          | `yaml`         |

--- a/docs/graphql_pivot.rst
+++ b/docs/graphql_pivot.rst
@@ -1,0 +1,130 @@
+GraphQL Pivot View
+==================
+
+.. list-table:: GraphQL Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: graphql
+
+           query HeroNameAndFriends($episode: Episode) { ... }
+     - Variables are prefixed with $ and defined in the operation header.
+   * - SingleLineComment
+     - .. code-block:: graphql
+
+           # comment
+     - GraphQL uses the hash character for single-line comments.
+   * - MultiLineComment
+     - N/A
+     - GraphQL does not have a native multi-line comment syntax; multiple single-line comments are used.
+   * - Print
+     - N/A
+     - GraphQL is a query language and does not have a native print statement.
+   * - Import
+     - N/A
+     - The GraphQL core specification does not define an import mechanism.
+   * - Constant
+     - N/A
+     - GraphQL does not support local constants within queries.
+   * - Equal
+     - N/A
+     - Comparisons are typically handled via field arguments on the server.
+   * - NotEqual
+     - N/A
+     -
+   * - GreaterThan
+     - N/A
+     -
+   * - ProcedureDefinition
+     - N/A
+     - Not supported natively.
+   * - FunctionDefinition
+     - N/A
+     - Not supported natively.
+   * - IfElse
+     - .. code-block:: graphql
+
+           @include(if: $withFriends)
+     - Conditional inclusion/exclusion of fields using directives.
+   * - SwitchCase
+     - N/A
+     - Not supported natively.
+   * - Loop
+     - N/A
+     - GraphQL queries are non-iterative.
+   * - ForLoop
+     - N/A
+     -
+   * - TryCatch
+     - N/A
+     - Errors are returned in the top-level errors key of the response.
+   * - Raise
+     - N/A
+     - Not supported natively.
+   * - Thread
+     - N/A
+     - Not supported natively.
+   * - SendMessage
+     - N/A
+     - Not supported natively.
+   * - ReceiveMessage
+     - N/A
+     - Not supported natively.
+   * - Addition
+     - N/A
+     - GraphQL does not support arithmetic in the query language.
+   * - Subtraction
+     - N/A
+     -
+   * - Multiplication
+     - N/A
+     -
+   * - Division
+     - N/A
+     -
+   * - Remainder
+     - N/A
+     -
+   * - Floor
+     - N/A
+     -
+   * - Rounding
+     - N/A
+     -
+   * - Increment
+     - N/A
+     -
+   * - Decrement
+     - N/A
+     -
+   * - LeftShift
+     - N/A
+     -
+   * - RightShift
+     - N/A
+     -
+   * - BitAnd
+     - N/A
+     -
+   * - BitOr
+     - N/A
+     -
+   * - BitXor
+     - N/A
+     -
+   * - BitNot
+     - N/A
+     -
+   * - Float4VectorMultiplication
+     - N/A
+     -
+   * - Float4VectorDotProduct
+     - N/A
+     -
+   * - Float4VectorCrossProduct
+     - N/A
+     -

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,9 @@ Downloads
    csharp_pivot
    swift_pivot
    kotlin_pivot
+   graphql_pivot
+   sparql_pivot
+   overpass_pivot
 
 Indices and tables
 ==================

--- a/docs/overpass_pivot.rst
+++ b/docs/overpass_pivot.rst
@@ -1,0 +1,163 @@
+Overpass Turbo Pivot View
+=========================
+
+.. list-table:: Overpass Turbo Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: text
+
+           node[name="Foo"]->.x;
+     - Variables represent sets of OSM elements and are assigned using ->.name.
+   * - SingleLineComment
+     - .. code-block:: text
+
+           // comment
+     - Standard C-style single-line comment.
+   * - MultiLineComment
+     - .. code-block:: text
+
+           /* line 1
+              line 2 */
+     - Standard C-style block comment.
+   * - Print
+     - .. code-block:: text
+
+           out;
+     - Outputs the contents of a set; various levels of verbosity are supported (ids, skel, body, meta).
+   * - Import
+     - N/A
+     - Overpass QL does not have a native import mechanism.
+   * - Constant
+     - N/A
+     - Constants are not supported natively beyond literals in filters/evaluators.
+   * - Equal
+     - .. code-block:: text
+
+           t["key"] == "value"
+     - Equality is used within (if:) filters or convert/make statements.
+   * - NotEqual
+     - .. code-block:: text
+
+           t["key"] != "value"
+     -
+   * - GreaterThan
+     - .. code-block:: text
+
+           count(nodes) > 10
+     -
+   * - ProcedureDefinition
+     - N/A
+     - Not supported natively.
+   * - FunctionDefinition
+     - N/A
+     - Not supported natively.
+   * - IfElse
+     - .. code-block:: text
+
+           if (count(nodes) > 0) {
+             out;
+           } else {
+             out count;
+           }
+     - Conditional execution of block statements (version 0.7.55+).
+   * - SwitchCase
+     - N/A
+     - Not supported natively.
+   * - Loop
+     - .. code-block:: text
+
+           complete { ... }
+     - The complete block statement repeatedly expands a set until it stabilizes.
+   * - ForLoop
+     - .. code-block:: text
+
+           foreach.a->.b { ... }
+     - The foreach statement loops over the elements of a set.
+   * - TryCatch
+     - N/A
+     - No native try-catch mechanism.
+   * - Raise
+     - N/A
+     - No native mechanism to raise exceptions.
+   * - Thread
+     - N/A
+     - Not supported natively.
+   * - SendMessage
+     - N/A
+     - Not supported natively.
+   * - ReceiveMessage
+     - N/A
+     - Not supported natively.
+   * - Addition
+     - .. code-block:: text
+
+           a + b
+     - Used within evaluators.
+   * - Subtraction
+     - .. code-block:: text
+
+           a - b
+     -
+   * - Multiplication
+     - .. code-block:: text
+
+           a * b
+     -
+   * - Division
+     - .. code-block:: text
+
+           a / b
+     -
+   * - Remainder
+     - N/A
+     - Overpass QL does not have a native modulo operator.
+   * - Floor
+     - N/A
+     -
+   * - Rounding
+     - .. code-block:: text
+
+           round(a)
+     -
+   * - Increment
+     - .. code-block:: text
+
+           a + 1
+     - No native increment operator.
+   * - Decrement
+     - .. code-block:: text
+
+           a - 1
+     -
+   * - LeftShift
+     - N/A
+     - Not supported natively.
+   * - RightShift
+     - N/A
+     -
+   * - BitAnd
+     - N/A
+     -
+   * - BitOr
+     - N/A
+     -
+   * - BitXor
+     - N/A
+     -
+   * - BitNot
+     - N/A
+     -
+   * - Float4VectorMultiplication
+     - N/A
+     -
+   * - Float4VectorDotProduct
+     - N/A
+     -
+   * - Float4VectorCrossProduct
+     - N/A
+     -

--- a/docs/sparql_pivot.rst
+++ b/docs/sparql_pivot.rst
@@ -1,0 +1,164 @@
+SPARQL Pivot View
+=================
+
+.. list-table:: SPARQL Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: sparql
+
+           BIND(42 AS ?x)
+     - Variables are prefixed with ? and assigned using BIND.
+   * - SingleLineComment
+     - .. code-block:: sparql
+
+           # comment
+     - SPARQL uses the hash character for single-line comments.
+   * - MultiLineComment
+     - N/A
+     - SPARQL does not have a native multi-line comment syntax.
+   * - Print
+     - .. code-block:: sparql
+
+           SELECT ("Hello" AS ?msg) {}
+     - Output is typically achieved by projecting expressions in the SELECT clause.
+   * - Import
+     - .. code-block:: sparql
+
+           PREFIX ex: <http://example.org/>
+     - PREFIX defines a namespace for IRIs.
+   * - Constant
+     - .. code-block:: sparql
+
+           VALUES ?MAX { 100 }
+     - VALUES provides a way to bind constants to variables.
+   * - Equal
+     - .. code-block:: sparql
+
+           ?a = ?b
+     - Used within FILTER or BIND expressions.
+   * - NotEqual
+     - .. code-block:: sparql
+
+           ?a != ?b
+     -
+   * - GreaterThan
+     - .. code-block:: sparql
+
+           ?a > ?b
+     -
+   * - ProcedureDefinition
+     - N/A
+     - Not supported natively.
+   * - FunctionDefinition
+     - N/A
+     - Not supported natively.
+   * - IfElse
+     - .. code-block:: sparql
+
+           BIND(IF(?x > 0, 1, 0) AS ?res)
+     - The IF function provides conditional logic within expressions.
+   * - SwitchCase
+     - .. code-block:: sparql
+
+           BIND(COALESCE(IF(?x=1, "one", 1/0), IF(?x=2, "two", 1/0), "none") AS ?res)
+     - Can be simulated using nested IFs or COALESCE.
+   * - Loop
+     - N/A
+     - SPARQL is a declarative query language and does not have native loops.
+   * - ForLoop
+     - N/A
+     -
+   * - TryCatch
+     - .. code-block:: sparql
+
+           COALESCE(?expression, <fallback>)
+     - COALESCE can be used to handle potentially failing expressions (like errors during evaluation).
+   * - Raise
+     - .. code-block:: sparql
+
+           1/0
+     - Intentional division by zero can cause an expression error, often used with COALESCE or FILTER.
+   * - Thread
+     - N/A
+     - Not supported natively.
+   * - SendMessage
+     - N/A
+     - Not supported natively.
+   * - ReceiveMessage
+     - N/A
+     - Not supported natively.
+   * - Addition
+     - .. code-block:: sparql
+
+           ?a + ?b
+     - Arithmetic operators are used in BIND or FILTER.
+   * - Subtraction
+     - .. code-block:: sparql
+
+           ?a - ?b
+     -
+   * - Multiplication
+     - .. code-block:: sparql
+
+           ?a * ?b
+     -
+   * - Division
+     - .. code-block:: sparql
+
+           ?a / ?b
+     -
+   * - Remainder
+     - N/A
+     - Standard SPARQL 1.1 does not have a modulo operator.
+   * - Floor
+     - .. code-block:: sparql
+
+           FLOOR(?a)
+     - Standard SPARQL 1.1 functions.
+   * - Rounding
+     - .. code-block:: sparql
+
+           ROUND(?a)
+     - Standard SPARQL 1.1 functions.
+   * - Increment
+     - .. code-block:: sparql
+
+           ?a + 1
+     - No native increment operator.
+   * - Decrement
+     - .. code-block:: sparql
+
+           ?a - 1
+     -
+   * - LeftShift
+     - N/A
+     - Not supported natively.
+   * - RightShift
+     - N/A
+     -
+   * - BitAnd
+     - N/A
+     -
+   * - BitOr
+     - N/A
+     -
+   * - BitXor
+     - N/A
+     -
+   * - BitNot
+     - N/A
+     -
+   * - Float4VectorMultiplication
+     - N/A
+     -
+   * - Float4VectorDotProduct
+     - N/A
+     -
+   * - Float4VectorCrossProduct
+     - N/A
+     -

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -6719,3 +6719,670 @@ instance CppFloat4VectorCrossProduct of Float4VectorCrossProduct {
     syntax = "c[0] = a[1]*b[2] - a[2]*b[1];\nc[1] = a[2]*b[0] - a[0]*b[2];\nc[2] = a[0]*b[1] - a[1]*b[0];\nc[3] = 0.0f;"
     notes = "Manual implementation for the first three components."
 }
+
+
+instance GraphQLVar of VariableDeclaration {
+    name = "id"
+    type = "ID"
+    initial_value = 0
+    syntax = "query HeroNameAndFriends($episode: Episode) { ... }"
+    notes = "Variables are prefixed with $ and defined in the operation header."
+}
+
+instance GraphQLSingleLineComment of SingleLineComment {
+    syntax = "# comment"
+    notes = "GraphQL uses the hash character for single-line comments."
+}
+
+instance GraphQLMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "GraphQL does not have a native multi-line comment syntax; multiple single-line comments are used."
+}
+
+instance GraphQLPrint of Print {
+    value = "N/A"
+    syntax = "N/A"
+    notes = "GraphQL is a query language and does not have a native print statement."
+}
+
+instance GraphQLImport of Import {
+    module_name = "N/A"
+    syntax = "N/A"
+    notes = "The GraphQL core specification does not define an import mechanism."
+}
+
+instance GraphQLConstant of Constant {
+    name = "N/A"
+    type = "N/A"
+    value = "N/A"
+    syntax = "N/A"
+    notes = "GraphQL does not support local constants within queries."
+}
+
+instance GraphQLEqual of Equal {
+    syntax = "N/A"
+    notes = "Comparisons are typically handled via field arguments on the server."
+}
+
+instance GraphQLNotEqual of NotEqual {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLGreaterThan of GreaterThan {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLProcedure of ProcedureDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLFunction of FunctionDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    return_type = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLIfElse of IfElse {
+    condition = "N/A"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "@include(if: $withFriends)"
+    notes = "Conditional inclusion/exclusion of fields using directives."
+}
+
+instance GraphQLSwitchCase of SwitchCase {
+    expression = "N/A"
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "GraphQL queries are non-iterative."
+}
+
+instance GraphQLForLoop of ForLoop {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Errors are returned in the top-level errors key of the response."
+}
+
+instance GraphQLRaise of Raise {
+    exception_type = "N/A"
+    message = "Error"
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance GraphQLAddition of Addition {
+    syntax = "N/A"
+    notes = "GraphQL does not support arithmetic in the query language."
+}
+
+instance GraphQLSubtraction of Subtraction {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLMultiplication of Multiplication {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLDivision of Division {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLRemainder of Remainder {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLFloor of Floor {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLRounding of Rounding {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLIncrement of Increment {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLDecrement of Decrement {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLRightShift of RightShift {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLBitOr of BitOr {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLBitXor of BitXor {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLBitNot of BitNot {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance GraphQLFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlVar of VariableDeclaration {
+    name = "x"
+    type = "Any"
+    initial_value = 42
+    syntax = "BIND(42 AS ?x)"
+    notes = "Variables are prefixed with ? and assigned using BIND."
+}
+
+instance SparqlSingleLineComment of SingleLineComment {
+    syntax = "# comment"
+    notes = "SPARQL uses the hash character for single-line comments."
+}
+
+instance SparqlMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "SPARQL does not have a native multi-line comment syntax."
+}
+
+instance SparqlPrint of Print {
+    value = "Hello"
+    syntax = "SELECT (\"Hello\" AS ?msg) {}"
+    notes = "Output is typically achieved by projecting expressions in the SELECT clause."
+}
+
+instance SparqlImport of Import {
+    module_name = "http://example.org/"
+    syntax = "PREFIX ex: <http://example.org/>"
+    notes = "PREFIX defines a namespace for IRIs."
+}
+
+instance SparqlConstant of Constant {
+    name = "MAX"
+    type = "Integer"
+    value = "100"
+    syntax = "VALUES ?MAX { 100 }"
+    notes = "VALUES provides a way to bind constants to variables."
+}
+
+instance SparqlEqual of Equal {
+    syntax = "?a = ?b"
+    notes = "Used within FILTER or BIND expressions."
+}
+
+instance SparqlNotEqual of NotEqual {
+    syntax = "?a != ?b"
+    notes = ""
+}
+
+instance SparqlGreaterThan of GreaterThan {
+    syntax = "?a > ?b"
+    notes = ""
+}
+
+instance SparqlProcedure of ProcedureDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance SparqlFunction of FunctionDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    return_type = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance SparqlIfElse of IfElse {
+    condition = "?x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "BIND(IF(?x > 0, 1, 0) AS ?res)"
+    notes = "The IF function provides conditional logic within expressions."
+}
+
+instance SparqlSwitchCase of SwitchCase {
+    expression = "?x"
+    syntax = "BIND(COALESCE(IF(?x=1, \"one\", 1/0), IF(?x=2, \"two\", 1/0), \"none\") AS ?res)"
+    notes = "Can be simulated using nested IFs or COALESCE."
+}
+
+instance SparqlLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "SPARQL is a declarative query language and does not have native loops."
+}
+
+instance SparqlForLoop of ForLoop {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "N/A" }
+    syntax = "COALESCE(?expression, <fallback>)"
+    notes = "COALESCE can be used to handle potentially failing expressions (like errors during evaluation)."
+}
+
+instance SparqlRaise of Raise {
+    exception_type = "N/A"
+    message = "Error"
+    syntax = "1/0"
+    notes = "Intentional division by zero can cause an expression error, often used with COALESCE or FILTER."
+}
+
+instance SparqlThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance SparqlSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance SparqlReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance SparqlAddition of Addition {
+    syntax = "?a + ?b"
+    notes = "Arithmetic operators are used in BIND or FILTER."
+}
+
+instance SparqlSubtraction of Subtraction {
+    syntax = "?a - ?b"
+    notes = ""
+}
+
+instance SparqlMultiplication of Multiplication {
+    syntax = "?a * ?b"
+    notes = ""
+}
+
+instance SparqlDivision of Division {
+    syntax = "?a / ?b"
+    notes = ""
+}
+
+instance SparqlRemainder of Remainder {
+    syntax = "N/A"
+    notes = "Standard SPARQL 1.1 does not have a modulo operator."
+}
+
+instance SparqlFloor of Floor {
+    syntax = "FLOOR(?a)"
+    notes = "Standard SPARQL 1.1 functions."
+}
+
+instance SparqlRounding of Rounding {
+    syntax = "ROUND(?a)"
+    notes = "Standard SPARQL 1.1 functions."
+}
+
+instance SparqlIncrement of Increment {
+    syntax = "?a + 1"
+    notes = "No native increment operator."
+}
+
+instance SparqlDecrement of Decrement {
+    syntax = "?a - 1"
+    notes = ""
+}
+
+instance SparqlLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance SparqlRightShift of RightShift {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlBitOr of BitOr {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlBitXor of BitXor {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlBitNot of BitNot {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance SparqlFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboVar of VariableDeclaration {
+    name = "x"
+    type = "Set"
+    initial_value = 0
+    syntax = "node[name=\"Foo\"]->.x;"
+    notes = "Variables represent sets of OSM elements and are assigned using ->.name."
+}
+
+instance OverpassTurboSingleLineComment of SingleLineComment {
+    syntax = "// comment"
+    notes = "Standard C-style single-line comment."
+}
+
+instance OverpassTurboMultiLineComment of MultiLineComment {
+    syntax = "/* line 1\n   line 2 */"
+    notes = "Standard C-style block comment."
+}
+
+instance OverpassTurboPrint of Print {
+    value = "elements"
+    syntax = "out;"
+    notes = "Outputs the contents of a set; various levels of verbosity are supported (ids, skel, body, meta)."
+}
+
+instance OverpassTurboImport of Import {
+    module_name = "N/A"
+    syntax = "N/A"
+    notes = "Overpass QL does not have a native import mechanism."
+}
+
+instance OverpassTurboConstant of Constant {
+    name = "N/A"
+    type = "N/A"
+    value = "N/A"
+    syntax = "N/A"
+    notes = "Constants are not supported natively beyond literals in filters/evaluators."
+}
+
+instance OverpassTurboEqual of Equal {
+    syntax = "t[\"key\"] == \"value\""
+    notes = "Equality is used within (if:) filters or convert/make statements."
+}
+
+instance OverpassTurboNotEqual of NotEqual {
+    syntax = "t[\"key\"] != \"value\""
+    notes = ""
+}
+
+instance OverpassTurboGreaterThan of GreaterThan {
+    syntax = "count(nodes) > 10"
+    notes = ""
+}
+
+instance OverpassTurboProcedure of ProcedureDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboFunction of FunctionDefinition {
+    name = "N/A"
+    parameters = ["N/A"]
+    return_type = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboIfElse of IfElse {
+    condition = "count(nodes) > 0"
+    then_branch = { raw "out;" }
+    else_branch = { raw "out count;" }
+    syntax = "if (count(nodes) > 0) {\n  out;\n} else {\n  out count;\n}"
+    notes = "Conditional execution of block statements (version 0.7.55+)."
+}
+
+instance OverpassTurboSwitchCase of SwitchCase {
+    expression = "N/A"
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "complete { ... }"
+    notes = "The complete block statement repeatedly expands a set until it stabilizes."
+}
+
+instance OverpassTurboForLoop of ForLoop {
+    syntax = "foreach.a->.b { ... }"
+    notes = "The foreach statement loops over the elements of a set."
+}
+
+instance OverpassTurboTryCatch of TryCatch {
+    try_body = { call do_something() }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "No native try-catch mechanism."
+}
+
+instance OverpassTurboRaise of Raise {
+    exception_type = "N/A"
+    message = "Error"
+    syntax = "N/A"
+    notes = "No native mechanism to raise exceptions."
+}
+
+instance OverpassTurboThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboAddition of Addition {
+    syntax = "a + b"
+    notes = "Used within evaluators."
+}
+
+instance OverpassTurboSubtraction of Subtraction {
+    syntax = "a - b"
+    notes = ""
+}
+
+instance OverpassTurboMultiplication of Multiplication {
+    syntax = "a * b"
+    notes = ""
+}
+
+instance OverpassTurboDivision of Division {
+    syntax = "a / b"
+    notes = ""
+}
+
+instance OverpassTurboRemainder of Remainder {
+    syntax = "N/A"
+    notes = "Overpass QL does not have a native modulo operator."
+}
+
+instance OverpassTurboFloor of Floor {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboRounding of Rounding {
+    syntax = "round(a)"
+    notes = ""
+}
+
+instance OverpassTurboIncrement of Increment {
+    syntax = "a + 1"
+    notes = "No native increment operator."
+}
+
+instance OverpassTurboDecrement of Decrement {
+    syntax = "a - 1"
+    notes = ""
+}
+
+instance OverpassTurboLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance OverpassTurboRightShift of RightShift {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboBitOr of BitOr {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboBitXor of BitXor {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboBitNot of BitNot {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = ""
+}
+
+instance OverpassTurboFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "N/A"
+    notes = ""
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx
 myst-parser
 sphinx-rtd-theme
 openpyxl
+pygments

--- a/src/generator.py
+++ b/src/generator.py
@@ -61,7 +61,8 @@ class CodeGenerator:
         "SQL", "C", "Cpp", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
-        "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin"
+        "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
+        "GraphQL", "SPARQL", "Overpass Turbo"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
@@ -103,6 +104,9 @@ class CodeGenerator:
         "CSharp": "csharp",
         "Swift": "swift",
         "Kotlin": "kotlin",
+        "GraphQL": "graphql",
+        "SPARQL": "sparql",
+        "Overpass Turbo": "text",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",

--- a/src/install.sh
+++ b/src/install.sh
@@ -15,4 +15,7 @@ pip install antlr4-python3-runtime==4.13.2
 echo "Installing openpyxl..."
 pip install openpyxl
 
+echo "Installing pygments..."
+pip install pygments
+
 echo "Development environment setup complete."


### PR DESCRIPTION
This change adds support for three new query languages: GraphQL, SPARQL, and Overpass QL (Overpass Turbo). 

Key updates:
1.  **Pattern Implementations:** Comprehensive implementation of existing programming patterns for all three languages in `patterns/programming.patterns`.
2.  **Generator Logic:** Updated `src/generator.py` to recognize the new languages and map them to appropriate Pygments lexers (`graphql`, `sparql`, and `text` for Overpass).
3.  **Documentation:** New pivot chapters generated for each language and integrated into the main `docs/index.rst` toctree.
4.  **Tooling & CI/CD:** Added `pygments` as a core dependency and updated the GitHub Actions workflow to include the new languages in comparison matrices (CSV, Excel, and RST).
5.  **Validation:** Verified the new pattern instances using the project's validator and ensured zero regressions by running the full test suite.

Fixes #281

---
*PR created automatically by Jules for task [6386184375257324356](https://jules.google.com/task/6386184375257324356) started by @chatelao*