### PR TITLE
Add multi-line command character (LineContinuation) for Bash, Cmd, and PowerShell

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,6 +43,7 @@ This section compares languages based on common programming patterns.
 - Collection definition
 - Associative array definition
 - Control flow (if/else, loops, for loops, for-each loops)
+- Line continuation
 - Function/Procedure definition
 - Error handling
 - Concurrency models

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -113,6 +113,12 @@ pattern ForLoop {
     parameter notes: String
 }
 
+pattern LineContinuation {
+    meta description: "Character used to continue a command on the next line."
+    parameter syntax: String
+    parameter notes: String
+}
+
 instance CVar of VariableDeclaration {
     name = "x"
     type = "int"
@@ -9414,3 +9420,18 @@ instance SqlMutexUnlock of MutexUnlock { syntax = "N/A" notes = "N/A" }
 instance SqlSemaphoreDefinition of SemaphoreDefinition { name = "N/A" initial_value = 0 syntax = "N/A" notes = "N/A" }
 instance SqlSemaphoreWait of SemaphoreWait { syntax = "N/A" notes = "N/A" }
 instance SqlSemaphoreSignal of SemaphoreSignal { syntax = "N/A" notes = "N/A" }
+
+instance BashLineContinuation of LineContinuation {
+    syntax = "\\"
+    notes = "The backslash is the standard line continuation character in Bash."
+}
+
+instance CmdLineContinuation of LineContinuation {
+    syntax = "^"
+    notes = "The caret is used for line continuation in Windows Command Prompt (Cmd)."
+}
+
+instance PowerShellLineContinuation of LineContinuation {
+    syntax = "`"
+    notes = "PowerShell uses the backtick character for line continuation."
+}


### PR DESCRIPTION
I have added a new pattern called `LineContinuation` to the project. This pattern documents the characters used to continue a command across multiple lines in different shells.

Specifically, I implemented the following instances:
- **Bash**: backslash (`\`)
- **Cmd (DOS)**: caret (`^`)
- **PowerShell**: backtick (`` ` ``)

The following files were updated:
- `patterns/programming.patterns`: Added the pattern definition and three language-specific instances.
- `DESIGN.md`: Added "Line continuation" to the list of compared programming patterns.

I verified the changes by:
1. Regenerating the documentation (`docs/programming.rst`) and confirming the new pattern and its implementations are correctly displayed.
2. Running the full test suite (`pytest`), which passed all 41 tests.
3. Requesting a code review, which returned a #Correct# rating.

Fixes #312

---
*PR created automatically by Jules for task [1068464787590646930](https://jules.google.com/task/1068464787590646930) started by @chatelao*