### PR TITLE
Add date and number formatting patterns across languages

### DIFF
--- a/docs/cpp_pivot.rst
+++ b/docs/cpp_pivot.rst
@@ -300,3 +300,13 @@ Cpp Pivot View
 
            std::set_intersection(v1.begin(), v1.end(), v2.begin(), v2.end(), std::back_inserter(res));
      - Uses set_intersection for sorted ranges; otherwise uses nested loops.
+   * - ToCharDate
+     - .. code-block:: cpp
+
+           std::strftime(buf, sizeof(buf), "%d.%m.%Y", &timeinfo);
+     - Standard C-style formatting available in C++.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: cpp
+
+           std::format("{:.2f}", num);
+     - Available in C++20 and later.

--- a/docs/csharp_pivot.rst
+++ b/docs/csharp_pivot.rst
@@ -295,3 +295,33 @@ CSharp Pivot View
 
            var res = from a in listA join b in listB on a.Id equals b.Id select new { a, b };
      - LINQ provides a native 'join' keyword.
+   * - ToCharDate
+     - .. code-block:: csharp
+
+           date.ToString("dd.MM.yyyy")
+     - Standard .NET format string.
+   * - ToCharDateTimezone
+     - .. code-block:: csharp
+
+           dt.ToString("yyyy-MM-dd HH:mm:ss K")
+     - K represents the timezone information.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: csharp
+
+           num.ToString("N0")
+     - The 'N' format specifier includes group separators.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: csharp
+
+           num.ToString("#,##0;(#,##0)")
+     - Custom format string with positive and negative sections.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: csharp
+
+           num.ToString("F2")
+     - The 'F' format specifier ensures fixed decimal places.
+   * - ToDate
+     - .. code-block:: csharp
+
+           DateTime.ParseExact(dateStr, "dd.MM.yyyy", CultureInfo.InvariantCulture)
+     - Strict parsing of the specific format.

--- a/docs/data_query.rst
+++ b/docs/data_query.rst
@@ -59,6 +59,216 @@ Parameters:
 
 
 
