### PR TITLE
Add Brainfuck support

### DIFF
--- a/docs/brainfuck_pivot.rst
+++ b/docs/brainfuck_pivot.rst
@@ -1,0 +1,53 @@
+Brainfuck Pivot View
+====================
+
+.. list-table:: Brainfuck Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - N/A
+     - Brainfuck uses an implicit array of memory cells; there are no named variables.
+   * - Loop
+     - .. code-block:: brainfuck
+
+           [ ... ]
+     - Standard Brainfuck loop: jump past ] if current cell is zero.
+   * - Increment
+     - .. code-block:: brainfuck
+
+           +
+     - Increments the byte at the data pointer.
+   * - Decrement
+     - .. code-block:: brainfuck
+
+           -
+     - Decrements the byte at the data pointer.
+   * - Print
+     - .. code-block:: brainfuck
+
+           .
+     - Outputs the byte at the data pointer as an ASCII character.
+   * - SingleLineComment
+     - .. code-block:: brainfuck
+
+           any text
+     - All characters except '><+-.,[]' are ignored and can be used as comments.
+   * - MultiLineComment
+     - .. code-block:: brainfuck
+
+           any text
+     - All characters except '><+-.,[]' are ignored and can be used as comments.
+   * - Addition
+     - .. code-block:: brainfuck
+
+           [->+<]
+     - Typically implemented by moving the value of one cell into another using a loop.
+   * - Subtraction
+     - .. code-block:: brainfuck
+
+           [->-<]
+     - Typically implemented by decrementing one cell while decrementing another in a loop.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,6 +68,7 @@ Downloads
    sparql_pivot
    overpass_turbo_pivot
    clojure_pivot
+   brainfuck_pivot
 
 Indices and tables
 ==================

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -8914,3 +8914,54 @@ instance TypeScriptLogicalXor of LogicalXor {
     syntax = "a != b"
     notes = "TypeScript uses != for logical XOR between booleans."
 }
+
+instance BrainfuckVar of VariableDeclaration {
+    name = "N/A"
+    type = "Byte"
+    initial_value = 0
+    syntax = "N/A"
+    notes = "Brainfuck uses an implicit array of memory cells; there are no named variables."
+}
+
+instance BrainfuckLoop of Loop {
+    condition = "current cell != 0"
+    body = { raw "..." }
+    syntax = "[ ... ]"
+    notes = "Standard Brainfuck loop: jump past ] if current cell is zero."
+}
+
+instance BrainfuckIncrement of Increment {
+    syntax = "+"
+    notes = "Increments the byte at the data pointer."
+}
+
+instance BrainfuckDecrement of Decrement {
+    syntax = "-"
+    notes = "Decrements the byte at the data pointer."
+}
+
+instance BrainfuckPrint of Print {
+    value = "N/A"
+    syntax = "."
+    notes = "Outputs the byte at the data pointer as an ASCII character."
+}
+
+instance BrainfuckSingleLineComment of SingleLineComment {
+    syntax = "any text"
+    notes = "All characters except '><+-.,[]' are ignored and can be used as comments."
+}
+
+instance BrainfuckMultiLineComment of MultiLineComment {
+    syntax = "any text"
+    notes = "All characters except '><+-.,[]' are ignored and can be used as comments."
+}
+
+instance BrainfuckAddition of Addition {
+    syntax = "[->+<]"
+    notes = "Typically implemented by moving the value of one cell into another using a loop."
+}
+
+instance BrainfuckSubtraction of Subtraction {
+    syntax = "[->-<]"
+    notes = "Typically implemented by decrementing one cell while decrementing another in a loop."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -62,7 +62,7 @@ class CodeGenerator:
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
-        "Clojure"
+        "Clojure", "Brainfuck"
     ]
     DATA_QUERY = [
         "SQL", "XQuery", "GraphQL", "SPARQL", "Overpass Turbo"
@@ -111,6 +111,7 @@ class CodeGenerator:
         "SPARQL": "sparql",
         "Overpass Turbo": "text",
         "Clojure": "clojure",
+        "Brainfuck": "brainfuck",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",


### PR DESCRIPTION
Integrated Brainfuck into the Bible of Babylon project. This involved updating the generator logic to recognize Brainfuck, adding implementations for various programming patterns in the Brainfuck DSL, and generating/linking the corresponding documentation. Verified the changes through the existing test suite.

Fixes #301

---
*PR created automatically by Jules for task [8643513831756025047](https://jules.google.com/task/8643513831756025047) started by @chatelao*