### PR TITLE
Add support for GraphQL, SPARQL, and Overpass Turbo

### DIFF
--- a/docs/graphql_pivot.rst
+++ b/docs/graphql_pivot.rst
@@ -1,0 +1,150 @@
+GraphQL Pivot View
+==================
+
+.. list-table:: GraphQL Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: graphql
+
+           $x: Int = 42
+     - Variables in GraphQL are prefixed with $ and used in operation definitions.
+   * - Equal
+     - N/A
+     - GraphQL does not have a native equality operator in the query language itself.
+   * - NotEqual
+     - N/A
+     - N/A
+   * - GreaterThan
+     - N/A
+     - N/A
+   * - ProcedureDefinition
+     - N/A
+     - GraphQL does not support procedure definitions.
+   * - FunctionDefinition
+     - .. code-block:: graphql
+
+           query getUser($id: ID) {
+               user(id: $id) {
+                   name
+               }
+           }
+     - Operations (query, mutation, subscription) are the closest equivalent to functions.
+   * - IfElse
+     - .. code-block:: graphql
+
+           @skip(if: $condition) or @include(if: $condition)
+     - Directives provide conditional inclusion of fields.
+   * - SwitchCase
+     - N/A
+     - N/A
+   * - Loop
+     - N/A
+     - GraphQL does not support loops in queries.
+   * - ForLoop
+     - N/A
+     - N/A
+   * - TryCatch
+     - N/A
+     - Errors are returned in the 'errors' field of the response.
+   * - Raise
+     - N/A
+     - N/A
+   * - Thread
+     - N/A
+     - N/A
+   * - SendMessage
+     - N/A
+     - N/A
+   * - ReceiveMessage
+     - .. code-block:: graphql
+
+           subscription { ... }
+     - Subscriptions allow receiving real-time updates.
+   * - SingleLineComment
+     - .. code-block:: graphql
+
+           # comment
+     - Standard GraphQL comment.
+   * - MultiLineComment
+     - .. code-block:: graphql
+
+           """ comment """
+     - Block strings can be used as multi-line descriptions/comments.
+   * - Print
+     - N/A
+     - N/A
+   * - Import
+     - N/A
+     - Schema stitching or federation is used to combine schemas.
+   * - Constant
+     - N/A
+     - N/A
+   * - Addition
+     - N/A
+     - N/A
+   * - Subtraction
+     - N/A
+     - N/A
+   * - Multiplication
+     - N/A
+     - N/A
+   * - Division
+     - N/A
+     - N/A
+   * - Remainder
+     - N/A
+     - N/A
+   * - Floor
+     - N/A
+     - N/A
+   * - Rounding
+     - N/A
+     - N/A
+   * - Increment
+     - N/A
+     - N/A
+   * - Decrement
+     - N/A
+     - N/A
+   * - LeftShift
+     - N/A
+     - N/A
+   * - RightShift
+     - N/A
+     - N/A
+   * - BitAnd
+     - N/A
+     - N/A
+   * - BitOr
+     - N/A
+     - N/A
+   * - BitXor
+     - N/A
+     - N/A
+   * - BitNot
+     - N/A
+     - N/A
+   * - Float4VectorMultiplication
+     - N/A
+     - N/A
+   * - Float4VectorDotProduct
+     - N/A
+     - N/A
+   * - Float4VectorCrossProduct
+     - N/A
+     - N/A
+   * - SetFiltering
+     - .. code-block:: graphql
+
+           user(id: 42)
+     - Filtering is typically done via field arguments.
+   * - SetJoin
+     - .. code-block:: graphql
+
+           user { posts { title } }
+     - Joins are expressed through nested selection sets.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,9 @@ Downloads
    csharp_pivot
    swift_pivot
    kotlin_pivot
+   graphql_pivot
+   sparql_pivot
+   overpass_turbo_pivot
 
 Indices and tables
 ==================

