### PR TITLE
Add Clojure support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
           echo "" >> docs/matrices.rst
           echo "Programming Languages" >> docs/matrices.rst
           echo "---------------------" >> docs/matrices.rst
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --pivot-matrix >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --pivot-matrix >> docs/matrices.rst
           echo "" >> docs/matrices.rst
           echo "Data Formats" >> docs/matrices.rst
           echo "------------" >> docs/matrices.rst
@@ -46,10 +46,10 @@ jobs:
           # Sphinx expects these files to be in the source tree during build
           # By convention, we put them in docs/
           # CSV
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --csv > docs/programming_matrix.csv
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
           # Excel
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --excel -o docs/programming_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
       - name: Build Documentation

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,17 +13,17 @@ build:
       - echo "" >> docs/matrices.rst
       - echo "Programming Languages" >> docs/matrices.rst
       - echo "---------------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --pivot-matrix >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --pivot-matrix >> docs/matrices.rst
       - echo "" >> docs/matrices.rst
       - echo "Data Formats" >> docs/matrices.rst
       - echo "------------" >> docs/matrices.rst
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
       # Generate Downloadable Matrices for Sphinx :download: role
       # CSV
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --csv > docs/programming_matrix.csv
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --csv > docs/programming_matrix.csv
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
       # Excel
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo" --excel -o docs/programming_matrix.xlsx
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --excel -o docs/programming_matrix.xlsx
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
 python:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -179,3 +179,4 @@
 - [x] Generate Pivot Chapter for C#
 - [x] Generate Pivot Chapter for Swift
 - [x] Generate Pivot Chapter for Kotlin
+- [x] Generate Pivot Chapter for Clojure

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -40,6 +40,7 @@ The transpiler maintains a mapping between internal instance names and Pygments-
 | C#            | `csharp`       |
 | Swift         | `swift`        |
 | Kotlin        | `kotlin`       |
+| Clojure       | `clojure`      |
 | JSON          | `json`         |
 | XML           | `xml`          |
 | YAML          | `yaml`         |

