### PR TITLE
Add Scala programming language support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,3 +180,4 @@
 - [x] Generate Pivot Chapter for Swift
 - [x] Generate Pivot Chapter for Kotlin
 - [x] Generate Pivot Chapter for Clojure
+- [x] Generate Pivot Chapter for Scala

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -41,6 +41,7 @@ The transpiler maintains a mapping between internal instance names and Pygments-
 | Swift         | `swift`        |
 | Kotlin        | `kotlin`       |
 | Clojure       | `clojure`      |
+| Scala         | `scala`        |
 | JSON          | `json`         |
 | XML           | `xml`          |
 | YAML          | `yaml`         |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Downloads
    overpass_turbo_pivot
    clojure_pivot
    brainfuck_pivot
+   scala_pivot
 
 Indices and tables
 ==================

--- a/docs/scala_pivot.rst
+++ b/docs/scala_pivot.rst
@@ -1,0 +1,296 @@
+Scala Pivot View
+================
+
+.. list-table:: Scala Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: scala
+
+           var x: Int = 42
+     - Scala supports both mutable (var) and immutable (val) variables.
+   * - ForEach
+     - .. code-block:: scala
+
+           collection.foreach(item => println(item))
+     - Commonly used with functional style.
+   * - CollectionDefinition
+     - .. code-block:: scala
+
+           val list = List(1, 2, 3)
+     - Immutable List is the default collection in Scala.
+   * - AssociativeArrayDefinition
+     - .. code-block:: scala
+
+           val map = Map("a" -> 1, "b" -> 2)
+     - Uses the -> operator to create tuples for the map.
+   * - Equal
+     - .. code-block:: scala
+
+           a == b
+     - In Scala, == calls the equals method, handling nulls safely.
+   * - NotEqual
+     - .. code-block:: scala
+
+           a != b
+     - Inverse of ==.
+   * - GreaterThan
+     - .. code-block:: scala
+
+           a > b
+     - Standard comparison operator.
+   * - LogicalAnd
+     - .. code-block:: scala
+
+           a && b
+     - Short-circuiting logical AND.
+   * - LogicalOr
+     - .. code-block:: scala
+
+           a || b
+     - Short-circuiting logical OR.
+   * - LogicalXor
+     - .. code-block:: scala
+
+           a ^ b
+     - Bitwise XOR operator used for booleans as well.
+   * - ProcedureDefinition
+     - .. code-block:: scala
+
+           def log(message: String): Unit = {
+               println(message)
+           }
+     - Procedures return Unit in Scala.
+   * - FunctionDefinition
+     - .. code-block:: scala
+
+           def addOne(x: Int): Int = {
+               x + 1
+           }
+     - The last expression in a block is the return value.
+   * - IfElse
+     - .. code-block:: scala
+
+           if (x > 0) 1 else 0
+     - if-else is an expression in Scala.
+   * - SwitchCase
+     - .. code-block:: scala
+
+           x match {
+               case 1 => "one"
+               case 2 => "two"
+               case _ => "many"
+           }
+     - Pattern matching is a powerful alternative to switch-case.
+   * - Loop
+     - .. code-block:: scala
+
+           while (x > 0) {
+               x -= 1
+           }
+     - Standard while loop.
+   * - ForLoop
+     - .. code-block:: scala
+
+           for (i <- 0 until 10) {
+               println(i)
+           }
+     - The for-comprehension is used for iteration.
+   * - TryCatch
+     - .. code-block:: scala
+
+           try {
+               // code
+           } catch {
+               case e: Exception => println(e)
+           } finally {
+               // cleanup
+           }
+     - Uses pattern matching in the catch block.
+   * - Raise
+     - .. code-block:: scala
+
+           throw new RuntimeException("error")
+     - Similar to Java.
+   * - Thread
+     - .. code-block:: scala
+
+           val t = new Thread(() => {
+               println("running")
+           })
+           t.start()
+     - Uses Java's Thread class.
+   * - SendMessage
+     - .. code-block:: scala
+
+           actor ! message
+     - Idiomatic message passing using Akka or Pekko actors.
+   * - ReceiveMessage
+     - .. code-block:: scala
+
+           def receive = {
+               case message => println(message)
+           }
+     - Actors define a receive partial function.
+   * - MutexDefinition
+     - .. code-block:: scala
+
+           val lock = new AnyRef
+     - Any object can serve as a monitor.
+   * - MutexLock
+     - .. code-block:: scala
+
+           lock.synchronized {
+               // critical section
+           }
+     - The synchronized block ensures mutual exclusion.
+   * - MutexUnlock
+     - N/A
+     - Released automatically at the end of the synchronized block.
+   * - SemaphoreDefinition
+     - .. code-block:: scala
+
+           val sem = new java.util.concurrent.Semaphore(1)
+     - Uses Java's Semaphore.
+   * - SemaphoreWait
+     - .. code-block:: scala
+
+           sem.acquire()
+     - Blocks until a permit is available.
+   * - SemaphoreSignal
+     - .. code-block:: scala
+
+           sem.release()
+     - Releases a permit.
+   * - SingleLineComment
+     - .. code-block:: scala
+
+           // comment
+     - Standard C-style comment.
+   * - MultiLineComment
+     - .. code-block:: scala
+
+           /* comment */
+     - Standard C-style multi-line comment.
+   * - Print
+     - .. code-block:: scala
+
+           println("Hello World")
+     - Prints to standard output with a newline.
+   * - Import
+     - .. code-block:: scala
+
+           import scala.collection.mutable.ListBuffer
+     - Standard import statement.
+   * - Constant
+     - .. code-block:: scala
+
+           val PI = 3.14159
+     - Immutable variables (val) are used for constants.
+   * - Addition
+     - .. code-block:: scala
+
+           a + b
+     - Standard arithmetic addition.
+   * - Subtraction
+     - .. code-block:: scala
+
+           a - b
+     - Standard arithmetic subtraction.
+   * - Multiplication
+     - .. code-block:: scala
+
+           a * b
+     - Standard arithmetic multiplication.
+   * - Division
+     - .. code-block:: scala
+
+           a / b
+     - Standard arithmetic division.
+   * - Remainder
+     - .. code-block:: scala
+
+           a % b
+     - Standard remainder operator.
+   * - Floor
+     - .. code-block:: scala
+
+           math.floor(x)
+     - Uses the scala.math library.
+   * - Rounding
+     - .. code-block:: scala
+
+           math.round(x)
+     - Uses the scala.math library.
+   * - Increment
+     - .. code-block:: scala
+
+           x += 1
+     - Scala does not have ++ operator.
+   * - Decrement
+     - .. code-block:: scala
+
+           x -= 1
+     - Scala does not have -- operator.
+   * - LeftShift
+     - .. code-block:: scala
+
+           a << b
+     - Bitwise left shift.
+   * - RightShift
+     - .. code-block:: scala
+
+           a >> b
+     - Bitwise right shift.
+   * - BitAnd
+     - .. code-block:: scala
+
+           a & b
+     - Bitwise AND.
+   * - BitOr
+     - .. code-block:: scala
+
+           a | b
+     - Bitwise OR.
+   * - BitXor
+     - .. code-block:: scala
+
+           a ^ b
+     - Bitwise XOR.
+   * - BitNot
+     - .. code-block:: scala
+
+           ~a
+     - Bitwise NOT.
+   * - Float4VectorMultiplication
+     - .. code-block:: scala
+
+           for (i <- 0 until 4) c(i) = a(i) * b(i)
+     - Loops are commonly used for vector operations in basic Scala.
+   * - Float4VectorDotProduct
+     - .. code-block:: scala
+
+           (0 until 4).map(i => a(i) * b(i)).sum
+     - Functional approach using map and sum.
+   * - Float4VectorCrossProduct
+     - .. code-block:: scala
+
+           res(0) = a(1) * b(2) - a(2) * b(1)
+           res(1) = a(2) * b(0) - a(0) * b(2)
+           res(2) = a(0) * b(1) - a(1) * b(0)
+           res(3) = 0.0
+     - Standard 3D cross product implementation.
+   * - SetFiltering
+     - .. code-block:: scala
+
+           val filtered = list.filter(_ > 0)
+     - Higher-order function filter with underscore syntax.
+   * - SetJoin
+     - .. code-block:: scala
+
+           for (a <- listA; b <- listB if a.id == b.id) yield (a, b)
+     - Uses for-comprehension with a guard for joining.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -9414,3 +9414,302 @@ instance SqlMutexUnlock of MutexUnlock { syntax = "N/A" notes = "N/A" }
 instance SqlSemaphoreDefinition of SemaphoreDefinition { name = "N/A" initial_value = 0 syntax = "N/A" notes = "N/A" }
 instance SqlSemaphoreWait of SemaphoreWait { syntax = "N/A" notes = "N/A" }
 instance SqlSemaphoreSignal of SemaphoreSignal { syntax = "N/A" notes = "N/A" }