--- a/docs/overpass_turbo_pivot.rst
+++ b/docs/overpass_turbo_pivot.rst
@@ -1,0 +1,156 @@
+Overpass Turbo Pivot View
+=========================
+
+.. list-table:: Overpass Turbo Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: text
+
+           .setname
+     - Overpass QL uses sets (prefixed with .) to store results.
+   * - Equal
+     - .. code-block:: text
+
+           ["name"="Berlin"]
+     - Equality is used in attribute filters.
+   * - NotEqual
+     - .. code-block:: text
+
+           ["name"!="Berlin"]
+     - Inequality in attribute filters.
+   * - GreaterThan
+     - N/A
+     - Overpass QL has limited support for numeric comparisons in some implementations.
+   * - ProcedureDefinition
+     - N/A
+     - N/A
+   * - FunctionDefinition
+     - N/A
+     - N/A
+   * - IfElse
+     - .. code-block:: text
+
+           if (condition) { ... } else { ... }
+     - Control flow statements were added in recent versions of Overpass QL.
+   * - SwitchCase
+     - N/A
+     - N/A
+   * - Loop
+     - .. code-block:: text
+
+           foreach .a ( ... )
+     - The foreach statement iterates over the elements of a set.
+   * - ForLoop
+     - .. code-block:: text
+
+           for ( ... )
+     - Overpass QL supports C-style for loops in recent versions.
+   * - TryCatch
+     - N/A
+     - N/A
+   * - Raise
+     - N/A
+     - N/A
+   * - Thread
+     - N/A
+     - N/A
+   * - SendMessage
+     - N/A
+     - N/A
+   * - ReceiveMessage
+     - N/A
+     - N/A
+   * - SingleLineComment
+     - .. code-block:: text
+
+           // comment
+     - C-style single-line comments.
+   * - MultiLineComment
+     - .. code-block:: text
+
+           /* comment */
+     - C-style multi-line comments.
+   * - Print
+     - .. code-block:: text
+
+           out;
+     - The out statement produces the result of the query.
+   * - Import
+     - .. code-block:: text
+
+           [out:json];
+     - Settings (like output format) are specified at the beginning of the script.
+   * - Constant
+     - .. code-block:: text
+
+           {{key=value}}
+     - Overpass Turbo (the web interface) supports mustache-style constants.
+   * - Addition
+     - N/A
+     - N/A
+   * - Subtraction
+     - N/A
+     - N/A
+   * - Multiplication
+     - N/A
+     - N/A
+   * - Division
+     - N/A
+     - N/A
+   * - Remainder
+     - N/A
+     - N/A
+   * - Floor
+     - N/A
+     - N/A
+   * - Rounding
+     - N/A
+     - N/A
+   * - Increment
+     - N/A
+     - N/A
+   * - Decrement
+     - N/A
+     - N/A
+   * - LeftShift
+     - N/A
+     - N/A
+   * - RightShift
+     - N/A
+     - N/A
+   * - BitAnd
+     - N/A
+     - N/A
+   * - BitOr
+     - N/A
+     - N/A
+   * - BitXor
+     - N/A
+     - N/A
+   * - BitNot
+     - N/A
+     - N/A
+   * - Float4VectorMultiplication
+     - N/A
+     - N/A
+   * - Float4VectorDotProduct
+     - N/A
+     - N/A
+   * - Float4VectorCrossProduct
+     - N/A
+     - N/A
+   * - SetFiltering
+     - .. code-block:: text
+
+           node["name"="Berlin"];
+     - Filters elements by tags or location.
+   * - SetJoin
+     - .. code-block:: text
+
+           (node(area); way(area););
+     - Unions and recursion (e.g., node(w)) are used to combine sets.

