### PR TITLE
Add Zig language support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,7 +36,7 @@ jobs:
           echo "" >> docs/matrices.rst
           echo "Programming Languages" >> docs/matrices.rst
           echo "---------------------" >> docs/matrices.rst
-          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --pivot-matrix >> docs/matrices.rst
+          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure,Zig" --pivot-matrix >> docs/matrices.rst
           echo "" >> docs/matrices.rst
           echo "Data Query Languages" >> docs/matrices.rst
           echo "--------------------" >> docs/matrices.rst
@@ -50,11 +50,11 @@ jobs:
           # Sphinx expects these files to be in the source tree during build
           # By convention, we put them in docs/
           # CSV
-          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --csv > docs/programming_matrix.csv
+          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure,Zig" --csv > docs/programming_matrix.csv
           python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --csv > docs/data_query_matrix.csv
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --csv > docs/data_formats_matrix.csv
           # Excel
-          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure" --excel -o docs/programming_matrix.xlsx
+          python3 -m src.main patterns/programming.patterns -m "C,Cpp,Java,Rust,Erlang,Lisp,Bash,Cmd,PowerShell,Python,PHP,CSS,CUDA,x86 Assembler,RISC-V Assembler,Prolog,Java Bytecode,ARM AArch64 Assembler,Camel,Go,Haskell,TypeScript,Tcl,COBOL,Fortran,CSharp,Swift,Kotlin,Clojure,Zig" --excel -o docs/programming_matrix.xlsx
           python3 -m src.main patterns/programming.patterns -m "SQL,XQuery,GraphQL,SPARQL,Overpass Turbo" --excel -o docs/data_query_matrix.xlsx
           python3 -m src.main patterns/data_formats.patterns -m "JSON,XML,YAML,TOML,CSV,Fixlength" --excel -o docs/data_formats_matrix.xlsx
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,6 +37,7 @@ This section compares languages based on common programming patterns.
 - Swift
 - Kotlin
 - Clojure
+- Zig
 
 **Patterns to be compared:**
 - Variable declaration

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -41,6 +41,7 @@ The transpiler maintains a mapping between internal instance names and Pygments-
 | Swift         | `swift`        |
 | Kotlin        | `kotlin`       |
 | Clojure       | `clojure`      |
+| Zig           | `zig`          |
 | JSON          | `json`         |
 | XML           | `xml`          |
 | YAML          | `yaml`         |

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Downloads
    overpass_turbo_pivot
    clojure_pivot
    brainfuck_pivot
+   zig_pivot
 
 Indices and tables
 ==================

