### PR TITLE
Add Clojure programming language support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
           echo "" >> docs/matrices.rst
           echo "Programming Languages" >> docs/matrices.rst
           echo "---------------------" >> docs/matrices.rst
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin" --pivot-matrix >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --pivot-matrix >> docs/matrices.rst
           echo "" >> docs/matrices.rst
           echo "Data Formats" >> docs/matrices.rst
           echo "------------" >> docs/matrices.rst
@@ -46,10 +46,10 @@ jobs:
           # Sphinx expects these files to be in the source tree during build
           # By convention, we put them in docs/
           # CSV
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --csv > docs/programming_matrix.csv
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
           # Excel
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --excel -o docs/programming_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
       - name: Build Documentation

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,17 +13,17 @@ build:
       - echo "" >> docs/matrices.rst
       - echo "Programming Languages" >> docs/matrices.rst
       - echo "---------------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --pivot-matrix >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp,Clojure" --pivot-matrix >> docs/matrices.rst
       - echo "" >> docs/matrices.rst
       - echo "Data Formats" >> docs/matrices.rst
       - echo "------------" >> docs/matrices.rst
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
       # Generate Downloadable Matrices for Sphinx :download: role
       # CSV
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --csv > docs/programming_matrix.csv
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp,Clojure" --csv > docs/programming_matrix.csv
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
       # Excel
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp" --excel -o docs/programming_matrix.xlsx
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Python,PHP,Bash,PowerShell,Cmd,SQL,Erlang,Lisp,XQuery,CSS,CUDA,x86 Assembler,RISC-V Assembler,ARM AArch64 Assembler,Prolog,Java Bytecode,Camel,Go,Haskell,TypeScript,Tcl,CSharp,Clojure" --excel -o docs/programming_matrix.xlsx
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
 python:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -38,6 +38,7 @@ This section compares languages based on common programming patterns.
 - C#
 - Swift
 - Kotlin
+- Clojure
 
 **Patterns to be compared:**
 - Variable declaration

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -40,6 +40,7 @@ The transpiler maintains a mapping between internal instance names and Pygments-
 | C#            | `csharp`       |
 | Swift         | `swift`        |
 | Kotlin        | `kotlin`       |
+| Clojure       | `clojure`      |
 | JSON          | `json`         |
 | XML           | `xml`          |
 | YAML          | `yaml`         |