--- a/docs/sparql_pivot.rst
+++ b/docs/sparql_pivot.rst
@@ -1,0 +1,168 @@
+SPARQL Pivot View
+=================
+
+.. list-table:: SPARQL Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: sparql
+
+           BIND(42 AS ?x)
+     - The BIND clause assigns a value to a variable.
+   * - Equal
+     - .. code-block:: sparql
+
+           FILTER(?a = ?b)
+     - Equality is checked within a FILTER or BIND expression.
+   * - NotEqual
+     - .. code-block:: sparql
+
+           FILTER(?a != ?b)
+     - Inequality check in SPARQL.
+   * - GreaterThan
+     - .. code-block:: sparql
+
+           FILTER(?a > ?b)
+     - Greater than comparison in SPARQL.
+   * - ProcedureDefinition
+     - N/A
+     - SPARQL does not support procedure definitions.
+   * - FunctionDefinition
+     - N/A
+     - User-defined functions are implementation-dependent (e.g., via ARQ).
+   * - IfElse
+     - .. code-block:: sparql
+
+           BIND(IF(?x > 0, 1, 0) AS ?res)
+     - The IF function returns one of two expressions based on a condition.
+   * - SwitchCase
+     - .. code-block:: sparql
+
+           COALESCE(IF(?x=1, 'one', 1/0), IF(?x=2, 'two', 1/0), 'none')
+     - Multi-way branching can be simulated using nested IFs or COALESCE.
+   * - Loop
+     - N/A
+     - SPARQL is a declarative query language and does not have loops.
+   * - ForLoop
+     - N/A
+     - N/A
+   * - TryCatch
+     - N/A
+     - Errors in expressions (like division by zero) result in the value being unbound.
+   * - Raise
+     - N/A
+     - N/A
+   * - Thread
+     - N/A
+     - N/A
+   * - SendMessage
+     - N/A
+     - N/A
+   * - ReceiveMessage
+     - N/A
+     - N/A
+   * - SingleLineComment
+     - .. code-block:: sparql
+
+           # comment
+     - SPARQL comments start with #.
+   * - MultiLineComment
+     - N/A
+     - SPARQL does not support multi-line comments.
+   * - Print
+     - N/A
+     - Results are returned as bindings or a graph.
+   * - Import
+     - .. code-block:: sparql
+
+           PREFIX dc: <http://purl.org/dc/elements/1.1/>
+     - PREFIX defines a namespace prefix.
+   * - Constant
+     - .. code-block:: sparql
+
+           VALUES ?MAX { 100 }
+     - VALUES can be used to provide constant values for variables.
+   * - Addition
+     - .. code-block:: sparql
+
+           ?a + ?b
+     - Arithmetic operators in SPARQL.
+   * - Subtraction
+     - .. code-block:: sparql
+
+           ?a - ?b
+     - Arithmetic operators in SPARQL.
+   * - Multiplication
+     - .. code-block:: sparql
+
+           ?a * ?b
+     - Arithmetic operators in SPARQL.
+   * - Division
+     - .. code-block:: sparql
+
+           ?a / ?b
+     - Arithmetic operators in SPARQL.
+   * - Remainder
+     - N/A
+     - N/A
+   * - Floor
+     - .. code-block:: sparql
+
+           floor(?a)
+     - Standard SPARQL function.
+   * - Rounding
+     - .. code-block:: sparql
+
+           round(?a)
+     - Standard SPARQL function.
+   * - Increment
+     - .. code-block:: sparql
+
+           ?a + 1
+     - N/A
+   * - Decrement
+     - .. code-block:: sparql
+
+           ?a - 1
+     - N/A
+   * - LeftShift
+     - N/A
+     - N/A
+   * - RightShift
+     - N/A
+     - N/A
+   * - BitAnd
+     - N/A
+     - N/A
+   * - BitOr
+     - N/A
+     - N/A
+   * - BitXor
+     - N/A
+     - N/A
+   * - BitNot
+     - N/A
+     - N/A
+   * - Float4VectorMultiplication
+     - N/A
+     - N/A
+   * - Float4VectorDotProduct
+     - N/A
+     - N/A
+   * - Float4VectorCrossProduct
+     - N/A
+     - N/A
+   * - SetFiltering
+     - .. code-block:: sparql
+
+           FILTER(?x > 0)
+     - The FILTER clause restricts the solutions.
+   * - SetJoin
+     - .. code-block:: sparql
+
+           ?s ?p ?o . ?s ?p2 ?o2
+     - Joins are performed by using the same variable in different triple patterns.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -7031,3 +7031,698 @@ instance KotlinSetJoin of SetJoin {
     syntax = "val res = listA.flatMap { a -> listB.filter { b -> a.id == b.id }.map { b -> a to b } }"
     notes = "Uses flatMap and filter extension functions."
 }