+ToCharDate
+----------
+
+
+:description: Formatting a date as a string (specifically DD.MM.YYYY).
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ToCharDate Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Language
+     - Syntax
+     - Notes
+   * - SqlToCharDate
+     - .. code-block:: sql
+
+           FORMAT(date_col, 'dd.MM.yyyy')
+     - T-SQL syntax using the FORMAT function.
+   * - XQueryToCharDate
+     - .. code-block:: xquery
+
+           format-date($date, '[D,2].[M,2].[Y,4]')
+     - Uses the XPath/XQuery format-date function.
+
+
+
+ToCharDateTimezone
+------------------
+
+
+:description: Formatting a date/time as a string including timezone information.
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ToCharDateTimezone Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Language
+     - Syntax
+     - Notes
+   * - SqlToCharDateTimezone
+     - .. code-block:: sql
+
+           FORMAT(datetime_col, 'yyyy-MM-dd HH:mm:ss K')
+     - T-SQL syntax; K represents the timezone offset.
+   * - XQueryToCharDateTimezone
+     - .. code-block:: xquery
+
+           format-dateTime($dt, '[Y]-[M,2]-[D,2] [H,2]:[m,2]:[s,2] [z]')
+     - Uses the format-dateTime function; [z] outputs the timezone.
+
+
+
+ToCharNumberThousandSeparator
+-----------------------------
+
+
+:description: Formatting a number with a thousands separator.
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ToCharNumberThousandSeparator Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Language
+     - Syntax
+     - Notes
+   * - SqlToCharNumberThousandSeparator
+     - .. code-block:: sql
+
+           FORMAT(num, '#,0')
+     - Formats the number with a comma as a thousands separator.
+   * - XQueryToCharNumberThousandSeparator
+     - .. code-block:: xquery
+
+           format-number($num, '#,##0')
+     - Uses the format-number function with a grouping separator.
+
+
+
+ToCharNumberNegativeBrackets
+----------------------------
+
+
+:description: Formatting a number using brackets for negative values.
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ToCharNumberNegativeBrackets Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Language
+     - Syntax
+     - Notes
+   * - SqlToCharNumberNegativeBrackets
+     - .. code-block:: sql
+
+           FORMAT(num, '#,0;(#,0)')
+     - The second part of the format string defines the layout for negative numbers.
+   * - XQueryToCharNumberNegativeBrackets
+     - .. code-block:: xquery
+
+           format-number($num, '#,##0;(#,##0)')
+     - The semicolon separates positive and negative sub-pictures.
+
+
+
+ToCharNumberFixedDecimals
+-------------------------
+
+
+:description: Formatting a number with a fixed number of decimal positions.
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ToCharNumberFixedDecimals Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Language
+     - Syntax
+     - Notes
+   * - SqlToCharNumberFixedDecimals
+     - .. code-block:: sql
+
+           FORMAT(num, 'N2')
+     - Uses standard numeric format with 2 decimal places.
+   * - XQueryToCharNumberFixedDecimals
+     - .. code-block:: xquery
+
+           format-number($num, '0.00')
+     - Ensures two decimal places are always displayed.
+
+
+
+ToDate
+------
+
+
+:description: Parsing a string (specifically in DD.MM.YYYY format) into a date object.
+
+
+Parameters:
+
+* syntax: String
+
+* notes: String
+
+
+
+.. list-table:: ToDate Comparison
+   :widths: auto
+   :header-rows: 1
+
+   * - Language
+     - Syntax
+     - Notes
+   * - SqlToDate
+     - .. code-block:: sql
+
+           CONVERT(DATE, '31.12.2023', 104)
+     - 104 is the format code for 'dd.mm.yyyy' in T-SQL.
+   * - XQueryToDate
+     - .. code-block:: xquery
+
+           xs:date(replace($str, '(\d{2})\.(\d{2})\.(\d{4})', '$3-$2-$1'))
+     - XQuery requires ISO 8601 format for xs:date; regex is used to transform dd.mm.yyyy.
+
+
+
 ForEach
 -------
 
@@ -354,57 +564,6 @@ Parameters:
    * - OverpassTurboGreaterThan
      - N/A
      - Overpass QL has limited support for numeric comparisons in some implementations.
-
-
-
-LogicalAnd
-----------
-
-
-:description: Returns true if both boolean operands are true.
-
-
-Parameters:
-
-* syntax: String
-
-* notes: String
-
-
-
-
-
-LogicalOr
----------
-
-
-:description: Returns true if at least one boolean operand is true.
-
-
-Parameters:
-
-* syntax: String
-
-* notes: String
-
-
-
-
-
-LogicalXor
-----------
-
-
-:description: Returns true if exactly one boolean operand is true.
-
-
-Parameters:
-
-* syntax: String
-
-* notes: String
-
-
 
 
 

--- a/docs/go_pivot.rst
+++ b/docs/go_pivot.rst
@@ -309,3 +309,18 @@ Go Pivot View
                }
            }
      - Standard imperative nested loop join.
+   * - ToCharDate
+     - .. code-block:: go
+
+           t.Format("02.01.2006")
+     - Go uses a unique layout-based formatting string.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: go
+
+           fmt.Sprintf("%.2f", num)
+     - Standard printf-style formatting.
+   * - ToDate
+     - .. code-block:: go
+
+           time.Parse("02.01.2006", dateStr)
+     - Parses a string using the same layout logic as Format.

--- a/docs/java_pivot.rst
+++ b/docs/java_pivot.rst
@@ -297,3 +297,34 @@ Java Pivot View
 
            listA.stream().flatMap(a -> listB.stream().filter(b -> a.id == b.id).map(b -> new Result(a, b))).collect(Collectors.toList());
      - Can be implemented using flatMap and filter on streams.