--- a/docs/clojure_pivot.rst
+++ b/docs/clojure_pivot.rst
@@ -1,0 +1,238 @@
+Clojure Pivot View
+==================
+
+.. list-table:: Clojure Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: clojure
+
+           (def x 42)
+     - Variables are defined using 'def'; they are immutable by default in the sense of 'binding'.
+   * - CollectionDefinition
+     - .. code-block:: clojure
+
+           (def l [1 2 3])
+     - Vectors are the standard ordered collection in Clojure.
+   * - AssociativeArrayDefinition
+     - .. code-block:: clojure
+
+           (def m {:a 1 :b 2})
+     - Maps are used for key-value pairs.
+   * - Equal
+     - .. code-block:: clojure
+
+           (= a b)
+     - Structural equality.
+   * - NotEqual
+     - .. code-block:: clojure
+
+           (not= a b)
+     - Negated equality.
+   * - GreaterThan
+     - .. code-block:: clojure
+
+           (> a b)
+     - Standard comparison.
+   * - ProcedureDefinition
+     - .. code-block:: clojure
+
+           (defn my-proc [args]
+             (println args))
+     - Procedures in Clojure are functions that return nil.
+   * - FunctionDefinition
+     - .. code-block:: clojure
+
+           (defn my-func [x]
+             (+ x 1))
+     - Functions return the result of the last expression.
+   * - IfElse
+     - .. code-block:: clojure
+
+           (if (> x 0) 1 0)
+     - Standard if-then-else.
+   * - SwitchCase
+     - .. code-block:: clojure
+
+           (case x
+             1 "one"
+             2 "two"
+             "default")
+     - The 'case' macro provides constant-time dispatch.
+   * - Loop
+     - .. code-block:: clojure
+
+           (loop [i 0]
+             (when (< i 10)
+               (println i)
+               (recur (inc i))))
+     - The 'loop/recur' form is the standard way to perform recursion in constant stack space.
+   * - ForLoop
+     - .. code-block:: clojure
+
+           (doseq [i (range 10)]
+             (println i))
+     - The 'doseq' macro is used for side-effecting iterations.
+   * - TryCatch
+     - .. code-block:: clojure
+
+           (try
+             (/ 1 0)
+             (catch Exception e
+               (println (.getMessage e))))
+     - Clojure's error handling interops with Java's exceptions.
+   * - Raise
+     - .. code-block:: clojure
+
+           (throw (Exception. "Error"))
+     - Throws a Java exception.
+   * - Thread
+     - .. code-block:: clojure
+
+           (future (println "Hello from thread"))
+     - Futures are a simple way to run code on another thread.
+   * - SendMessage
+     - .. code-block:: clojure
+
+           (send my-agent (fn [state] (inc state)))
+     - Agents provide a way to manage asynchronous state updates.
+   * - ReceiveMessage
+     - .. code-block:: clojure
+
+           @my-agent
+     - The '@' or 'deref' function is used to get the current state of an agent or the result of a future.
+   * - SingleLineComment
+     - .. code-block:: clojure
+
+           ; comment
+     - Semicolon starts a single-line comment.
+   * - MultiLineComment
+     - .. code-block:: clojure
+
+           (comment
+             (some code))
+     - The 'comment' macro ignores its body, effectively serving as a multi-line comment.
+   * - Print
+     - .. code-block:: clojure
+
+           (println "Hello, World!")
+     - Standard output with a newline.
+   * - Import
+     - .. code-block:: clojure
+
+           (require '[clojure.string :as str])
+     - The 'require' form is used to load namespaces.
+   * - Constant
+     - .. code-block:: clojure
+
+           (def ^:const my-const 10)
+     - Constants are defined with the ^:const metadata for compiler optimization.
+   * - Addition
+     - .. code-block:: clojure
+
+           (+ a b)
+     - Prefix notation for addition.
+   * - Subtraction
+     - .. code-block:: clojure
+
+           (- a b)
+     - Prefix notation for subtraction.
+   * - Multiplication
+     - .. code-block:: clojure
+
+           (* a b)
+     - Prefix notation for multiplication.
+   * - Division
+     - .. code-block:: clojure
+
+           (/ a b)
+     - Prefix notation for division.
+   * - Remainder
+     - .. code-block:: clojure
+
+           (rem a b)
+     - Returns the remainder of division.
+   * - Floor
+     - .. code-block:: clojure
+
+           (Math/floor x)
+     - Uses Java interop for floor.
+   * - Rounding
+     - .. code-block:: clojure
+
+           (Math/round x)
+     - Uses Java interop for rounding.
+   * - Increment
+     - .. code-block:: clojure
+
+           (inc x)
+     - Increments the value by 1.
+   * - Decrement
+     - .. code-block:: clojure
+
+           (dec x)
+     - Decrements the value by 1.
+   * - LeftShift
+     - .. code-block:: clojure
+
+           (bit-shift-left x n)
+     - Bitwise left shift.
+   * - RightShift
+     - .. code-block:: clojure
+
+           (bit-shift-right x n)
+     - Bitwise right shift.
+   * - BitAnd
+     - .. code-block:: clojure
+
+           (bit-and a b)
+     - Bitwise AND.
+   * - BitOr
+     - .. code-block:: clojure
+
+           (bit-or a b)
+     - Bitwise OR.
+   * - BitXor
+     - .. code-block:: clojure
+
+           (bit-xor a b)
+     - Bitwise XOR.
+   * - BitNot
+     - .. code-block:: clojure
+
+           (bit-not x)
+     - Bitwise NOT.
+   * - Float4VectorMultiplication
+     - .. code-block:: clojure
+
+           (mapv * a b)
+     - Element-wise multiplication of vectors.
+   * - Float4VectorDotProduct
+     - .. code-block:: clojure
+
+           (reduce + (map * a b))
+     - Standard dot product implementation.
+   * - Float4VectorCrossProduct
+     - .. code-block:: clojure
+
+           (let [[ax ay az] a
+                 [bx by bz] b]
+             [(- (* ay bz) (* az by))
+              (- (* az bx) (* ax bz))
+              (- (* ax by) (* ay bx))
+              0.0])
+     - Uses destructuring and vector literal.
+   * - SetFiltering
+     - .. code-block:: clojure
+
+           (filter #(= % :val) my-set)
+     - Higher-order function for filtering.
+   * - SetJoin
+     - .. code-block:: clojure
+
+           (clojure.set/join set-a set-b)
+     - Relational join operation from the clojure.set namespace.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Downloads
    graphql_pivot
    sparql_pivot
    overpass_turbo_pivot
+   clojure_pivot
 
 Indices and tables
 ==================

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -8170,3 +8170,253 @@ instance OverpassTurboSetJoin of SetJoin {
     syntax = "(node(area); way(area););"
     notes = "Unions and recursion (e.g., node(w)) are used to combine sets."
 }
+
+
+instance ClojureVariableDeclaration of VariableDeclaration {
+    name = "x"
+    type = "Dynamic"
+    initial_value = 42
+    syntax = "(def x 42)"
+    notes = "Variables are defined using 'def'; they are immutable by default in the sense of 'binding'."
+}
+
+instance ClojureCollectionDefinition of CollectionDefinition {
+    name = "l"
+    type = "vector"
+    syntax = "(def l [1 2 3])"
+    notes = "Vectors are the standard ordered collection in Clojure."
+}
+
+instance ClojureAssociativeArrayDefinition of AssociativeArrayDefinition {
+    name = "m"
+    syntax = "(def m {:a 1 :b 2})"
+    notes = "Maps are used for key-value pairs."
+}
+
+instance ClojureEqual of Equal {
+    syntax = "(= a b)"
+    notes = "Structural equality."
+}
+
+instance ClojureNotEqual of NotEqual {
+    syntax = "(not= a b)"
+    notes = "Negated equality."
+}
+
+instance ClojureGreaterThan of GreaterThan {
+    syntax = "(> a b)"
+    notes = "Standard comparison."
+}
+
+instance ClojureProcedure of ProcedureDefinition {
+    name = "my-proc"
+    parameters = ["args"]
+    body = {
+        raw "(println args)"
+    }
+    syntax = "(defn my-proc [args]\n  (println args))"
+    notes = "Procedures in Clojure are functions that return nil."
+}
+
+instance ClojureFunction of FunctionDefinition {
+    name = "my-func"
+    parameters = ["x"]
+    return_type = "Dynamic"
+    body = {
+        raw "(+ x 1)"
+    }
+    syntax = "(defn my-func [x]\n  (+ x 1))"
+    notes = "Functions return the result of the last expression."
+}
+
+instance ClojureIfElse of IfElse {
+    condition = "(> x 0)"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "(if (> x 0) 1 0)"
+    notes = "Standard if-then-else."
+}
+
+instance ClojureSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "(case x\n  1 \"one\"\n  2 \"two\"\n  \"default\")"
+    notes = "The 'case' macro provides constant-time dispatch."
+}
+
+instance ClojureLoop of Loop {
+    condition = "(< i 10)"
+    body = { raw "(println i)" }
+    syntax = "(loop [i 0]\n  (when (< i 10)\n    (println i)\n    (recur (inc i))))"
+    notes = "The 'loop/recur' form is the standard way to perform recursion in constant stack space."
+}
+
+instance ClojureForLoop of ForLoop {
+    syntax = "(doseq [i (range 10)]\n  (println i))"
+    notes = "The 'doseq' macro is used for side-effecting iterations."
+}
+
+instance ClojureTryCatch of TryCatch {
+    try_body = { raw "(/ 1 0)" }
+    exception_type = "Exception"
+    error_variable = "e"
+    catch_body = { raw "(println (.getMessage e))" }
+    syntax = "(try\n  (/ 1 0)\n  (catch Exception e\n    (println (.getMessage e))))"
+    notes = "Clojure's error handling interops with Java's exceptions."
+}
+
+instance ClojureRaise of Raise {
+    exception_type = "Exception"
+    message = "Error"
+    syntax = "(throw (Exception. \"Error\"))"
+    notes = "Throws a Java exception."
+}
+
+instance ClojureThread of Thread {
+    body = { raw "(println \"Hello from thread\")" }
+    syntax = "(future (println \"Hello from thread\"))"
+    notes = "Futures are a simple way to run code on another thread."
+}
+
+instance ClojureSendMessage of SendMessage {
+    recipient = "my-agent"
+    message = "(inc state)"
+    syntax = "(send my-agent (fn [state] (inc state)))"
+    notes = "Agents provide a way to manage asynchronous state updates."
+}
+
+instance ClojureReceiveMessage of ReceiveMessage {
+    match_pattern = "@my-agent"
+    body = { raw "state" }
+    syntax = "@my-agent"
+    notes = "The '@' or 'deref' function is used to get the current state of an agent or the result of a future."
+}
+
+instance ClojureSingleLineComment of SingleLineComment {
+    syntax = "; comment"
+    notes = "Semicolon starts a single-line comment."
+}
+
+instance ClojureMultiLineComment of MultiLineComment {
+    syntax = "(comment\n  (some code))"
+    notes = "The 'comment' macro ignores its body, effectively serving as a multi-line comment."
+}
+
+instance ClojurePrint of Print {
+    value = "Hello, World!"
+    syntax = "(println \"Hello, World!\")"
+    notes = "Standard output with a newline."
+}
+
+instance ClojureImport of Import {
+    module_name = "clojure.string"
+    syntax = "(require '[clojure.string :as str])"
+    notes = "The 'require' form is used to load namespaces."
+}
+
+instance ClojureConstant of Constant {
+    name = "my-const"
+    type = "Dynamic"
+    value = "10"
+    syntax = "(def ^:const my-const 10)"
+    notes = "Constants are defined with the ^:const metadata for compiler optimization."
+}
+
+instance ClojureAddition of Addition {
+    syntax = "(+ a b)"
+    notes = "Prefix notation for addition."
+}
+
+instance ClojureSubtraction of Subtraction {
+    syntax = "(- a b)"
+    notes = "Prefix notation for subtraction."
+}
+
+instance ClojureMultiplication of Multiplication {
+    syntax = "(* a b)"
+    notes = "Prefix notation for multiplication."
+}
+
+instance ClojureDivision of Division {
+    syntax = "(/ a b)"
+    notes = "Prefix notation for division."
+}
+
+instance ClojureRemainder of Remainder {
+    syntax = "(rem a b)"
+    notes = "Returns the remainder of division."
+}
+
+instance ClojureFloor of Floor {
+    syntax = "(Math/floor x)"
+    notes = "Uses Java interop for floor."
+}
+
+instance ClojureRounding of Rounding {
+    syntax = "(Math/round x)"
+    notes = "Uses Java interop for rounding."
+}
+
+instance ClojureIncrement of Increment {
+    syntax = "(inc x)"
+    notes = "Increments the value by 1."
+}
+
+instance ClojureDecrement of Decrement {
+    syntax = "(dec x)"
+    notes = "Decrements the value by 1."
+}
+
+instance ClojureLeftShift of LeftShift {
+    syntax = "(bit-shift-left x n)"
+    notes = "Bitwise left shift."
+}
+
+instance ClojureRightShift of RightShift {
+    syntax = "(bit-shift-right x n)"
+    notes = "Bitwise right shift."
+}
+
+instance ClojureBitAnd of BitAnd {
+    syntax = "(bit-and a b)"
+    notes = "Bitwise AND."
+}
+
+instance ClojureBitOr of BitOr {
+    syntax = "(bit-or a b)"
+    notes = "Bitwise OR."
+}
+
+instance ClojureBitXor of BitXor {
+    syntax = "(bit-xor a b)"
+    notes = "Bitwise XOR."
+}
+
+instance ClojureBitNot of BitNot {
+    syntax = "(bit-not x)"
+    notes = "Bitwise NOT."
+}
+
+instance ClojureFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "(mapv * a b)"
+    notes = "Element-wise multiplication of vectors."
+}
+
+instance ClojureFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "(reduce + (map * a b))"
+    notes = "Standard dot product implementation."
+}
+
+instance ClojureFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "(let [[ax ay az] a\n      [bx by bz] b]\n  [(- (* ay bz) (* az by))\n   (- (* az bx) (* ax bz))\n   (- (* ax by) (* ay bx))\n   0.0])"
+    notes = "Uses destructuring and vector literal."
+}
+
+instance ClojureSetFiltering of SetFiltering {
+    syntax = "(filter #(= % :val) my-set)"
+    notes = "Higher-order function for filtering."
+}
+
+instance ClojureSetJoin of SetJoin {
+    syntax = "(clojure.set/join set-a set-b)"
+    notes = "Relational join operation from the clojure.set namespace."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -62,7 +62,7 @@ class CodeGenerator:
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
-        "GraphQL", "SPARQL", "Overpass Turbo"
+        "GraphQL", "SPARQL", "Overpass Turbo", "Clojure"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
@@ -107,6 +107,7 @@ class CodeGenerator:
         "GraphQL": "graphql",
         "SPARQL": "sparql",
         "Overpass Turbo": "text",
+        "Clojure": "clojure",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",


### PR DESCRIPTION
This PR adds comprehensive support for Clojure as a documented programming language. It includes:
- Syntax implementations for all patterns (variables, collections, control flow, functions, error handling, concurrency, and arithmetic).
- Registration of the `clojure` Pygments lexer for syntax highlighting.
- Integration into the documentation `index.rst`, comparison matrices, and automated build workflows.
- A new Clojure pivot chapter.

Fixes #291

---
*PR created automatically by Jules for task [15637619688847533491](https://jules.google.com/task/15637619688847533491) started by @chatelao*