--- a/docs/zig_pivot.rst
+++ b/docs/zig_pivot.rst
@@ -1,0 +1,288 @@
+Zig Pivot View
+==============
+
+.. list-table:: Zig Pivot Table
+   :widths: auto
+   :header-rows: 1
+
+   * - Pattern
+     - Syntax
+     - Notes
+   * - VariableDeclaration
+     - .. code-block:: zig
+
+           var x: i32 = 42;
+     - Variables are declared with 'var' for mutable values.
+   * - CollectionDefinition
+     - .. code-block:: zig
+
+           var a = [_]i32{1, 2, 3};
+     - Zig uses array literals with the { } syntax; [_] infers the size.
+   * - AssociativeArrayDefinition
+     - .. code-block:: zig
+
+           var map = std.AutoHashMap(i32, i32).init(allocator);
+     - Zig's standard library provides HashMap types; they require an allocator for initialization.
+   * - Equal
+     - .. code-block:: zig
+
+           a == b
+     - Standard equality operator for primitive types.
+   * - NotEqual
+     - .. code-block:: zig
+
+           a != b
+     - Standard inequality operator.
+   * - GreaterThan
+     - .. code-block:: zig
+
+           a > b
+     - Standard comparison operator.
+   * - LogicalAnd
+     - .. code-block:: zig
+
+           a and b
+     - Short-circuiting logical AND.
+   * - LogicalOr
+     - .. code-block:: zig
+
+           a or b
+     - Short-circuiting logical OR.
+   * - LogicalXor
+     - .. code-block:: zig
+
+           a != b
+     - Logical XOR is achieved using inequality for booleans.
+   * - ProcedureDefinition
+     - .. code-block:: zig
+
+           fn logMessage(msg: []const u8) void {
+               std.debug.print("{s}\n", .{msg});
+           }
+     - Procedures use the 'void' return type.
+   * - FunctionDefinition
+     - .. code-block:: zig
+
+           fn add(a: i32, b: i32) i32 {
+               return a + b;
+           }
+     - Functions return a type; 'return' is required.
+   * - IfElse
+     - .. code-block:: zig
+
+           if (x > 0) {
+               return 1;
+           } else {
+               return 0;
+           }
+     - Standard if-else statement; parentheses around the condition are required.
+   * - SwitchCase
+     - .. code-block:: zig
+
+           switch (x) {
+               1 => return 1,
+               2 => return 2,
+               else => return 0,
+           }
+     - Zig's switch is an expression and must be exhaustive.
+   * - Loop
+     - .. code-block:: zig
+
+           while (x > 0) {
+               x -= 1;
+           }
+     - Standard while loop.
+   * - ForLoop
+     - .. code-block:: zig
+
+           for (0..10) |i| {
+               // body
+           }
+     - Zig's for loop iterates over ranges or collections.
+   * - ForEach
+     - .. code-block:: zig
+
+           for (collection) |item| {
+               // body
+           }
+     - Zig uses the for loop to iterate over elements of an array or slice.
+   * - TryCatch
+     - .. code-block:: zig
+
+           doSomething() catch |err| {
+               handle(err);
+           };
+     - Zig uses error unions and the catch keyword for error handling.
+   * - Raise
+     - .. code-block:: zig
+
+           return error.BadThing;
+     - Zig uses explicit error return values from the 'error' set.
+   * - Thread
+     - .. code-block:: zig
+
+           const thread = try std.Thread.spawn(.{}, doWork, .{});
+           thread.join();
+     - Uses std.Thread.spawn to run a function in a new thread.
+   * - SendMessage
+     - N/A
+     - Zig does not have a native message-passing primitive; usually implemented via shared memory and synchronization.
+   * - ReceiveMessage
+     - N/A
+     - Not supported natively.
+   * - MutexDefinition
+     - .. code-block:: zig
+
+           var mutex = std.Thread.Mutex{};
+     - Provides mutual exclusion.
+   * - MutexLock
+     - .. code-block:: zig
+
+           mutex.lock();
+     - Acquires the lock; blocks if held.
+   * - MutexUnlock
+     - .. code-block:: zig
+
+           mutex.unlock();
+     - Releases the lock.
+   * - SemaphoreDefinition
+     - .. code-block:: zig
+
+           var sem = std.Thread.Semaphore{ .permits = 1 };
+     - Initializes a semaphore with a permit count.
+   * - SemaphoreWait
+     - .. code-block:: zig
+
+           sem.wait();
+     - Decrements the permit count; blocks if zero.
+   * - SemaphoreSignal
+     - .. code-block:: zig
+
+           sem.post();
+     - Increments the permit count.
+   * - SingleLineComment
+     - .. code-block:: zig
+
+           // comment
+     - Standard single-line comment.
+   * - MultiLineComment
+     - N/A
+     - Zig does not have multi-line comments; multiple single-line comments are used.
+   * - Print
+     - .. code-block:: zig
+
+           std.debug.print("Hello, World!\n", .{});
+     - Standard debug print; requires the std library.
+   * - Import
+     - .. code-block:: zig
+
+           const std = @import("std");
+     - The @import built-in function imports a package or file.
+   * - Constant
+     - .. code-block:: zig
+
+           const MAX: i32 = 100;
+     - Constants are declared with 'const' and are immutable.
+   * - Addition
+     - .. code-block:: zig
+
+           a + b
+     - Standard addition operator; Zig also has wrap-around addition with +%.
+   * - Subtraction
+     - .. code-block:: zig
+
+           a - b
+     - Standard subtraction operator.
+   * - Multiplication
+     - .. code-block:: zig
+
+           a * b
+     - Standard multiplication operator.
+   * - Division
+     - .. code-block:: zig
+
+           a / b
+     - Standard division operator.
+   * - Remainder
+     - .. code-block:: zig
+
+           @mod(a, b)
+     - Zig uses the @mod built-in for the remainder.
+   * - Floor
+     - .. code-block:: zig
+
+           @floor(a)
+     - Uses the @floor built-in function for floating-point values.
+   * - Rounding
+     - .. code-block:: zig
+
+           @round(a)
+     - Uses the @round built-in function for floating-point values.
+   * - Increment
+     - .. code-block:: zig
+
+           a += 1
+     - Zig does not support prefix or postfix ++ operators.
+   * - Decrement
+     - .. code-block:: zig
+
+           a -= 1
+     - Zig does not support -- operators.
+   * - LeftShift
+     - .. code-block:: zig
+
+           a << b
+     - Standard bitwise left shift.
+   * - RightShift
+     - .. code-block:: zig
+
+           a >> b
+     - Standard bitwise right shift.
+   * - BitAnd
+     - .. code-block:: zig
+
+           a & b
+     - Bitwise AND operator.
+   * - BitOr
+     - .. code-block:: zig
+
+           a | b
+     - Bitwise OR operator.
+   * - BitXor
+     - .. code-block:: zig
+
+           a ^ b
+     - Bitwise XOR operator.
+   * - BitNot
+     - .. code-block:: zig
+
+           ~a
+     - Bitwise NOT operator.
+   * - Float4VectorMultiplication
+     - .. code-block:: zig
+
+           const c = a * b;
+     - Zig supports native SIMD vector operations for @Vector types.
+   * - Float4VectorDotProduct
+     - .. code-block:: zig
+
+           const dot = @reduce(.Add, a * b);
+     - Uses @reduce with .Add on the element-wise product of vectors.
+   * - Float4VectorCrossProduct
+     - .. code-block:: zig
+
+           const c = .{ a[1]*b[2] - a[2]*b[1], a[2]*b[0] - a[0]*b[2], a[0]*b[1] - a[1]*b[0], 0.0 };
+     - Manual implementation for 3D cross product of vectors.
+   * - SetFiltering
+     - .. code-block:: zig
+
+           for (a) |item| { if (condition(item)) try res.append(item); }
+     - Typically implemented using a loop and a conditional append to a dynamic list.
+   * - SetJoin
+     - .. code-block:: zig
+
+           for (listA) |a| { for (listB) |b| { if (a.id == b.id) try res.append(.{ .a = a, .b = b }); } }
+     - Implemented using nested loops for joining collections.
+   * - LineContinuation
+     - N/A
+     - Zig treats newlines as whitespace, so explicit line continuation characters are not needed.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -9435,3 +9435,306 @@ instance PowerShellLineContinuation of LineContinuation {
     syntax = "`"
     notes = "PowerShell uses the backtick character for line continuation."
 }