+   * - ToCharDate
+     - .. code-block:: java
+
+           date.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+     - Uses the modern java.time API.
+   * - ToCharDateTimezone
+     - .. code-block:: java
+
+           dt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"))
+     - z provides the timezone name.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: java
+
+           NumberFormat.getInstance().format(num)
+     - Uses locale-specific formatting.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: java
+
+           DecimalFormat df = new DecimalFormat("#,##0;(#,##0)");
+           df.format(num);
+     - DecimalFormat supports positive and negative patterns separated by a semicolon.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: java
+
+           String.format("%.2f", num)
+     - Standard string formatting to 2 decimal places.
+   * - ToDate
+     - .. code-block:: java
+
+           LocalDate.parse(dateStr, DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+     - Parses a string directly into a LocalDate object.

--- a/docs/php_pivot.rst
+++ b/docs/php_pivot.rst
@@ -285,3 +285,33 @@ PHP Pivot View
 
            sem_release($sem)
      - N/A
+   * - ToCharDate
+     - .. code-block:: php
+
+           $date->format('d.m.Y')
+     - Using the DateTime object's format method.
+   * - ToCharDateTimezone
+     - .. code-block:: php
+
+           $date->format('Y-m-d H:i:s T')
+     - T provides the timezone abbreviation.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: php
+
+           number_format($num, 0, '.', ',')
+     - Standard function for numeric formatting.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: php
+
+           $num < 0 ? '(' . number_format(abs($num)) . ')' : number_format($num)
+     - Manual formatting for brackets.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: php
+
+           number_format($num, 2)
+     - Formats to 2 decimal places.
+   * - ToDate
+     - .. code-block:: php
+
+           DateTime::createFromFormat('d.m.Y', $dateStr)
+     - Static method to parse specific formats.

--- a/docs/python_pivot.rst
+++ b/docs/python_pivot.rst
@@ -267,3 +267,33 @@ Python Pivot View
 
            res = [{**a, **b} for a in list_a for b in list_b if a['id'] == b['id']]
      - Uses nested list comprehensions.
+   * - ToCharDate
+     - .. code-block:: python
+
+           date_obj.strftime('%d.%m.%Y')
+     - Standard strftime formatting.
+   * - ToCharDateTimezone
+     - .. code-block:: python
+
+           dt_obj.strftime('%Y-%m-%d %H:%M:%S %Z')
+     - %Z provides the timezone name; %z provides the offset.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: python
+
+           f'{num:,}'
+     - Uses f-string formatting with a comma as the separator.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: python
+
+           f'({-num:,})' if num < 0 else f'{num:,}'
+     - Python requires conditional logic or a custom locale-aware formatter for brackets.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: python
+
+           f'{num:.2f}'
+     - Formats to exactly 2 decimal places.
+   * - ToDate
+     - .. code-block:: python
+
+           datetime.strptime(date_str, '%d.%m.%Y').date()
+     - Parses a string into a datetime object and extracts the date.

--- a/docs/rust_pivot.rst
+++ b/docs/rust_pivot.rst
@@ -293,3 +293,23 @@ Rust Pivot View
 
            list_a.iter().flat_map(|a| list_b.iter().filter(move |b| a.id == b.id).map(move |b| (a, b)));
      - Implemented using flat_map and filter.
+   * - ToCharDate
+     - .. code-block:: rust
+
+           date.format("%d.%m.%Y").to_string()
+     - Requires the chrono crate.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: rust
+
+           num.to_formatted_string(&Locale::en)
+     - Requires the num-format crate.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: rust
+
+           format!("{:.2}", num)
+     - Standard macro for string formatting.
+   * - ToDate
+     - .. code-block:: rust
+
+           NaiveDate::parse_from_str(date_str, "%d.%m.%Y")
+     - Requires the chrono crate.

--- a/docs/sql_pivot.rst
+++ b/docs/sql_pivot.rst
@@ -262,3 +262,33 @@ SQL Pivot View
    * - SemaphoreSignal
      - N/A
      - N/A
+   * - ToCharDate
+     - .. code-block:: sql
+
+           FORMAT(date_col, 'dd.MM.yyyy')
+     - T-SQL syntax using the FORMAT function.
+   * - ToCharDateTimezone
+     - .. code-block:: sql
+
+           FORMAT(datetime_col, 'yyyy-MM-dd HH:mm:ss K')
+     - T-SQL syntax; K represents the timezone offset.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: sql
+
+           FORMAT(num, '#,0')
+     - Formats the number with a comma as a thousands separator.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: sql
+
+           FORMAT(num, '#,0;(#,0)')
+     - The second part of the format string defines the layout for negative numbers.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: sql
+
+           FORMAT(num, 'N2')
+     - Uses standard numeric format with 2 decimal places.
+   * - ToDate
+     - .. code-block:: sql
+
+           CONVERT(DATE, '31.12.2023', 104)
+     - 104 is the format code for 'dd.mm.yyyy' in T-SQL.

--- a/docs/typescript_pivot.rst
+++ b/docs/typescript_pivot.rst
@@ -269,3 +269,34 @@ TypeScript Pivot View
 
            const res = a.flatMap(x => b.filter(y => x.id === y.id).map(y => ({...x, ...y})));
      - Uses flatMap and filter for a functional approach.
+   * - ToCharDate
+     - .. code-block:: typescript
+
+           date.toLocaleDateString('de-DE')
+     - German locale uses the dd.mm.yyyy format.
+   * - ToCharDateTimezone
+     - .. code-block:: typescript
+
+           date.toISOString()
+     - Outputs a string in ISO 8601 format including UTC 'Z'.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: typescript
+
+           num.toLocaleString()
+     - Uses locale-specific separators.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: typescript
+
+           new Intl.NumberFormat('en-US', { currencySign: 'accounting', style: 'currency', currency: 'USD' }).format(num)
+     - Accounting style uses brackets for negative values.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: typescript
+
+           num.toFixed(2)
+     - Formats to exactly 2 decimal places.
+   * - ToDate
+     - .. code-block:: typescript
+
+           const [d, m, y] = str.split('.');
+           new Date(`${y}-${m}-${d}`);
+     - Manual parsing is often needed as Date.parse is implementation-dependent for non-ISO formats.

--- a/docs/xquery_pivot.rst
+++ b/docs/xquery_pivot.rst
@@ -219,3 +219,33 @@ XQuery Pivot View
            where $a/id = $b/id
            return <res>{$a, $b}</res>
      - Join is performed using multiple 'for' clauses and a 'where' filter.
+   * - ToCharDate
+     - .. code-block:: xquery
+
+           format-date($date, '[D,2].[M,2].[Y,4]')
+     - Uses the XPath/XQuery format-date function.
+   * - ToCharDateTimezone
+     - .. code-block:: xquery
+
+           format-dateTime($dt, '[Y]-[M,2]-[D,2] [H,2]:[m,2]:[s,2] [z]')
+     - Uses the format-dateTime function; [z] outputs the timezone.
+   * - ToCharNumberThousandSeparator
+     - .. code-block:: xquery
+
+           format-number($num, '#,##0')
+     - Uses the format-number function with a grouping separator.
+   * - ToCharNumberNegativeBrackets
+     - .. code-block:: xquery
+
+           format-number($num, '#,##0;(#,##0)')
+     - The semicolon separates positive and negative sub-pictures.
+   * - ToCharNumberFixedDecimals
+     - .. code-block:: xquery
+
+           format-number($num, '0.00')
+     - Ensures two decimal places are always displayed.
+   * - ToDate
+     - .. code-block:: xquery
+
+           xs:date(replace($str, '(\d{2})\.(\d{2})\.(\d{4})', '$3-$2-$1'))
+     - XQuery requires ISO 8601 format for xs:date; regex is used to transform dd.mm.yyyy.

--- a/patterns/programming.patterns
+++ b/patterns/programming.patterns
@@ -7,6 +7,42 @@ pattern VariableDeclaration {
     parameter notes: String
 }
 
+pattern ToCharDate {
+    meta description: "Formatting a date as a string (specifically DD.MM.YYYY)."
+    parameter syntax: String
+    parameter notes: String
+}
+
+pattern ToCharDateTimezone {
+    meta description: "Formatting a date/time as a string including timezone information."
+    parameter syntax: String
+    parameter notes: String
+}
+
+pattern ToCharNumberThousandSeparator {
+    meta description: "Formatting a number with a thousands separator."
+    parameter syntax: String
+    parameter notes: String
+}
+
+pattern ToCharNumberNegativeBrackets {
+    meta description: "Formatting a number using brackets for negative values."
+    parameter syntax: String
+    parameter notes: String
+}
+
+pattern ToCharNumberFixedDecimals {
+    meta description: "Formatting a number with a fixed number of decimal positions."
+    parameter syntax: String
+    parameter notes: String
+}
+
+pattern ToDate {
+    meta description: "Parsing a string (specifically in DD.MM.YYYY format) into a date object."
+    parameter syntax: String
+    parameter notes: String
+}
+
 pattern ForEach {
     meta description: "Iterating over the elements of a collection."
     parameter syntax: String
@@ -10040,4 +10076,260 @@ instance ScalaSemaphoreWait of SemaphoreWait {
 instance ScalaSemaphoreSignal of SemaphoreSignal {
     syntax = "sem.release()"
     notes = "Increments the permit count."
+}
+
+instance SqlToCharDate of ToCharDate {
+    syntax = "FORMAT(date_col, 'dd.MM.yyyy')"
+    notes = "T-SQL syntax using the FORMAT function."
+}
+
+instance SqlToCharDateTimezone of ToCharDateTimezone {
+    syntax = "FORMAT(datetime_col, 'yyyy-MM-dd HH:mm:ss K')"
+    notes = "T-SQL syntax; K represents the timezone offset."
+}
+
+instance SqlToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "FORMAT(num, '#,0')"
+    notes = "Formats the number with a comma as a thousands separator."
+}
+
+instance SqlToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "FORMAT(num, '#,0;(#,0)')"
+    notes = "The second part of the format string defines the layout for negative numbers."
+}
+
+instance SqlToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "FORMAT(num, 'N2')"
+    notes = "Uses standard numeric format with 2 decimal places."
+}
+
+instance SqlToDate of ToDate {
+    syntax = "CONVERT(DATE, '31.12.2023', 104)"
+    notes = "104 is the format code for 'dd.mm.yyyy' in T-SQL."
+}
+
+instance XQueryToCharDate of ToCharDate {
+    syntax = "format-date($date, '[D,2].[M,2].[Y,4]')"
+    notes = "Uses the XPath/XQuery format-date function."
+}
+
+instance XQueryToCharDateTimezone of ToCharDateTimezone {
+    syntax = "format-dateTime($dt, '[Y]-[M,2]-[D,2] [H,2]:[m,2]:[s,2] [z]')"
+    notes = "Uses the format-dateTime function; [z] outputs the timezone."
+}
+
+instance XQueryToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "format-number($num, '#,##0')"
+    notes = "Uses the format-number function with a grouping separator."
+}
+
+instance XQueryToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "format-number($num, '#,##0;(#,##0)')"
+    notes = "The semicolon separates positive and negative sub-pictures."
+}
+
+instance XQueryToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "format-number($num, '0.00')"
+    notes = "Ensures two decimal places are always displayed."
+}
+
+instance XQueryToDate of ToDate {
+    syntax = "xs:date(replace($str, '(\\d{2})\\.(\\d{2})\\.(\\d{4})', '$3-$2-$1'))"
+    notes = "XQuery requires ISO 8601 format for xs:date; regex is used to transform dd.mm.yyyy."
+}
+
+instance PythonToCharDate of ToCharDate {
+    syntax = "date_obj.strftime('%d.%m.%Y')"
+    notes = "Standard strftime formatting."
+}
+
+instance PythonToCharDateTimezone of ToCharDateTimezone {
+    syntax = "dt_obj.strftime('%Y-%m-%d %H:%M:%S %Z')"
+    notes = "%Z provides the timezone name; %z provides the offset."
+}
+
+instance PythonToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "f'{num:,}'"
+    notes = "Uses f-string formatting with a comma as the separator."
+}
+
+instance PythonToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "f'({-num:,})' if num < 0 else f'{num:,}'"
+    notes = "Python requires conditional logic or a custom locale-aware formatter for brackets."
+}
+
+instance PythonToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "f'{num:.2f}'"
+    notes = "Formats to exactly 2 decimal places."
+}
+
+instance PythonToDate of ToDate {
+    syntax = "datetime.strptime(date_str, '%d.%m.%Y').date()"
+    notes = "Parses a string into a datetime object and extracts the date."
+}
+
+instance JavaToCharDate of ToCharDate {
+    syntax = "date.format(DateTimeFormatter.ofPattern(\"dd.MM.yyyy\"))"
+    notes = "Uses the modern java.time API."
+}
+
+instance JavaToCharDateTimezone of ToCharDateTimezone {
+    syntax = "dt.format(DateTimeFormatter.ofPattern(\"yyyy-MM-dd HH:mm:ss z\"))"
+    notes = "z provides the timezone name."
+}
+
+instance JavaToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "NumberFormat.getInstance().format(num)"
+    notes = "Uses locale-specific formatting."
+}
+
+instance JavaToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "DecimalFormat df = new DecimalFormat(\"#,##0;(#,##0)\");\ndf.format(num);"
+    notes = "DecimalFormat supports positive and negative patterns separated by a semicolon."
+}
+
+instance JavaToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "String.format(\"%.2f\", num)"
+    notes = "Standard string formatting to 2 decimal places."
+}
+
+instance JavaToDate of ToDate {
+    syntax = "LocalDate.parse(dateStr, DateTimeFormatter.ofPattern(\"dd.MM.yyyy\"))"
+    notes = "Parses a string directly into a LocalDate object."
+}
+
+instance PhpToCharDate of ToCharDate {
+    syntax = "$date->format('d.m.Y')"
+    notes = "Using the DateTime object's format method."
+}
+
+instance PhpToCharDateTimezone of ToCharDateTimezone {
+    syntax = "$date->format('Y-m-d H:i:s T')"
+    notes = "T provides the timezone abbreviation."
+}
+
+instance PhpToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "number_format($num, 0, '.', ',')"
+    notes = "Standard function for numeric formatting."
+}
+
+instance PhpToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "$num < 0 ? '(' . number_format(abs($num)) . ')' : number_format($num)"
+    notes = "Manual formatting for brackets."
+}
+
+instance PhpToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "number_format($num, 2)"
+    notes = "Formats to 2 decimal places."
+}
+
+instance PhpToDate of ToDate {
+    syntax = "DateTime::createFromFormat('d.m.Y', $dateStr)"
+    notes = "Static method to parse specific formats."
+}
+
+instance CSharpToCharDate of ToCharDate {
+    syntax = "date.ToString(\"dd.MM.yyyy\")"
+    notes = "Standard .NET format string."
+}
+
+instance CSharpToCharDateTimezone of ToCharDateTimezone {
+    syntax = "dt.ToString(\"yyyy-MM-dd HH:mm:ss K\")"
+    notes = "K represents the timezone information."
+}
+
+instance CSharpToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "num.ToString(\"N0\")"
+    notes = "The 'N' format specifier includes group separators."
+}
+
+instance CSharpToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "num.ToString(\"#,##0;(#,##0)\")"
+    notes = "Custom format string with positive and negative sections."
+}
+
+instance CSharpToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "num.ToString(\"F2\")"
+    notes = "The 'F' format specifier ensures fixed decimal places."
+}
+
+instance CSharpToDate of ToDate {
+    syntax = "DateTime.ParseExact(dateStr, \"dd.MM.yyyy\", CultureInfo.InvariantCulture)"
+    notes = "Strict parsing of the specific format."
+}
+
+instance TypeScriptToCharDate of ToCharDate {
+    syntax = "date.toLocaleDateString('de-DE')"
+    notes = "German locale uses the dd.mm.yyyy format."
+}
+
+instance TypeScriptToCharDateTimezone of ToCharDateTimezone {
+    syntax = "date.toISOString()"
+    notes = "Outputs a string in ISO 8601 format including UTC 'Z'."
+}
+
+instance TypeScriptToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "num.toLocaleString()"
+    notes = "Uses locale-specific separators."
+}
+
+instance TypeScriptToCharNumberNegativeBrackets of ToCharNumberNegativeBrackets {
+    syntax = "new Intl.NumberFormat('en-US', { currencySign: 'accounting', style: 'currency', currency: 'USD' }).format(num)"
+    notes = "Accounting style uses brackets for negative values."
+}
+
+instance TypeScriptToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "num.toFixed(2)"
+    notes = "Formats to exactly 2 decimal places."
+}
+
+instance TypeScriptToDate of ToDate {
+    syntax = "const [d, m, y] = str.split('.');\nnew Date(`${y}-${m}-${d}`);"
+    notes = "Manual parsing is often needed as Date.parse is implementation-dependent for non-ISO formats."
+}
+
+
+instance CppToCharDate of ToCharDate {
+    syntax = "std::strftime(buf, sizeof(buf), \"%d.%m.%Y\", &timeinfo);"
+    notes = "Standard C-style formatting available in C++."
+}
+
+instance CppToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "std::format(\"{:.2f}\", num);"
+    notes = "Available in C++20 and later."
+}
+
+instance RustToCharDate of ToCharDate {
+    syntax = "date.format(\"%d.%m.%Y\").to_string()"
+    notes = "Requires the chrono crate."
+}
+
+instance RustToCharNumberThousandSeparator of ToCharNumberThousandSeparator {
+    syntax = "num.to_formatted_string(&Locale::en)"
+    notes = "Requires the num-format crate."
+}
+
+instance RustToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "format!(\"{:.2}\", num)"
+    notes = "Standard macro for string formatting."
+}
+
+instance RustToDate of ToDate {
+    syntax = "NaiveDate::parse_from_str(date_str, \"%d.%m.%Y\")"
+    notes = "Requires the chrono crate."
+}
+
+instance GoToCharDate of ToCharDate {
+    syntax = "t.Format(\"02.01.2006\")"
+    notes = "Go uses a unique layout-based formatting string."
+}
+
+instance GoToCharNumberFixedDecimals of ToCharNumberFixedDecimals {
+    syntax = "fmt.Sprintf(\"%.2f\", num)"
+    notes = "Standard printf-style formatting."
+}
+
+instance GoToDate of ToDate {
+    syntax = "time.Parse(\"02.01.2006\", dateStr)"
+    notes = "Parses a string using the same layout logic as Format."
 }

--- a/src/generator.py
+++ b/src/generator.py
@@ -264,6 +264,9 @@ class CodeGenerator:
 
         # Render each pattern and its instances
         for pattern_name, pattern in patterns_map.items():
+            if filter_languages and pattern_name not in instances_by_pattern:
+                continue
+
             results.append(self.render_pattern(pattern))
 
             if pattern_name in instances_by_pattern:


### PR DESCRIPTION
Added date and number formatting patterns (`ToCharDate`, `ToCharDateTimezone`, `ToCharNumberThousandSeparator`, `ToCharNumberNegativeBrackets`, `ToCharNumberFixedDecimals`) and a date parsing pattern (`ToDate`). Implementations were added for SQL, XQuery, and several major programming languages. The documentation and pivot pages were updated accordingly. The generator logic was also refined to avoid rendering empty pattern sections in language-filtered documentation.

Fixes #320

---
*PR created automatically by Jules for task [8508953556069043989](https://jules.google.com/task/8508953556069043989) started by @chatelao*