### PR TITLE
Add Data Query category and reclassify relevant languages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,11 @@ jobs:
           echo "" >> docs/matrices.rst
           echo "Programming Languages" >> docs/matrices.rst
           echo "---------------------" >> docs/matrices.rst
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --pivot-matrix >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --pivot-matrix >> docs/matrices.rst
+          echo "" >> docs/matrices.rst
+          echo "Data Query Languages" >> docs/matrices.rst
+          echo "--------------------" >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --pivot-matrix >> docs/matrices.rst
           echo "" >> docs/matrices.rst
           echo "Data Formats" >> docs/matrices.rst
           echo "------------" >> docs/matrices.rst
@@ -46,10 +50,12 @@ jobs:
           # Sphinx expects these files to be in the source tree during build
           # By convention, we put them in docs/
           # CSV
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --csv > docs/data_query_matrix.csv
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
           # Excel
-          python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --excel -o docs/data_query_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
       - name: Build Documentation

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,17 +13,23 @@ build:
       - echo "" >> docs/matrices.rst
       - echo "Programming Languages" >> docs/matrices.rst
       - echo "---------------------" >> docs/matrices.rst
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --pivot-matrix >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --pivot-matrix >> docs/matrices.rst
+      - echo "" >> docs/matrices.rst
+      - echo "Data Query Languages" >> docs/matrices.rst
+      - echo "--------------------" >> docs/matrices.rst
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --pivot-matrix >> docs/matrices.rst
       - echo "" >> docs/matrices.rst
       - echo "Data Formats" >> docs/matrices.rst
       - echo "------------" >> docs/matrices.rst
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --pivot-matrix >> docs/matrices.rst
       # Generate Downloadable Matrices for Sphinx :download: role
       # CSV
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --csv > docs/programming_matrix.csv
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --csv > docs/programming_matrix.csv
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --csv > docs/data_query_matrix.csv
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
       # Excel
-      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,C,Cpp,XQuery,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,GraphQL,SPARQL,Overpass Turbo,Clojure" --excel -o docs/programming_matrix.xlsx
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --excel -o docs/programming_matrix.xlsx
+      - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --excel -o docs/data_query_matrix.xlsx
       - export PYTHONPATH=$PYTHONPATH:. && python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 
 python:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,16 +2,14 @@
 
 ## Book Structure
 
-The comparative book is divided into two main parts: Programming Languages and Data Formats.
+The comparative book is divided into three main parts: Programming Languages, Data Query Languages, and Data Formats.
 
 ### Part I: Programming Languages
 This section compares languages based on common programming patterns.
 
 **Languages:**
-- SQL
 - C
 - C++
-- XQuery
 - Java
 - Rust
 - Erlang
@@ -38,6 +36,7 @@ This section compares languages based on common programming patterns.
 - C#
 - Swift
 - Kotlin
+- Clojure
 
 **Patterns to be compared:**
 - Variable declaration
@@ -76,7 +75,20 @@ This section compares languages based on common programming patterns.
 - 4-float vector dot product
 - 4-float vector cross product
 
-### Part II: Data Formats
+### Part II: Data Query Languages
+This section compares languages specifically designed for querying data.
+
+**Languages:**
+- SQL
+- XQuery
+- GraphQL
+- SPARQL
+- Overpass Turbo
+
+**Patterns to be compared:**
+- Same as Programming Languages
+
+### Part III: Data Formats
 This section compares data structures and serialization formats.
 
 **Formats:**

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Downloads
 =========
 
 - **Programming Language Matrix:** :download:`CSV <programming_matrix.csv>` | :download:`Excel <programming_matrix.xlsx>`
+- **Data Query Matrix:** :download:`CSV <data_query_matrix.csv>` | :download:`Excel <data_query_matrix.xlsx>`
 - **Data Format Matrix:** :download:`CSV <data_formats_matrix.csv>` | :download:`Excel <data_formats_matrix.xlsx>`
 
 .. toctree::

--- a/src/generator.py
+++ b/src/generator.py
@@ -58,16 +58,19 @@ def format_value(value) -> str:
 class CodeGenerator:
     # Centralized lists of supported languages and formats
     PROGRAMMING_LANGUAGES = [
-        "SQL", "C", "Cpp", "XQuery", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
+        "C", "Cpp", "Java", "Rust", "Erlang", "Lisp", "Bash", "Cmd",
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
-        "GraphQL", "SPARQL", "Overpass Turbo", "Clojure"
+        "Clojure"
+    ]
+    DATA_QUERY = [
+        "SQL", "XQuery", "GraphQL", "SPARQL", "Overpass Turbo"
     ]
     DATA_FORMATS = [
         "JSON", "XML", "YAML", "TOML", "CSV", "Fixlength"
     ]
-    ALL_SUPPORTED = PROGRAMMING_LANGUAGES + DATA_FORMATS
+    ALL_SUPPORTED = PROGRAMMING_LANGUAGES + DATA_QUERY + DATA_FORMATS
 
     LEXER_MAP = {
         "SQL": "sql",


### PR DESCRIPTION
I have added a third category "Data Query Languages" and moved SQL, XQuery, GraphQL, SPARQL, and Overpass Turbo from the "Programming Languages" group to this new category. I have also updated the documentation (DESIGN.md, docs/index.rst) and CI/CD configurations (.github/workflows/pages.yml, .readthedocs.yaml) to ensure that the "Data Query" matrix is generated and linked correctly in both CSV and Excel formats. Additionally, I added Clojure to the Programming Languages list in DESIGN.md to match the implementation. All tests passed, and documentation generation was verified locally.

Fixes #295

---
*PR created automatically by Jules for task [2111635695731616930](https://jules.google.com/task/2111635695731616930) started by @chatelao*