+
+instance ZigVar of VariableDeclaration {
+    name = "x"
+    type = "i32"
+    initial_value = 42
+    syntax = "var x: i32 = 42;"
+    notes = "Variables are declared with 'var' for mutable values."
+}
+
+instance ZigCollectionDefinition of CollectionDefinition {
+    name = "a"
+    type = "[3]i32"
+    syntax = "var a = [_]i32{1, 2, 3};"
+    notes = "Zig uses array literals with the { } syntax; [_] infers the size."
+}
+
+instance ZigAssociativeArrayDefinition of AssociativeArrayDefinition {
+    name = "map"
+    syntax = "var map = std.AutoHashMap(i32, i32).init(allocator);"
+    notes = "Zig's standard library provides HashMap types; they require an allocator for initialization."
+}
+
+instance ZigEqual of Equal {
+    syntax = "a == b"
+    notes = "Standard equality operator for primitive types."
+}
+
+instance ZigNotEqual of NotEqual {
+    syntax = "a != b"
+    notes = "Standard inequality operator."
+}
+
+instance ZigGreaterThan of GreaterThan {
+    syntax = "a > b"
+    notes = "Standard comparison operator."
+}
+
+instance ZigLogicalAnd of LogicalAnd {
+    syntax = "a and b"
+    notes = "Short-circuiting logical AND."
+}
+
+instance ZigLogicalOr of LogicalOr {
+    syntax = "a or b"
+    notes = "Short-circuiting logical OR."
+}
+
+instance ZigLogicalXor of LogicalXor {
+    syntax = "a != b"
+    notes = "Logical XOR is achieved using inequality for booleans."
+}
+
+instance ZigProcedure of ProcedureDefinition {
+    name = "logMessage"
+    parameters = ["msg: []const u8"]
+    body = { raw "std.debug.print(\"{s}\\n\", .{msg});" }
+    syntax = "fn logMessage(msg: []const u8) void {\n    std.debug.print(\"{s}\\n\", .{msg});\n}"
+    notes = "Procedures use the 'void' return type."
+}
+
+instance ZigFunction of FunctionDefinition {
+    name = "add"
+    parameters = ["a: i32", "b: i32"]
+    return_type = "i32"
+    body = { raw "return a + b;" }
+    syntax = "fn add(a: i32, b: i32) i32 {\n    return a + b;\n}"
+    notes = "Functions return a type; 'return' is required."
+}
+
+instance ZigIfElse of IfElse {
+    condition = "x > 0"
+    then_branch = { return 1 }
+    else_branch = { return 0 }
+    syntax = "if (x > 0) {\n    return 1;\n} else {\n    return 0;\n}"
+    notes = "Standard if-else statement; parentheses around the condition are required."
+}
+
+instance ZigSwitchCase of SwitchCase {
+    expression = "x"
+    syntax = "switch (x) {\n    1 => return 1,\n    2 => return 2,\n    else => return 0,\n}"
+    notes = "Zig's switch is an expression and must be exhaustive."
+}
+
+instance ZigLoop of Loop {
+    condition = "x > 0"
+    body = { raw "x -= 1;" }
+    syntax = "while (x > 0) {\n    x -= 1;\n}"
+    notes = "Standard while loop."
+}
+
+instance ZigForLoop of ForLoop {
+    syntax = "for (0..10) |i| {\n    // body\n}"
+    notes = "Zig's for loop iterates over ranges or collections."
+}
+
+instance ZigForEach of ForEach {
+    syntax = "for (collection) |item| {\n    // body\n}"
+    notes = "Zig uses the for loop to iterate over elements of an array or slice."
+}
+
+instance ZigTryCatch of TryCatch {
+    try_body = { call doSomething() }
+    exception_type = "anyerror"
+    error_variable = "err"
+    catch_body = { call handle(err) }
+    syntax = "doSomething() catch |err| {\n    handle(err);\n};"
+    notes = "Zig uses error unions and the catch keyword for error handling."
+}
+
+instance ZigRaise of Raise {
+    exception_type = "error"
+    message = "BadThing"
+    syntax = "return error.BadThing;"
+    notes = "Zig uses explicit error return values from the 'error' set."
+}
+
+instance ZigThread of Thread {
+    body = { call doWork() }
+    syntax = "const thread = try std.Thread.spawn(.{}, doWork, .{});\nthread.join();"
+    notes = "Uses std.Thread.spawn to run a function in a new thread."
+}
+
+instance ZigSendMessage of SendMessage {
+    recipient = "N/A"
+    message = "N/A"
+    syntax = "N/A"
+    notes = "Zig does not have a native message-passing primitive; usually implemented via shared memory and synchronization."
+}
+
+instance ZigReceiveMessage of ReceiveMessage {
+    match_pattern = "N/A"
+    body = { raw "N/A" }
+    syntax = "N/A"
+    notes = "Not supported natively."
+}
+
+instance ZigMutexDefinition of MutexDefinition {
+    name = "mutex"
+    syntax = "var mutex = std.Thread.Mutex{};"
+    notes = "Provides mutual exclusion."
+}
+
+instance ZigMutexLock of MutexLock {
+    syntax = "mutex.lock();"
+    notes = "Acquires the lock; blocks if held."
+}
+
+instance ZigMutexUnlock of MutexUnlock {
+    syntax = "mutex.unlock();"
+    notes = "Releases the lock."
+}
+
+instance ZigSemaphoreDefinition of SemaphoreDefinition {
+    name = "sem"
+    initial_value = 1
+    syntax = "var sem = std.Thread.Semaphore{ .permits = 1 };"
+    notes = "Initializes a semaphore with a permit count."
+}
+
+instance ZigSemaphoreWait of SemaphoreWait {
+    syntax = "sem.wait();"
+    notes = "Decrements the permit count; blocks if zero."
+}
+
+instance ZigSemaphoreSignal of SemaphoreSignal {
+    syntax = "sem.post();"
+    notes = "Increments the permit count."
+}
+
+instance ZigSingleLineComment of SingleLineComment {
+    syntax = "// comment"
+    notes = "Standard single-line comment."
+}
+
+instance ZigMultiLineComment of MultiLineComment {
+    syntax = "N/A"
+    notes = "Zig does not have multi-line comments; multiple single-line comments are used."
+}
+
+instance ZigPrint of Print {
+    value = "Hello, World!"
+    syntax = "std.debug.print(\"Hello, World!\\n\", .{});"
+    notes = "Standard debug print; requires the std library."
+}
+
+instance ZigImport of Import {
+    module_name = "std"
+    syntax = "const std = @import(\"std\");"
+    notes = "The @import built-in function imports a package or file."
+}
+
+instance ZigConstant of Constant {
+    name = "MAX"
+    type = "i32"
+    value = "100"
+    syntax = "const MAX: i32 = 100;"
+    notes = "Constants are declared with 'const' and are immutable."
+}
+
+instance ZigAddition of Addition {
+    syntax = "a + b"
+    notes = "Standard addition operator; Zig also has wrap-around addition with +%."
+}
+
+instance ZigSubtraction of Subtraction {
+    syntax = "a - b"
+    notes = "Standard subtraction operator."
+}
+
+instance ZigMultiplication of Multiplication {
+    syntax = "a * b"
+    notes = "Standard multiplication operator."
+}
+
+instance ZigDivision of Division {
+    syntax = "a / b"
+    notes = "Standard division operator."
+}
+
+instance ZigRemainder of Remainder {
+    syntax = "@mod(a, b)"
+    notes = "Zig uses the @mod built-in for the remainder."
+}
+
+instance ZigFloor of Floor {
+    syntax = "@floor(a)"
+    notes = "Uses the @floor built-in function for floating-point values."
+}
+
+instance ZigRounding of Rounding {
+    syntax = "@round(a)"
+    notes = "Uses the @round built-in function for floating-point values."
+}
+
+instance ZigIncrement of Increment {
+    syntax = "a += 1"
+    notes = "Zig does not support prefix or postfix ++ operators."
+}
+
+instance ZigDecrement of Decrement {
+    syntax = "a -= 1"
+    notes = "Zig does not support -- operators."
+}
+
+instance ZigLeftShift of LeftShift {
+    syntax = "a << b"
+    notes = "Standard bitwise left shift."
+}
+
+instance ZigRightShift of RightShift {
+    syntax = "a >> b"
+    notes = "Standard bitwise right shift."
+}
+
+instance ZigBitAnd of BitAnd {
+    syntax = "a & b"
+    notes = "Bitwise AND operator."
+}
+
+instance ZigBitOr of BitOr {
+    syntax = "a | b"
+    notes = "Bitwise OR operator."
+}
+
+instance ZigBitXor of BitXor {
+    syntax = "a ^ b"
+    notes = "Bitwise XOR operator."
+}
+
+instance ZigBitNot of BitNot {
+    syntax = "~a"
+    notes = "Bitwise NOT operator."
+}
+
+instance ZigFloat4VectorMultiplication of Float4VectorMultiplication {
+    syntax = "const c = a * b;"
+    notes = "Zig supports native SIMD vector operations for @Vector types."
+}
+
+instance ZigFloat4VectorDotProduct of Float4VectorDotProduct {
+    syntax = "const dot = @reduce(.Add, a * b);"
+    notes = "Uses @reduce with .Add on the element-wise product of vectors."
+}
+
+instance ZigFloat4VectorCrossProduct of Float4VectorCrossProduct {
+    syntax = "const c = .{ a[1]*b[2] - a[2]*b[1], a[2]*b[0] - a[0]*b[2], a[0]*b[1] - a[1]*b[0], 0.0 };"
+    notes = "Manual implementation for 3D cross product of vectors."
+}
+
+instance ZigSetFiltering of SetFiltering {
+    syntax = "for (a) |item| { if (condition(item)) try res.append(item); }"
+    notes = "Typically implemented using a loop and a conditional append to a dynamic list."
+}
+
+instance ZigSetJoin of SetJoin {
+    syntax = "for (listA) |a| { for (listB) |b| { if (a.id == b.id) try res.append(.{ .a = a, .b = b }); } }"
+    notes = "Implemented using nested loops for joining collections."
+}
+
+instance ZigLineContinuation of LineContinuation {
+    syntax = "N/A"
+    notes = "Zig treats newlines as whitespace, so explicit line continuation characters are not needed."
+}

