### PR TITLE
Enable PDF download on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+formats:
+  - pdf
+
 build:
   os: ubuntu-22.04
   tools:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'
+
+# -- Options for LaTeX output ------------------------------------------------
+
+latex_engine = 'xelatex'
 html_static_path = ['_static']
 
 html_context = {


### PR DESCRIPTION
This change enables PDF generation on Read the Docs by adding the `pdf` format to `.readthedocs.yaml`. Additionally, it configures Sphinx to use the `xelatex` engine in `docs/conf.py` to ensure robust character rendering in the output PDF.

Fixes #302

---
*PR created automatically by Jules for task [4021598407052647640](https://jules.google.com/task/4021598407052647640) started by @chatelao*