+
+
+instance ScalaVar of VariableDeclaration {
+    name = "x"
+    type = "Int"
+    initial_value = 42
+    syntax = "var x: Int = 42"
+    notes = "Scala supports both mutable (var) and immutable (val) variables."
+}
+
+instance ScalaForEach of ForEach {
+    syntax = "collection.foreach(item => println(item))"
+    notes = "Commonly used with functional style."
+}
+
+instance ScalaCollectionDefinition of CollectionDefinition {
+    name = "list"
+    type = "List[Int]"
+    syntax = "val list = List(1, 2, 3)"
+    notes = "Immutable List is the default collection in Scala."
+}
+
+instance ScalaAssociativeArrayDefinition of AssociativeArrayDefinition {
+    name = "map"
+    syntax = "val map = Map(\"a\" -> 1, \"b\" -> 2)"
+    notes = "Uses the -> operator to create tuples for the map."
+}
+
+instance ScalaEqual of Equal {
+    syntax = "a == b"
+    notes = "In Scala, == calls the equals method, handling nulls safely."
+}
+
+instance ScalaNotEqual of NotEqual {
+    syntax = "a != b"
+    notes = "Inverse of ==."
+}
+
+instance ScalaGreaterThan of GreaterThan {
+    syntax = "a > b"
+    notes = "Standard comparison operator."
+}
+
+instance ScalaLogicalAnd of LogicalAnd {
+    syntax = "a && b"
+    notes = "Short-circuiting logical AND."
+}
+
+instance ScalaLogicalOr of LogicalOr {
+    syntax = "a || b"
+    notes = "Short-circuiting logical OR."
+}
+
+instance ScalaLogicalXor of LogicalXor {
+    syntax = "a ^ b"
+    notes = "Bitwise XOR operator used for booleans as well."
+}
+
+instance ScalaProcedureDefinition of ProcedureDefinition {
+    name = "log"
+    parameters = ["message: String"]
+    body = { raw "println(message)" }
+    syntax = "def log(message: String): Unit = {\n    println(message)\n}"
+    notes = "Procedures return Unit in Scala."
+}
+
+instance ScalaFunctionDefinition of FunctionDefinition {
+    name = "addOne"
+    parameters = ["x: Int"]
+    return_type = "Int"
+    body = { return "x + 1" }
+    syntax = "def addOne(x: Int): Int = {\n    x + 1\n}"
+    notes = "The last expression in a block is the return value."
+}
+
+instance ScalaIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) 1 else 0"
+    notes = "if-else is an expression in Scala."
+}
+
+instance ScalaSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "x match {\n    case 1 => \"one\"\n    case 2 => \"two\"\n    case _ => \"many\"\n}"
+    notes = "Pattern matching is a powerful alternative to switch-case."
+}
+
+instance ScalaLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x -= 1" }
+    syntax = "while (x > 0) {\n    x -= 1\n}"
+    notes = "Standard while loop."
+}
+
+instance ScalaForLoop of ForLoop {
+    syntax = "for (i <- 0 until 10) {\n    println(i)\n}"
+    notes = "The for-comprehension is used for iteration."
+}
+
+instance ScalaTryCatch of TryCatch {
+    try_body = { raw "doSomething()" }
+    exception_type = "Exception"
+    error_variable = "e"
+    catch_body = { raw "println(e)" }
+    syntax = "try {\n    // code\n} catch {\n    case e: Exception => println(e)\n} finally {\n    // cleanup\n}"
+    notes = "Uses pattern matching in the catch block."
+}
+
+instance ScalaRaise of Raise {
+    exception_type = "RuntimeException"
+    message = "error"
+    syntax = "throw new RuntimeException(\"error\")"
+    notes = "Similar to Java."
+}
+
+instance ScalaThread of Thread {
+    body = { raw "println(\"running\")" }
+    syntax = "val t = new Thread(() => {\n    println(\"running\")\n})\nt.start()"
+    notes = "Uses Java's Thread class."
+}
+
+instance ScalaSendMessage of SendMessage {
+    recipient = "actor"
+    message = "msg"
+    syntax = "actor ! message"
+    notes = "Idiomatic message passing using Akka or Pekko actors."
+}
+
+instance ScalaReceiveMessage of ReceiveMessage {
+    match_pattern = "message"
+    body = { raw "println(message)" }
+    syntax = "def receive = {\n    case message => println(message)\n}"
+    notes = "Actors define a receive partial function."
+}
+
+instance ScalaMutexDefinition of MutexDefinition {
+    name = "lock"
+    syntax = "val lock = new AnyRef"
+    notes = "Any object can serve as a monitor."
+}
+
+instance ScalaMutexLock of MutexLock {
+    syntax = "lock.synchronized {\n    // critical section\n}"
+    notes = "The synchronized block ensures mutual exclusion."
+}
+
+instance ScalaMutexUnlock of MutexUnlock {
+    syntax = "N/A"
+    notes = "Released automatically at the end of the synchronized block."
+}
+
+instance ScalaSemaphoreDefinition of SemaphoreDefinition {
+    name = "sem"
+    initial_value = 1
+    syntax = "val sem = new java.util.concurrent.Semaphore(1)"
+    notes = "Uses Java's Semaphore."
+}
+
+instance ScalaSemaphoreWait of SemaphoreWait {
+    syntax = "sem.acquire()"
+    notes = "Blocks until a permit is available."
+}
+
+instance ScalaSemaphoreSignal of SemaphoreSignal {
+    syntax = "sem.release()"
+    notes = "Releases a permit."
+}
+
+instance ScalaSingleLineComment of SingleLineComment {
+    syntax = "// comment"
+    notes = "Standard C-style comment."
+}
+
+instance ScalaMultiLineComment of MultiLineComment {
+    syntax = "/* comment */"
+    notes = "Standard C-style multi-line comment."
+}
+
+instance ScalaPrint of Print {
+    value = "\"Hello World\""
+    syntax = "println(\"Hello World\")"
+    notes = "Prints to standard output with a newline."
+}
+
+instance ScalaImport of Import {
+    module_name = "scala.collection.mutable.ListBuffer"
+    syntax = "import scala.collection.mutable.ListBuffer"
+    notes = "Standard import statement."
+}
+
+instance ScalaConstant of Constant {
+    name = "PI"
+    type = "Double"
+    value = "3.14159"
+    syntax = "val PI = 3.14159"
+    notes = "Immutable variables (val) are used for constants."
+}
+
+instance ScalaAddition of Addition {
+    syntax = "a + b"
+    notes = "Standard arithmetic addition."
+}
+
+instance ScalaSubtraction of Subtraction {
+    syntax = "a - b"
+    notes = "Standard arithmetic subtraction."
+}
+
+instance ScalaMultiplication of Multiplication {
+    syntax = "a * b"
+    notes = "Standard arithmetic multiplication."
+}
+
+instance ScalaDivision of Division {
+    syntax = "a / b"
+    notes = "Standard arithmetic division."
+}
+
+instance ScalaRemainder of Remainder {
+    syntax = "a % b"
+    notes = "Standard remainder operator."
+}
+
+instance ScalaFloor of Floor {
+    syntax = "math.floor(x)"
+    notes = "Uses the scala.math library."
+}
+
+instance ScalaRounding of Rounding {
+    syntax = "math.round(x)"
+    notes = "Uses the scala.math library."
+}
+
+instance ScalaIncrement of Increment {
+    syntax = "x += 1"
+    notes = "Scala does not have ++ operator."
+}
+
+instance ScalaDecrement of Decrement {
+    syntax = "x -= 1"
+    notes = "Scala does not have -- operator."
+}
+
+instance ScalaLeftShift of LeftShift {
+    syntax = "a << b"
+    notes = "Bitwise left shift."
+}
+
+instance ScalaRightShift of RightShift {
+    syntax = "a >> b"
+    notes = "Bitwise right shift."
+}
+
+instance ScalaBitAnd of BitAnd {
+    syntax = "a & b"
+    notes = "Bitwise AND."
+}
+
+instance ScalaBitOr of BitOr {
+    syntax = "a | b"
+    notes = "Bitwise OR."
+}
+
+instance ScalaBitXor of BitXor {
+    syntax = "a ^ b"
+    notes = "Bitwise XOR."
+}
+
+instance ScalaBitNot of BitNot {
+    syntax = "~a"
+    notes = "Bitwise NOT."
+}
+
+instance ScalaFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "for (i <- 0 until 4) c(i) = a(i) * b(i)"
+    notes = "Loops are commonly used for vector operations in basic Scala."
+}
+
+instance ScalaFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "(0 until 4).map(i => a(i) * b(i)).sum"
+    notes = "Functional approach using map and sum."
+}
+
+instance ScalaFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "res(0) = a(1) * b(2) - a(2) * b(1)\nres(1) = a(2) * b(0) - a(0) * b(2)\nres(2) = a(0) * b(1) - a(1) * b(0)\nres(3) = 0.0"
+    notes = "Standard 3D cross product implementation."
+}
+
+instance ScalaSetFiltering of SetFiltering {
+    syntax = "val filtered = list.filter(_ > 0)"
+    notes = "Higher-order function filter with underscore syntax."
+}
+
+instance ScalaSetJoin of SetJoin {
+    syntax = "for (a <- listA; b <- listB if a.id == b.id) yield (a, b)"
+    notes = "Uses for-comprehension with a guard for joining."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -62,7 +62,7 @@ class CodeGenerator:
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
-        "Clojure", "Brainfuck"
+        "Clojure", "Brainfuck", "Scala"
     ]
     DATA_QUERY = [
         "SQL", "XQuery", "GraphQL", "SPARQL", "Overpass Turbo"
@@ -112,6 +112,7 @@ class CodeGenerator:
         "Overpass Turbo": "text",
         "Clojure": "clojure",
         "Brainfuck": "brainfuck",
+        "Scala": "scala",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",


### PR DESCRIPTION
This PR adds the Scala programming language to the "Bible of Babylon".
It includes:
- Syntax highlighting configuration for Scala.
- Comprehensive implementations for 52 common programming patterns in Scala.
- A new language-specific pivot chapter in the documentation.
- Updates to the project roadmap and syntax documentation.
All patterns have been validated and all tests pass.

Fixes #310

---
*PR created automatically by Jules for task [11766358916664378005](https://jules.google.com/task/11766358916664378005) started by @chatelao*