--- a/src/generator.py
+++ b/src/generator.py
@@ -62,7 +62,7 @@ class CodeGenerator:
         "PowerShell", "Python", "PHP", "CSS", "CUDA", "x86 Assembler", "RISC-V Assembler", "Prolog",
         "X86", "Riscv", "Java Bytecode", "OCaml", "ARM AArch64 Assembler", "Arm", "Camel",
         "Go", "Haskell", "TypeScript", "Tcl", "COBOL", "Fortran", "CSharp", "Swift", "Kotlin",
-        "Clojure", "Brainfuck"
+        "Clojure", "Brainfuck", "Zig"
     ]
     DATA_QUERY = [
         "SQL", "XQuery", "GraphQL", "SPARQL", "Overpass Turbo"
@@ -112,6 +112,7 @@ class CodeGenerator:
         "Overpass Turbo": "text",
         "Clojure": "clojure",
         "Brainfuck": "brainfuck",
+        "Zig": "zig",
         "JSON": "json",
         "XML": "xml",
         "YAML": "yaml",


### PR DESCRIPTION
This PR adds comprehensive support for the Zig programming language. It includes:
- Language configuration in `src/generator.py` with syntax highlighting support.
- Full set of pattern implementations in `patterns/programming.patterns`, covering basic syntax, control flow, functions, error handling, concurrency, and SIMD operations.
- Updated documentation including a new Zig-specific pivot chapter and updated comparison matrices.
- CI/CD integration to ensure Zig is included in future documentation builds.

Fixes #316

---
*PR created automatically by Jules for task [15255849897535470786](https://jules.google.com/task/15255849897535470786) started by @chatelao*