--- a/docs/clojure_pivot.rst
+++ b/docs/clojure_pivot.rst
@@ -1,0 +1,225 @@
+Clojure Pivot View
+==================
+
+.. list-table:: Clojure Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: clojure
+
+           (def x 42)
+     - Global var definition; for local bindings, 'let' is used.
+   * - IfElse
+     - .. code-block:: clojure
+
+           (if (> x 0) 1 0)
+     - Standard functional if-expression.
+   * - SwitchCase
+     - .. code-block:: clojure
+
+           (case x
+             1 1
+             2 2
+             0)
+     - The case macro dispatches on constant values.
+   * - Loop
+     - .. code-block:: clojure
+
+           (while (> x 0)
+             (println x))
+     - While macro for side-effecting loops.
+   * - ForLoop
+     - .. code-block:: clojure
+
+           (doseq [i (range 10)]
+             (println i))
+     - Iterates over a sequence for side effects.
+   * - FunctionDefinition
+     - .. code-block:: clojure
+
+           (defn add [a b]
+             (+ a b))
+     - Standard function definition; the last expression is returned.
+   * - ProcedureDefinition
+     - .. code-block:: clojure
+
+           (defn log-message [msg]
+             (println msg))
+     - Procedures are functions that typically return nil.
+   * - TryCatch
+     - .. code-block:: clojure
+
+           (try
+             (do-something)
+             (catch Exception e
+               (handle e)))
+     - Standard exception handling using try-catch blocks.
+   * - Raise
+     - .. code-block:: clojure
+
+           (throw (Exception. "Error"))
+     - Uses 'throw' to raise an exception object.
+   * - Thread
+     - .. code-block:: clojure
+
+           (future (do-work))
+     - The future macro runs code in another thread and returns a handle to the result.
+   * - SendMessage
+     - .. code-block:: clojure
+
+           (send a + 42)
+     - Asynchronous message passing using agents.
+   * - ReceiveMessage
+     - .. code-block:: clojure
+
+           (let [msg @c] (handle msg))
+     - Dereferencing a promise or future (using @) blocks until the value is available.
+   * - SingleLineComment
+     - .. code-block:: clojure
+
+           ; comment
+     - Standard Clojure single-line comment.
+   * - MultiLineComment
+     - .. code-block:: clojure
+
+           (comment
+             line 1
+             line 2)
+     - The comment macro is used for multi-line blocks; they are treated as code that returns nil.
+   * - Print
+     - .. code-block:: clojure
+
+           (println "Hello, World!")
+     - Prints to stdout with a newline.
+   * - Import
+     - .. code-block:: clojure
+
+           (:require [clojure.string :as str])
+     - Imports a namespace; usually within an ns macro.
+   * - Constant
+     - .. code-block:: clojure
+
+           (def ^:const MAX 100)
+     - Defines a constant value.
+   * - Addition
+     - .. code-block:: clojure
+
+           (+ a b)
+     - Standard prefix arithmetic operator.
+   * - Subtraction
+     - .. code-block:: clojure
+
+           (- a b)
+     - Standard prefix arithmetic operator.
+   * - Multiplication
+     - .. code-block:: clojure
+
+           (* a b)
+     - Standard prefix arithmetic operator.
+   * - Division
+     - .. code-block:: clojure
+
+           (/ a b)
+     - Standard prefix arithmetic operator.
+   * - Remainder
+     - .. code-block:: clojure
+
+           (rem a b)
+     - Standard prefix arithmetic operator.
+   * - Equal
+     - .. code-block:: clojure
+
+           (= a b)
+     - Standard equality operator.
+   * - NotEqual
+     - .. code-block:: clojure
+
+           (not= a b)
+     - Standard inequality operator.
+   * - GreaterThan
+     - .. code-block:: clojure
+
+           (> a b)
+     - Standard greater than operator.
+   * - BitAnd
+     - .. code-block:: clojure
+
+           (bit-and a b)
+     - Standard bitwise operators.
+   * - BitOr
+     - .. code-block:: clojure
+
+           (bit-or a b)
+     - Standard bitwise operators.
+   * - BitXor
+     - .. code-block:: clojure
+
+           (bit-xor a b)
+     - Standard bitwise operators.
+   * - BitNot
+     - .. code-block:: clojure
+
+           (bit-not a)
+     - Standard bitwise operators.
+   * - LeftShift
+     - .. code-block:: clojure
+
+           (bit-shift-left a b)
+     - Standard bitwise operators.
+   * - RightShift
+     - .. code-block:: clojure
+
+           (bit-shift-right a b)
+     - Standard bitwise operators.
+   * - Floor
+     - .. code-block:: clojure
+
+           (Math/floor a)
+     - Uses Java interop for floor.
+   * - Rounding
+     - .. code-block:: clojure
+
+           (Math/round a)
+     - Uses Java interop for rounding.
+   * - Increment
+     - .. code-block:: clojure
+
+           (inc a)
+     - Standard increment function.
+   * - Decrement
+     - .. code-block:: clojure
+
+           (dec a)
+     - Standard decrement function.
+   * - SetFiltering
+     - .. code-block:: clojure
+
+           (filter #(> % 0) a)
+     - Uses the higher-order filter function with a predicate.
+   * - SetJoin
+     - .. code-block:: clojure
+
+           (clojure.set/join list-a list-b {:id :id})
+     - The clojure.set namespace provides a join function for sets of maps.
+   * - Float4VectorMultiplication
+     - .. code-block:: clojure
+
+           (mapv * a b)
+     - Applies multiplication element-wise to vectors and returns a new vector.
+   * - Float4VectorDotProduct
+     - .. code-block:: clojure
+
+           (reduce + (map * a b))
+     - Functional approach using map and reduce.
+   * - Float4VectorCrossProduct
+     - .. code-block:: clojure
+
+           [( - (* (a 1) (b 2)) (* (a 2) (b 1)))
+            ( - (* (a 2) (b 0)) (* (a 0) (b 2)))
+            ( - (* (a 0) (b 1)) (* (a 1) (b 0)))
+            0.0]
+     - Manual implementation for 3D cross product using vector indexing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Downloads
    graphql_pivot
    sparql_pivot
    overpass_turbo_pivot
+   clojure_pivot
 
 Indices and tables
 ==================

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -7726,3 +7726,235 @@ instance OverpassTurboSetJoin of SetJoin {
     syntax = "(node(area); way(area););"
     notes = "Unions and recursion (e.g., node(w)) are used to combine sets."
 }
+
+instance ClojureVar of VariableDeclaration {
+    name = "x"
+    type = "Dynamic"
+    initial_value = 42
+    syntax = "(def x 42)"
+    notes = "Global var definition; for local bindings, 'let' is used."
+}
+
+instance ClojureIfElse of IfElse {
+    condition = "(> x 0)"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "(if (> x 0) 1 0)"
+    notes = "Standard functional if-expression."
+}
+
+instance ClojureSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "(case x\n  1 1\n  2 2\n  0)"
+    notes = "The case macro dispatches on constant values."
+}
+
+instance ClojureLoop of Loop {
+    condition = "(> x 0)"
+    body = { raw "(println x)" }
+    syntax = "(while (> x 0)\n  (println x))"
+    notes = "While macro for side-effecting loops."
+}
+
+instance ClojureForLoop of ForLoop {
+    syntax = "(doseq [i (range 10)]\n  (println i))"
+    notes = "Iterates over a sequence for side effects."
+}
+
+instance ClojureFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["a", "b"]
+    return_type = "Dynamic"
+    body = { raw "(+ a b)" }
+    syntax = "(defn add [a b]\n  (+ a b))"
+    notes = "Standard function definition; the last expression is returned."
+}
+
+instance ClojureProcedure of ProcedureDefinition {
+    name = "log-message"
+    parameters = ["msg"]
+    body = { call println(msg) }
+    syntax = "(defn log-message [msg]\n  (println msg))"
+    notes = "Procedures are functions that typically return nil."
+}
+
+instance ClojureTryCatch of TryCatch {
+    try_body = { raw "(do-something)" }
+    exception_type = "Exception"
+    error_variable = "e"
+    catch_body = { raw "(handle e)" }
+    syntax = "(try\n  (do-something)\n  (catch Exception e\n    (handle e)))"
+    notes = "Standard exception handling using try-catch blocks."
+}
+
+instance ClojureRaise of Raise {
+    exception_type = "Exception"
+    message = "Error"
+    syntax = "(throw (Exception. \"Error\"))"
+    notes = "Uses 'throw' to raise an exception object."
+}
+
+instance ClojureThread of Thread {
+    body = { raw "(do-work)" }
+    syntax = "(future (do-work))"
+    notes = "The future macro runs code in another thread and returns a handle to the result."
+}
+
+instance ClojureSendMessage of SendMessage {
+    recipient = "a"
+    message = "42"
+    syntax = "(send a + 42)"
+    notes = "Asynchronous message passing using agents."
+}
+
+instance ClojureReceiveMessage of ReceiveMessage {
+    match_pattern = "msg"
+    body = { call handle(msg) }
+    syntax = "(let [msg @c] (handle msg))"
+    notes = "Dereferencing a promise or future (using @) blocks until the value is available."
+}
+
+instance ClojureSingleLineComment of SingleLineComment {
+    syntax = "; comment"
+    notes = "Standard Clojure single-line comment."
+}
+
+instance ClojureMultiLineComment of MultiLineComment {
+    syntax = "(comment\n  line 1\n  line 2)"
+    notes = "The comment macro is used for multi-line blocks; they are treated as code that returns nil."
+}
+
+instance ClojurePrint of Print {
+    value = "Hello, World!"
+    syntax = "(println \"Hello, World!\")"
+    notes = "Prints to stdout with a newline."
+}
+
+instance ClojureImport of Import {
+    module_name = "clojure.string"
+    syntax = "(:require [clojure.string :as str])"
+    notes = "Imports a namespace; usually within an ns macro."
+}
+
+instance ClojureConstant of Constant {
+    name = "MAX"
+    type = "int"
+    value = "100"
+    syntax = "(def ^:const MAX 100)"
+    notes = "Defines a constant value."
+}
+
+instance ClojureAddition of Addition {
+    syntax = "(+ a b)"
+    notes = "Standard prefix arithmetic operator."
+}
+
+instance ClojureSubtraction of Subtraction {
+    syntax = "(- a b)"
+    notes = "Standard prefix arithmetic operator."
+}
+
+instance ClojureMultiplication of Multiplication {
+    syntax = "(* a b)"
+    notes = "Standard prefix arithmetic operator."
+}
+
+instance ClojureDivision of Division {
+    syntax = "(/ a b)"
+    notes = "Standard prefix arithmetic operator."
+}
+
+instance ClojureRemainder of Remainder {
+    syntax = "(rem a b)"
+    notes = "Standard prefix arithmetic operator."
+}
+
+instance ClojureEqual of Equal {
+    syntax = "(= a b)"
+    notes = "Standard equality operator."
+}
+
+instance ClojureNotEqual of NotEqual {
+    syntax = "(not= a b)"
+    notes = "Standard inequality operator."
+}
+
+instance ClojureGreaterThan of GreaterThan {
+    syntax = "(> a b)"
+    notes = "Standard greater than operator."
+}
+
+instance ClojureBitAnd of BitAnd {
+    syntax = "(bit-and a b)"
+    notes = "Standard bitwise operators."
+}
+
+instance ClojureBitOr of BitOr {
+    syntax = "(bit-or a b)"
+    notes = "Standard bitwise operators."
+}
+
+instance ClojureBitXor of BitXor {
+    syntax = "(bit-xor a b)"
+    notes = "Standard bitwise operators."
+}
+
+instance ClojureBitNot of BitNot {
+    syntax = "(bit-not a)"
+    notes = "Standard bitwise operators."
+}
+
+instance ClojureLeftShift of LeftShift {
+    syntax = "(bit-shift-left a b)"
+    notes = "Standard bitwise operators."
+}
+
+instance ClojureRightShift of RightShift {
+    syntax = "(bit-shift-right a b)"
+    notes = "Standard bitwise operators."
+}
+
+instance ClojureFloor of Floor {
+    syntax = "(Math/floor a)"
+    notes = "Uses Java interop for floor."
+}
+
+instance ClojureRounding of Rounding {
+    syntax = "(Math/round a)"
+    notes = "Uses Java interop for rounding."
+}
+
+instance ClojureIncrement of Increment {
+    syntax = "(inc a)"
+    notes = "Standard increment function."
+}
+
+instance ClojureDecrement of Decrement {
+    syntax = "(dec a)"
+    notes = "Standard decrement function."
+}
+
+instance ClojureSetFiltering of SetFiltering {
+    syntax = "(filter #(> % 0) a)"
+    notes = "Uses the higher-order filter function with a predicate."
+}
+
+instance ClojureSetJoin of SetJoin {
+    syntax = "(clojure.set/join list-a list-b {:id :id})"
+    notes = "The clojure.set namespace provides a join function for sets of maps."
+}
+
+instance ClojureFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "(mapv * a b)"
+    notes = "Applies multiplication element-wise to vectors and returns a new vector."
+}
+
+instance ClojureFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "(reduce + (map * a b))"
+    notes = "Functional approach using map and reduce."
+}
+
+instance ClojureFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "[( - (* (a 1) (b 2)) (* (a 2) (b 1)))\n ( - (* (a 2) (b 0)) (* (a 0) (b 2)))\n ( - (* (a 0) (b 1)) (* (a 1) (b 0)))\n 0.0]"
+    notes = "Manual implementation for 3D cross product using vector indexing."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -62,7 +62,7 @@ class CodeGenerator:
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
-        "GraphQL", "SPARQL", "Overpass Turbo"
+        "GraphQL", "SPARQL", "Overpass Turbo", "Clojure"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
@@ -104,6 +104,7 @@ class CodeGenerator:
         "CSharp": "csharp",
         "Swift": "swift",
         "Kotlin": "kotlin",
+        "Clojure": "clojure",
         "GraphQL": "graphql",
         "SPARQL": "sparql",
         "Overpass Turbo": "text",


### PR DESCRIPTION
This submission adds support for the Clojure programming language. 
It includes:
- Implementations for all 40 programming patterns in `patterns/programming.patterns`.
- Updates to `src/generator.py` to register Clojure and its Pygments lexer.
- Addition of Clojure to `DESIGN.md` and `SYNTAX.md`.
- Generation of the Clojure pivot page (`docs/clojure_pivot.rst`) and its inclusion in `docs/index.rst`.
- Updates to `.github/workflows/pages.yml` and `.readthedocs.yaml` to include Clojure in automated matrix generation.
All tests passed.

Fixes #289

---
*PR created automatically by Jules for task [693447434830062695](https://jules.google.com/task/693447434830062695) started by @chatelao*