+instance GraphQlVariableDeclaration of VariableDeclaration {
+    name = "x"
+    type = "Int"
+    initial_value = 42
+    syntax = "$x: Int = 42"
+    notes = "Variables in GraphQL are prefixed with $ and used in operation definitions."
+}
+
+instance GraphQlEqual of Equal {
+    syntax = "N/A"
+    notes = "GraphQL does not have a native equality operator in the query language itself."
+}
+
+instance GraphQlNotEqual of NotEqual {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlGreaterThan of GreaterThan {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlProcedureDefinition of ProcedureDefinition {
+    name = "N/A"
+    parameters = []
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "GraphQL does not support procedure definitions."
+}
+
+instance GraphQlFunctionDefinition of FunctionDefinition {
+    name = "getUser"
+    parameters = ["$id: ID"]
+    return_type = "User"
+    body = { raw "user(id: $id) { name }" }
+    syntax = "query getUser($id: ID) {\n    user(id: $id) {\n        name\n    }\n}"
+    notes = "Operations (query, mutation, subscription) are the closest equivalent to functions."
+}
+
+instance GraphQlIfElse of IfElse {
+    condition = "N/A"
+    then_branch = { raw "N/A" }
+    else_branch = { raw "N/A" }
+    syntax = "@skip(if: $condition) or @include(if: $condition)"
+    notes = "Directives provide conditional inclusion of fields."
+}
+
+instance GraphQlSwitchCase of SwitchCase {
+    expression = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "GraphQL does not support loops in queries."
+}
+
+instance GraphQlForLoop of ForLoop {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlTryCatch of TryCatch {
+    try_body = { raw "N/A" }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Errors are returned in the 'errors' field of the response."
+}
+
+instance GraphQlRaise of Raise {
+    exception_type = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "subscription { ... }"
+    notes = "Subscriptions allow receiving real-time updates."
+}
+
+instance GraphQlSingleLineComment of SingleLineComment {
+    syntax = "# comment"
+    notes = "Standard GraphQL comment."
+}
+
+instance GraphQlMultiLineComment of MultiLineComment {
+    syntax = "\"\"\" comment \"\"\""
+    notes = "Block strings can be used as multi-line descriptions/comments."
+}
+
+instance GraphQlPrint of Print {
+    value = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlImport of Import {
+    module_name = "N/A"
+    syntax = "N/A"
+    notes = "Schema stitching or federation is used to combine schemas."
+}
+
+instance GraphQlConstant of Constant {
+    name = "N/A"
+    type = "N/A"
+    value = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlAddition of Addition {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlSubtraction of Subtraction {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlMultiplication of Multiplication {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlDivision of Division {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlRemainder of Remainder {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlFloor of Floor {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlRounding of Rounding {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlIncrement of Increment {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlDecrement of Decrement {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlRightShift of RightShift {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlBitOr of BitOr {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlBitXor of BitXor {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlBitNot of BitNot {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance GraphQlSetFiltering of SetFiltering {
+    syntax = "user(id: 42)"
+    notes = "Filtering is typically done via field arguments."
+}
+
+instance GraphQlSetJoin of SetJoin {
+    syntax = "user { posts { title } }"
+    notes = "Joins are expressed through nested selection sets."
+}
+
+instance SparqlVariableDeclaration of VariableDeclaration {
+    name = "x"
+    type = "xs:integer"
+    initial_value = 42
+    syntax = "BIND(42 AS ?x)"
+    notes = "The BIND clause assigns a value to a variable."
+}
+
+instance SparqlEqual of Equal {
+    syntax = "FILTER(?a = ?b)"
+    notes = "Equality is checked within a FILTER or BIND expression."
+}
+
+instance SparqlNotEqual of NotEqual {
+    syntax = "FILTER(?a != ?b)"
+    notes = "Inequality check in SPARQL."
+}
+
+instance SparqlGreaterThan of GreaterThan {
+    syntax = "FILTER(?a > ?b)"
+    notes = "Greater than comparison in SPARQL."
+}
+
+instance SparqlProcedureDefinition of ProcedureDefinition {
+    name = "N/A"
+    parameters = []
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "SPARQL does not support procedure definitions."
+}
+
+instance SparqlFunctionDefinition of FunctionDefinition {
+    name = "N/A"
+    parameters = []
+    return_type = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "User-defined functions are implementation-dependent (e.g., via ARQ)."
+}
+
+instance SparqlIfElse of IfElse {
+    condition = "?x > 0"
+    then_branch = { raw "1" }
+    else_branch = { raw "0" }
+    syntax = "BIND(IF(?x > 0, 1, 0) AS ?res)"
+    notes = "The IF function returns one of two expressions based on a condition."
+}
+
+instance SparqlSwitchCase of SwitchCase {
+    expression = "?x"
+    syntax = "COALESCE(IF(?x=1, 'one', 1/0), IF(?x=2, 'two', 1/0), 'none')"
+    notes = "Multi-way branching can be simulated using nested IFs or COALESCE."
+}
+
+instance SparqlLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "SPARQL is a declarative query language and does not have loops."
+}
+
+instance SparqlForLoop of ForLoop {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlTryCatch of TryCatch {
+    try_body = { raw "N/A" }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Errors in expressions (like division by zero) result in the value being unbound."
+}
+
+instance SparqlRaise of Raise {
+    exception_type = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlSingleLineComment of SingleLineComment {
+    syntax = "# comment"
+    notes = "SPARQL comments start with #."
+}
+
+instance SparqlMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "SPARQL does not support multi-line comments."
+}
+
+instance SparqlPrint of Print {
+    value = "N/A"
+    syntax = "N/A"
+    notes = "Results are returned as bindings or a graph."
+}
+
+instance SparqlImport of Import {
+    module_name = "N/A"
+    syntax = "PREFIX dc: <http://purl.org/dc/elements/1.1/>"
+    notes = "PREFIX defines a namespace prefix."
+}
+
+instance SparqlConstant of Constant {
+    name = "N/A"
+    type = "N/A"
+    value = "N/A"
+    syntax = "VALUES ?MAX { 100 }"
+    notes = "VALUES can be used to provide constant values for variables."
+}
+
+instance SparqlAddition of Addition {
+    syntax = "?a + ?b"
+    notes = "Arithmetic operators in SPARQL."
+}
+
+instance SparqlSubtraction of Subtraction {
+    syntax = "?a - ?b"
+    notes = "Arithmetic operators in SPARQL."
+}
+
+instance SparqlMultiplication of Multiplication {
+    syntax = "?a * ?b"
+    notes = "Arithmetic operators in SPARQL."
+}
+
+instance SparqlDivision of Division {
+    syntax = "?a / ?b"
+    notes = "Arithmetic operators in SPARQL."
+}
+
+instance SparqlRemainder of Remainder {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlFloor of Floor {
+    syntax = "floor(?a)"
+    notes = "Standard SPARQL function."
+}
+
+instance SparqlRounding of Rounding {
+    syntax = "round(?a)"
+    notes = "Standard SPARQL function."
+}
+
+instance SparqlIncrement of Increment {
+    syntax = "?a + 1"
+    notes = "N/A"
+}
+
+instance SparqlDecrement of Decrement {
+    syntax = "?a - 1"
+    notes = "N/A"
+}
+
+instance SparqlLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlRightShift of RightShift {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlBitOr of BitOr {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlBitXor of BitXor {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlBitNot of BitNot {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance SparqlSetFiltering of SetFiltering {
+    syntax = "FILTER(?x > 0)"
+    notes = "The FILTER clause restricts the solutions."
+}
+
+instance SparqlSetJoin of SetJoin {
+    syntax = "?s ?p ?o . ?s ?p2 ?o2"
+    notes = "Joins are performed by using the same variable in different triple patterns."
+}
+
+instance OverpassTurboVariableDeclaration of VariableDeclaration {
+    name = "x"
+    type = "Set"
+    initial_value = 0
+    syntax = ".setname"
+    notes = "Overpass QL uses sets (prefixed with .) to store results."
+}
+
+instance OverpassTurboEqual of Equal {
+    syntax = "[\"name\"=\"Berlin\"]"
+    notes = "Equality is used in attribute filters."
+}
+
+instance OverpassTurboNotEqual of NotEqual {
+    syntax = "[\"name\"!=\"Berlin\"]"
+    notes = "Inequality in attribute filters."
+}
+
+instance OverpassTurboGreaterThan of GreaterThan {
+    syntax = "N/A"
+    notes = "Overpass QL has limited support for numeric comparisons in some implementations."
+}
+
+instance OverpassTurboProcedureDefinition of ProcedureDefinition {
+    name = "N/A"
+    parameters = []
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboFunctionDefinition of FunctionDefinition {
+    name = "N/A"
+    parameters = []
+    return_type = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboIfElse of IfElse {
+    condition = "condition"
+    then_branch = { raw "N/A" }
+    else_branch = { raw "N/A" }
+    syntax = "if (condition) { ... } else { ... }"
+    notes = "Control flow statements were added in recent versions of Overpass QL."
+}
+
+instance OverpassTurboSwitchCase of SwitchCase {
+    expression = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboLoop of Loop {
+    condition = "N/A"
+    body = { raw "N/A" }
+    syntax = "foreach .a ( ... )"
+    notes = "The foreach statement iterates over the elements of a set."
+}
+
+instance OverpassTurboForLoop of ForLoop {
+    syntax = "for ( ... )"
+    notes = "Overpass QL supports C-style for loops in recent versions."
+}
+
+instance OverpassTurboTryCatch of TryCatch {
+    try_body = { raw "N/A" }
+    exception_type = "N/A"
+    error_variable = "N/A"
+    catch_body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboRaise of Raise {
+    exception_type = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboThread of Thread {
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboSingleLineComment of SingleLineComment {
+    syntax = "// comment"
+    notes = "C-style single-line comments."
+}
+
+instance OverpassTurboMultiLineComment of MultiLineComment {
+    syntax = "/* comment */"
+    notes = "C-style multi-line comments."
+}
+
+instance OverpassTurboPrint of Print {
+    value = "N/A"
+    syntax = "out;"
+    notes = "The out statement produces the result of the query."
+}
+
+instance OverpassTurboImport of Import {
+    module_name = "N/A"
+    syntax = "[out:json];"
+    notes = "Settings (like output format) are specified at the beginning of the script."
+}
+
+instance OverpassTurboConstant of Constant {
+    name = "N/A"
+    type = "N/A"
+    value = "N/A"
+    syntax = "{{key=value}}"
+    notes = "Overpass Turbo (the web interface) supports mustache-style constants."
+}
+
+instance OverpassTurboAddition of Addition {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboSubtraction of Subtraction {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboMultiplication of Multiplication {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboDivision of Division {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboRemainder of Remainder {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboFloor of Floor {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboRounding of Rounding {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboIncrement of Increment {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboDecrement of Decrement {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboLeftShift of LeftShift {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboRightShift of RightShift {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboBitAnd of BitAnd {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboBitOr of BitOr {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboBitXor of BitXor {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboBitNot of BitNot {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "N/A"
+    notes = "N/A"
+}
+
+instance OverpassTurboSetFiltering of SetFiltering {
+    syntax = "node[\"name\"=\"Berlin\"];"
+    notes = "Filters elements by tags or location."
+}
+
+instance OverpassTurboSetJoin of SetJoin {
+    syntax = "(node(area); way(area););"
+    notes = "Unions and recursion (e.g., node(w)) are used to combine sets."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -61,7 +61,8 @@ class CodeGenerator:
         "SQL", "C", "Cpp", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
-        "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin"
+        "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
+        "GraphQL", "SPARQL", "Overpass Turbo"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
@@ -103,6 +104,9 @@ class CodeGenerator:
         "CSharp": "csharp",
         "Swift": "swift",
         "Kotlin": "kotlin",
+        "GraphQL": "graphql",
+        "SPARQL": "sparql",
+        "Overpass Turbo": "text",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",


### PR DESCRIPTION
Support for GraphQL, SPARQL, and Overpass Turbo has been added to the pattern comparison project. This involved defining approximately 40 pattern instances for each language in `patterns/programming.patterns`, registering the languages in the `CodeGenerator` with appropriate syntax highlighting lexers, and generating language-specific pivot chapters in the `docs/` directory. The main documentation index was updated to link these new chapters. All changes have been verified through tests and manual inspection of the generated documentation.

Fixes #285

---
*PR created automatically by Jules for task [3617097086340398262](https://jules.google.com/task/3617097086340398262) started by @chatelao*